### PR TITLE
fix: remove useless detail_level='full' from outcome_progress

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -113,15 +113,12 @@ pub struct OhInit {
 
 #[macros::mcp_tool(
     name = "outcome_progress",
-    description = "The real intersection query: given an outcome ID, finds related commits (by [outcome:X] tags and file pattern matches), code symbols in changed files, and markdown mentioning the outcome. This joins layers structurally, not by keyword. Returns summary by default (<5K chars); use detail_level='full' for complete data."
+    description = "The real intersection query: given an outcome ID, finds related commits (by [outcome:X] tags and file pattern matches), code symbols in changed files, and markdown mentioning the outcome. This joins layers structurally, not by keyword. Returns a navigable summary (<5K chars) with stable Node IDs — use search_symbols and graph_query to drill deeper."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct OutcomeProgress {
     /// The outcome ID (e.g. 'agent-alignment') from .oh/outcomes/
     pub outcome_id: String,
-    /// Detail level: 'summary' (default, <5K chars) or 'full' (complete data)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub detail_level: Option<String>,
 }
 
 #[macros::mcp_tool(
@@ -2237,7 +2234,6 @@ impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
 
             "outcome_progress" => {
                 let args: OutcomeProgress = parse_args(params.arguments)?;
-                let full = args.detail_level.as_deref() == Some("full");
                 let graph_nodes = if let Ok(guard) = self.get_graph().await {
                     guard.as_ref().map(|gs| gs.nodes.clone()).unwrap_or_default()
                 } else {
@@ -2245,13 +2241,9 @@ impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
                 };
                 match query::outcome_progress(root, &args.outcome_id, &graph_nodes) {
                     Ok(result) => {
-                        let mut md = if full {
-                            result.to_markdown()
-                        } else {
-                            result.to_summary_markdown()
-                        };
+                        let mut md = result.to_summary_markdown();
 
-                        // Append PR merge section from the graph
+                        // Append PR merge count from the graph
                         if let Ok(guard) = self.get_graph().await {
                          if let Some(graph_state) = guard.as_ref() {
                             let file_patterns: Vec<String> = result
@@ -2272,15 +2264,9 @@ impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
                                 &args.outcome_id,
                                 &file_patterns,
                             );
-                            if full {
-                                let pr_md = query::format_pr_merges_markdown(&pr_nodes);
-                                if !pr_md.is_empty() {
-                                    md.push('\n');
-                                    md.push_str(&pr_md);
-                                }
-                            } else if !pr_nodes.is_empty() {
+                            if !pr_nodes.is_empty() {
                                 md.push_str(&format!(
-                                    "\n## PR Merges\n\n{} PR merge(s) serving this outcome (use detail_level='full' to see details)\n",
+                                    "\n## PR Merges\n\n{} PR merge(s) serving this outcome\n",
                                     pr_nodes.len()
                                 ));
                             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -184,59 +184,6 @@ pub struct QueryResult {
 }
 
 impl QueryResult {
-    pub fn to_markdown(&self) -> String {
-        let mut out = format!("# Query: {}\n\n", self.query);
-
-        if !self.outcomes.is_empty() {
-            out.push_str("## Matching Outcomes / Signals / Guardrails / Metis\n\n");
-            for a in &self.outcomes {
-                out.push_str(&a.to_markdown());
-                out.push_str("\n---\n\n");
-            }
-        }
-
-        if !self.commits.is_empty() {
-            out.push_str("## Relevant Commits\n\n");
-            for c in &self.commits {
-                out.push_str(&c.to_markdown());
-                out.push('\n');
-            }
-            out.push('\n');
-        }
-
-        if !self.code_symbols.is_empty() {
-            out.push_str("## Matching Code Symbols\n\n");
-            for node in &self.code_symbols {
-                out.push_str(&format!(
-                    "- `{}:{}` **{}** `{}`\n",
-                    node.id.file.display(),
-                    node.line_start,
-                    node.id.kind,
-                    node.signature,
-                ));
-            }
-            out.push('\n');
-        }
-
-        if !self.markdown_chunks.is_empty() {
-            out.push_str("## Matching Markdown Sections\n\n");
-            for m in &self.markdown_chunks {
-                out.push_str(&m.to_markdown());
-                out.push_str("\n\n---\n\n");
-            }
-        }
-
-        if self.outcomes.is_empty()
-            && self.commits.is_empty()
-            && self.code_symbols.is_empty()
-            && self.markdown_chunks.is_empty()
-        {
-            out.push_str("_No results found._\n");
-        }
-
-        out
-    }
-
     /// Navigable summary rendering targeting <10K chars.
     /// Returns stable node IDs and suggested tool calls so agents can drill deeper.
     ///
@@ -244,7 +191,7 @@ impl QueryResult {
     /// - Commits: only tagged commits (containing [outcome:]), capped at 15, with drill-down hint
     /// - Symbols: counts by kind + top 5 files with up to 3 key symbols each, including stable IDs
     /// - Markdown: heading names + file paths
-    /// - PR Merges: count + suggestion to use detail_level='full' (appended by caller)
+    /// - PR Merges: count (appended by caller)
     pub fn to_summary_markdown(&self) -> String {
         let mut out = format!("# Query: {}\n\n", self.query);
 


### PR DESCRIPTION
## Summary
- Remove `detail_level` parameter — `outcome_progress` now always returns navigable summary (<5K chars) with stable Node IDs
- Delete `QueryResult::to_markdown()` (the full-dump renderer that produced 995K chars, too large for any agent context)
- PR merge section always shows count inline instead of hinting at a full mode that overflows context

## Context
The `detail_level='full'` mode was added before `search_symbols` and `graph_query` existed as drill-down paths. Now that summary returns stable IDs that agents can feed into those tools, the full dump is redundant and actively harmful (overflows context windows).

Net: -67 lines.

## Test plan
- [x] 190 tests passing
- [x] `cargo build --release` clean
- [x] Functionally tested `outcome_progress` via live MCP — returns summary with Node IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)