### PR TITLE
chore: switch metal-candle dep from branch to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,21 +4461,6 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-graphics-types",
- "foreign-types 0.5.0",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
-name = "metal"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
@@ -4492,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "metal-candle"
 version = "1.3.0"
-source = "git+https://github.com/open-horizon-labs/metal-candle?branch=fix%2Fcandle-0.9-compat#37336c61802e9a3488cc1981736454b290852a47"
+source = "git+https://github.com/open-horizon-labs/metal-candle#9fd6da93991ea67c01a9a494d817f2a47b991dd0"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
@@ -4500,8 +4485,7 @@ dependencies = [
  "candle-transformers",
  "dirs 5.0.1",
  "hf-hub",
- "metal 0.27.0",
- "objc",
+ "objc2-metal",
  "rand 0.8.5",
  "safetensors 0.7.0",
  "serde",
@@ -4809,7 +4793,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
@@ -4863,15 +4846,6 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
-]
-
-[[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -7465,7 +7439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7adf545a99a086d362efc739e7cf4317c18cbeda22706000fd434d70ea3d95"
 dependencies = [
  "half",
- "metal 0.29.0",
+ "metal",
  "objc",
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ arrow-array = "57"
 arrow-schema = "57"
 
 # Local embeddings — Metal GPU on Apple Silicon, CPU fallback
-metal-candle = { git = "https://github.com/open-horizon-labs/metal-candle", branch = "fix/candle-0.9-compat", features = ["embeddings"] }
+metal-candle = { git = "https://github.com/open-horizon-labs/metal-candle", features = ["embeddings"] }
 candle-core = { version = "0.9", features = ["metal"] }
 
 # CLI


### PR DESCRIPTION
## Summary

- Drop `branch = "fix/candle-0.9-compat"` pin from `metal-candle` git dependency
- That branch is now merged into `open-horizon-labs/metal-candle` main with full fused Metal GPU ops restored for candle-core 0.9.2

## Test plan

- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)