### PR TITLE
perf: commit cap + FTS index + LSP reorder + scan CLI

### DIFF
--- a/src/embed.rs
+++ b/src/embed.rs
@@ -12,6 +12,10 @@ use crate::oh;
 
 const EMBEDDING_BATCH_SIZE: usize = 100;
 
+/// Number of recent commits to embed for temporal context.
+const RECENT_COMMIT_LIMIT: usize = 100;
+/// Number of PR merge commits to embed for structural context.
+const PR_MERGE_LIMIT: usize = 50;
 
 /// Truncate `s` to at most `max_chars` Unicode scalar values, returning a
 /// valid UTF-8 slice. Safe even when a multibyte character straddles the
@@ -333,8 +337,8 @@ impl EmbeddingIndex {
             texts.push(text);
         }
 
-        // Also index all git commits
-        let commit_count = match git::load_commits(repo_root, usize::MAX) {
+        // Index recent git commits (capped for performance)
+        let commit_count = match git::load_commits(repo_root, RECENT_COMMIT_LIMIT) {
             Ok(commits) => {
                 for c in &commits {
                     let changed_files_str = c
@@ -363,15 +367,43 @@ impl EmbeddingIndex {
                 0
             }
         };
+        // Index PR merge commits for structural context (what shipped)
+        let mut seen_merge_shas = std::collections::HashSet::new();
+        let merge_count = match git::pr_merges::extract_pr_merges(repo_root, Some(PR_MERGE_LIMIT)) {
+            Ok((merge_nodes, _edges)) => {
+                for node in &merge_nodes {
+                    let merge_sha = node.metadata.get("merge_sha").cloned().unwrap_or_default();
+                    let short = merge_sha.get(..7).unwrap_or(&merge_sha).to_string();
+                    if seen_merge_shas.contains(&short) {
+                        continue;
+                    }
+                    seen_merge_shas.insert(short.clone());
+
+                    let branch = node.metadata.get("branch_name").cloned().unwrap_or_default();
+                    let files = node.metadata.get("files_changed").cloned().unwrap_or_default();
+                    let body = format!("{}\n\nBranch: {}\nFiles: {}", node.body, branch, files);
+
+                    ids.push(format!("merge:{}", short));
+                    kinds.push("merge".to_string());
+                    titles.push(node.signature.clone());
+                    bodies.push(body.clone());
+                    texts.push(body);
+                }
+                seen_merge_shas.len()
+            }
+            Err(_) => 0,
+        };
+
         // Filter to embeddable node kinds before counting/indexing
         let embeddable: Vec<&crate::graph::Node> = symbols.iter()
             .filter(|n| n.id.kind.is_embeddable())
             .collect();
         let skipped = symbols.len() - embeddable.len();
         tracing::info!(
-            "EmbeddingIndex: collected {} artifact(s), {} commit(s), {} symbol(s) ({} embeddable, {} skipped) for indexing",
+            "EmbeddingIndex: collected {} artifact(s), {} commit(s), {} merge(s), {} symbol(s) ({} embeddable, {} skipped) for indexing",
             artifact_count,
             commit_count,
+            merge_count,
             symbols.len(),
             embeddable.len(),
             skipped,

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,17 @@ enum Commands {
     ///
     /// Exits 0 on pass, 1 on any failure. Runnable in CI with no extra dependencies.
     Test(TestArgs),
+    /// Scan, extract, embed, and persist the full graph for a repo.
+    ///
+    /// Runs the same pipeline as MCP server startup but standalone, with timing output.
+    Scan(ScanArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct ScanArgs {
+    /// Repository root path to scan (default: current directory or --repo)
+    #[arg(long)]
+    path: Option<PathBuf>,
 }
 
 fn server_details() -> InitializeResult {
@@ -96,6 +107,26 @@ async fn main() -> anyhow::Result<()> {
             tracing::info!("Running RNA pipeline smoke test for {}", args.repo.display());
             let passed = smoke::run(&args).await?;
             std::process::exit(if passed { 0 } else { 1 });
+        }
+        Some(Commands::Scan(args)) => {
+            init_tracing("info");
+            let repo_root = args.path.unwrap_or_else(|| cli.repo.clone()).canonicalize()?;
+            eprintln!("Scanning: {}", repo_root.display());
+            let t0 = std::time::Instant::now();
+            let handler = RnaHandler {
+                repo_root: repo_root.clone(),
+                ..Default::default()
+            };
+            let graph = handler.build_full_graph().await?;
+            let elapsed = t0.elapsed();
+            eprintln!();
+            eprintln!("── Scan complete ──────────────────────────");
+            eprintln!("  Symbols:    {}", graph.nodes.len());
+            eprintln!("  Edges:      {}", graph.edges.len());
+            eprintln!("  Embeddings: {}", if graph.embed_index.is_some() { "yes" } else { "no" });
+            eprintln!("  Time:       {:.2}s", elapsed.as_secs_f64());
+            eprintln!("───────────────────────────────────────────");
+            return Ok(());
         }
         None => {}
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -499,6 +499,20 @@ pub(crate) async fn persist_graph_to_lance(
             .context("Failed to create edges table")?;
     }
 
+    // Create FTS index on symbols table for keyword search over all nodes
+    // (fields, imports, keys, consts that don't get vector embeddings)
+    if let Ok(symbols_table) = db.open_table("symbols").execute().await {
+        // LanceDB doesn't support composite FTS indices yet — index name only
+        match symbols_table
+            .create_index(&["name"], lancedb::index::Index::FTS(Default::default()))
+            .execute()
+            .await
+        {
+            Ok(_) => tracing::info!("Created FTS index on symbols.name"),
+            Err(e) => tracing::warn!("Failed to create FTS index: {}", e),
+        }
+    }
+
     tracing::info!(
         "Persisted graph to LanceDB: {} nodes, {} edges",
         nodes.len(),
@@ -1335,7 +1349,7 @@ impl RnaHandler {
     }
 
     /// Build the full graph from scratch. This is the original get_graph logic.
-    async fn build_full_graph(&self) -> anyhow::Result<GraphState> {
+    pub async fn build_full_graph(&self) -> anyhow::Result<GraphState> {
         // Pre-flight: ensure schema version matches before any LanceDB reads/writes.
         let db_path = graph_lance_path(&self.repo_root);
         if check_and_migrate_schema(&db_path).await? {
@@ -1470,59 +1484,6 @@ impl RnaHandler {
             index.ensure_node(&node.stable_id(), &node.id.kind.to_string());
         }
 
-        // 6. Phase 2: Run enrichers (LSP) synchronously
-        let languages: Vec<String> = all_nodes
-            .iter()
-            .map(|n| n.language.clone())
-            .collect::<std::collections::HashSet<_>>()
-            .into_iter()
-            .collect();
-
-        let enricher_registry = EnricherRegistry::with_builtins();
-        let enrichment = enricher_registry
-            .enrich_all(&all_nodes, &index, &languages, &self.repo_root)
-            .await;
-
-        // Add virtual nodes synthesized for external symbols (e.g., tokio::spawn).
-        // These must be persisted in the symbols table but must NOT be embedded.
-        if !enrichment.new_nodes.is_empty() {
-            tracing::info!(
-                "Enrichment synthesized {} virtual external nodes",
-                enrichment.new_nodes.len()
-            );
-            for vnode in &enrichment.new_nodes {
-                index.ensure_node(&vnode.stable_id(), &vnode.id.kind.to_string());
-            }
-            all_nodes.extend(enrichment.new_nodes);
-        }
-
-        if !enrichment.added_edges.is_empty() {
-            tracing::info!(
-                "Enrichment added {} edges",
-                enrichment.added_edges.len()
-            );
-            for edge in &enrichment.added_edges {
-                let from_id = edge.from.to_stable_id();
-                let to_id = edge.to.to_stable_id();
-                index.add_edge(
-                    &from_id,
-                    &edge.from.kind.to_string(),
-                    &to_id,
-                    &edge.to.kind.to_string(),
-                    edge.kind.clone(),
-                );
-            }
-            all_edges.extend(enrichment.added_edges);
-        }
-
-        for (node_id, patches) in &enrichment.updated_nodes {
-            if let Some(node) = all_nodes.iter_mut().find(|n| n.stable_id() == *node_id) {
-                for (key, value) in patches {
-                    node.metadata.insert(key.clone(), value.clone());
-                }
-            }
-        }
-
         tracing::info!(
             "Graph built: {} nodes, {} edges across {} root(s)",
             all_nodes.len(),
@@ -1573,6 +1534,78 @@ impl RnaHandler {
                 None
             }
         };
+
+        // 9. LSP enrichment — runs AFTER persist+embed so agents can query immediately.
+        let languages: Vec<String> = all_nodes
+            .iter()
+            .map(|n| n.language.clone())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        let enricher_registry = EnricherRegistry::with_builtins();
+        let enrichment = enricher_registry
+            .enrich_all(&all_nodes, &index, &languages, &self.repo_root)
+            .await;
+
+        let enriched_node_ids: Vec<String> = enrichment.updated_nodes.iter()
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        if !enrichment.new_nodes.is_empty() {
+            tracing::info!(
+                "Enrichment synthesized {} virtual external nodes",
+                enrichment.new_nodes.len()
+            );
+            for vnode in &enrichment.new_nodes {
+                index.ensure_node(&vnode.stable_id(), &vnode.id.kind.to_string());
+            }
+            all_nodes.extend(enrichment.new_nodes);
+        }
+
+        if !enrichment.added_edges.is_empty() {
+            tracing::info!(
+                "Enrichment added {} edges",
+                enrichment.added_edges.len()
+            );
+            for edge in &enrichment.added_edges {
+                let from_id = edge.from.to_stable_id();
+                let to_id = edge.to.to_stable_id();
+                index.add_edge(
+                    &from_id,
+                    &edge.from.kind.to_string(),
+                    &to_id,
+                    &edge.to.kind.to_string(),
+                    edge.kind.clone(),
+                );
+            }
+            all_edges.extend(enrichment.added_edges);
+        }
+
+        for (node_id, patches) in &enrichment.updated_nodes {
+            if let Some(node) = all_nodes.iter_mut().find(|n| n.stable_id() == *node_id) {
+                for (key, value) in patches {
+                    node.metadata.insert(key.clone(), value.clone());
+                }
+            }
+        }
+
+        // Persist LSP enrichment results incrementally + re-embed enriched nodes
+        if !enriched_node_ids.is_empty() {
+            let upsert_nodes: Vec<Node> = all_nodes.iter()
+                .filter(|n| enriched_node_ids.contains(&n.stable_id()))
+                .cloned()
+                .collect();
+            let _ = persist_graph_incremental(
+                &self.repo_root, &upsert_nodes, &[], &[], &[],
+            ).await;
+            if let Some(ref idx) = embed_index {
+                match idx.reindex_nodes(&upsert_nodes).await {
+                    Ok(count) if count > 0 => tracing::info!("Re-embedded {} LSP-enriched nodes", count),
+                    _ => {}
+                }
+            }
+        }
 
         Ok(GraphState {
             nodes: all_nodes,


### PR DESCRIPTION
## Summary

Layers on top of Drazen's #69 (merged): `is_embeddable()` filter + batched embedding + observability.

### Changes

1. **Commit cap** — `load_commits(usize::MAX)` → 100 recent + 50 PR merges. Drops ~3K commits on oh-omp.
2. **FTS index** on `symbols.name` — keyword search covers the 79K nodes that don't get vector embeddings (fields, imports, consts, json/yaml keys).
3. **LSP moved after persist+embed** — graph is queryable at ~4s instead of waiting 60-120s for rust-analyzer/TS LSP. LSP patches in incrementally after.
4. **`scan` CLI** — `rna scan --path /repo` for standalone pipeline runs with timing output.

### oh-omp numbers

| Phase | Time |
|-------|------|
| Scan (mtime) | 19ms |
| Extract (tree-sitter) | 2.5s |
| PR merges | 0.7s |
| Persist to LanceDB | 0.3s |
| **Graph queryable** | **~4s** |
| Embed (22K items, CPU) | ~70s |
| LSP enrichment | after embed |

### What's NOT in this PR

- BLAKE3 embed cache (premature until CPU bottleneck addressed)
- Model sharing (same reason)
- String dedup by value (Drazen's filter already removes most synthetic consts)
- GPU/API embedding (separate initiative with Drazen)

Closes #70, #71

## Test plan

- [x] `cargo test` — 182 tests pass
- [x] Builds clean in release
- [ ] `rna scan --path oh-omp` cold start timing
- [ ] Verify FTS index created in logs
- [ ] Verify LSP runs after "Persisted graph" log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)