### PR TITLE
Fix #34: LSP cursor column — use AST name_col across all extractors

### DIFF
--- a/src/extract/java.rs
+++ b/src/extract/java.rs
@@ -62,6 +62,10 @@ fn collect_nodes(
             if let Some(name_node) = node.child_by_field_name("name") {
                 let name = name_node.utf8_text(source).unwrap_or("unknown").to_string();
                 let sig = node.utf8_text(source).unwrap_or("").lines().next().unwrap_or("").trim().to_string();
+                // Record the AST-accurate byte column of the name identifier so the
+                // LSP enricher can place the cursor without signature string searching.
+                let mut metadata = BTreeMap::new();
+                metadata.insert("name_col".to_string(), name_node.start_position().column.to_string());
 
                 nodes.push(Node {
                     id: NodeId {
@@ -75,7 +79,7 @@ fn collect_nodes(
                     line_end: node.end_position().row + 1,
                     signature: sig,
                     body: String::new(),
-                    metadata: BTreeMap::new(),
+                    metadata,
                     source: ExtractionSource::TreeSitter,
                 });
 
@@ -92,6 +96,8 @@ fn collect_nodes(
             if let Some(name_node) = node.child_by_field_name("name") {
                 let name = name_node.utf8_text(source).unwrap_or("unknown").to_string();
                 let sig = node.utf8_text(source).unwrap_or("").lines().next().unwrap_or("").trim().to_string();
+                let mut metadata = BTreeMap::new();
+                metadata.insert("name_col".to_string(), name_node.start_position().column.to_string());
 
                 nodes.push(Node {
                     id: NodeId {
@@ -105,7 +111,7 @@ fn collect_nodes(
                     line_end: node.end_position().row + 1,
                     signature: sig,
                     body: String::new(),
-                    metadata: BTreeMap::new(),
+                    metadata,
                     source: ExtractionSource::TreeSitter,
                 });
 
@@ -121,6 +127,8 @@ fn collect_nodes(
             if let Some(name_node) = node.child_by_field_name("name") {
                 let name = name_node.utf8_text(source).unwrap_or("unknown").to_string();
                 let sig = node.utf8_text(source).unwrap_or("").lines().next().unwrap_or("").trim().to_string();
+                let mut metadata = BTreeMap::new();
+                metadata.insert("name_col".to_string(), name_node.start_position().column.to_string());
 
                 nodes.push(Node {
                     id: NodeId {
@@ -134,7 +142,7 @@ fn collect_nodes(
                     line_end: node.end_position().row + 1,
                     signature: sig,
                     body: String::new(),
-                    metadata: BTreeMap::new(),
+                    metadata,
                     source: ExtractionSource::TreeSitter,
                 });
             }
@@ -148,6 +156,8 @@ fn collect_nodes(
                 };
                 let body = node.utf8_text(source).unwrap_or("").to_string();
                 let sig = body.lines().next().unwrap_or("").trim().to_string();
+                let mut metadata = BTreeMap::new();
+                metadata.insert("name_col".to_string(), name_node.start_position().column.to_string());
 
                 nodes.push(Node {
                     id: NodeId {
@@ -161,7 +171,7 @@ fn collect_nodes(
                     line_end: node.end_position().row + 1,
                     signature: sig,
                     body,
-                    metadata: BTreeMap::new(),
+                    metadata,
                     source: ExtractionSource::TreeSitter,
                 });
             }
@@ -175,6 +185,8 @@ fn collect_nodes(
                 };
                 let body = node.utf8_text(source).unwrap_or("").to_string();
                 let sig = body.lines().next().unwrap_or("").trim().to_string();
+                let mut metadata = BTreeMap::new();
+                metadata.insert("name_col".to_string(), name_node.start_position().column.to_string());
 
                 nodes.push(Node {
                     id: NodeId {
@@ -188,7 +200,7 @@ fn collect_nodes(
                     line_end: node.end_position().row + 1,
                     signature: sig,
                     body,
-                    metadata: BTreeMap::new(),
+                    metadata,
                     source: ExtractionSource::TreeSitter,
                 });
             }


### PR DESCRIPTION
## Summary

Fixes #34 — LSP cursor column detection was fragile due to signature string scanning.

The main extractor changes (lsp.rs, rust.rs, python.rs, go.rs, typescript.rs, javascript.rs) landed on main via earlier commits. This PR closes the gap: Java extractor was missing `name_col` metadata on all node types (class, interface, enum, method, constructor).

**Root cause:** `node.signature.find(&node.id.name)` fails for:
- Overloaded parameter names (`pub fn from_str(from_str: &str)` → finds param, not fn name)
- Non-Rust languages (wrong fallback offset for Java `public void `, Python `def `, Go `func `)
- Complex signatures with generics, async, unsafe

**Fix:** Each tree-sitter extractor stores `name_col` in `Node.metadata` using `name_node.start_position().column` — the exact byte offset of the identifier as recorded by the AST. The LSP enricher reads this first; if absent (legacy nodes), falls back to signature scan and logs at `debug`.

## Changes

- `src/extract/java.rs` — add `name_col` to all 5 node types (class, interface, enum, method, constructor)

All other extractors already updated on main. 153 tests pass.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` — 153 passed, 0 failed
- [x] Overloaded param name case: `pub fn from_str(from_str: &str)` — name_col points to fn name col, not param col
- [x] Java extractor coverage: class, interface, enum, method, constructor all emit name_col
- [x] Wrong-column misses logged at `debug` (not dropped silently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)