### PR TITLE
Harden main CI with MCP client smoke verification

### DIFF
--- a/.github/scripts/mcp-smoke.mjs
+++ b/.github/scripts/mcp-smoke.mjs
@@ -1,0 +1,35 @@
+import process from "node:process";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const [serverPath, repoPath] = process.argv.slice(2);
+if (!serverPath || !repoPath) {
+  console.error("Usage: node .github/scripts/mcp-smoke.mjs <server-path> <repo-path>");
+  process.exit(2);
+}
+
+const client = new Client(
+  { name: "rna-ci-smoke", version: "0.1.0" },
+  { capabilities: {} },
+);
+
+const transport = new StdioClientTransport({
+  command: serverPath,
+  args: ["--repo", repoPath],
+});
+
+try {
+  await client.connect(transport);
+  const tools = (await client.listTools()).tools ?? [];
+  if (tools.length === 0) throw new Error("Smoke check failed: zero tools");
+
+  const mustHave = new Set(["oh_get_outcomes", "oh_get_guardrails", "outcome_progress"]);
+  const seen = new Set(tools.map((t) => t.name));
+  for (const name of mustHave) {
+    if (!seen.has(name)) throw new Error(`Smoke check failed: missing tool '${name}'`);
+  }
+
+  console.log(`Smoke check passed: ${tools.length} tools visible.`);
+} finally {
+  await client.close();
+}

--- a/.github/workflows/rust-main-merge.yml
+++ b/.github/workflows/rust-main-merge.yml
@@ -7,8 +7,10 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,3 +26,14 @@ jobs:
 
       - name: Build binary
         run: cargo build --release
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install MCP TypeScript SDK
+        run: npm install --no-save @modelcontextprotocol/sdk
+
+      - name: MCP stdio smoke test
+        run: node .github/scripts/mcp-smoke.mjs ./target/release/repo-native-alignment .


### PR DESCRIPTION
## Summary
- harden `.github/workflows/rust-main-merge.yml` for main merges/PRs
- add real MCP client smoke script (`.github/scripts/mcp-smoke.mjs`) using `@modelcontextprotocol/sdk`

## What changed
- workflow now:
  - runs `cargo test setup::tests`
  - builds release binary
  - installs Node 20 + MCP SDK
  - runs stdio client smoke against built server and asserts key tools exist

## Verification
- `cargo test setup::tests`
- `cargo build --release`
- `node .github/scripts/mcp-smoke.mjs ./target/release/repo-native-alignment .`

Refs: #5, #21
