### PR TITLE
chore: fixed batch_size=32, drop memory heuristic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5682,7 +5682,6 @@ dependencies = [
  "futures",
  "git2",
  "lancedb",
- "libc",
  "lsp-types",
  "metal-candle",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,9 +71,6 @@ futures = "0.3"
 # LSP protocol types (for Phase 2 enrichment via language servers)
 lsp-types = "0.97"
 
-# System memory detection for adaptive batch sizing
-libc = "0.2"
-
 # Error handling
 anyhow = "1"
 

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -9,56 +9,10 @@ use lancedb::query::{ExecutableQuery, QueryBase};
 use crate::git;
 use crate::oh;
 
-/// Maximum fraction of system memory to use for embedding buffers.
-/// Metal GPU uses unified memory — GPU buffers ARE system memory.
-const MAX_MEMORY_FRACTION: f64 = 0.20;
-/// Per-text memory estimate for Metal GPU embedding (model activations + buffers).
-/// Empirically: batch=64 × 26K texts peaked at 17GB → ~650KB per text in-flight.
-const BYTES_PER_TEXT_ESTIMATE: usize = 700_000;
-/// Minimum batch size (too small = GPU underutilized).
-const MIN_BATCH_SIZE: usize = 8;
-/// Maximum batch size (cap for safety even on large-RAM machines).
-const MAX_BATCH_SIZE: usize = 64;
-
-fn compute_batch_size() -> usize {
-    let total_mem = total_system_memory_bytes();
-    let budget = (total_mem as f64 * MAX_MEMORY_FRACTION) as usize;
-    let batch = (budget / BYTES_PER_TEXT_ESTIMATE).max(MIN_BATCH_SIZE).min(MAX_BATCH_SIZE);
-    tracing::info!(
-        "EmbeddingIndex: system RAM {:.1}GB, {:.0}% budget = {:.1}GB → batch_size={}",
-        total_mem as f64 / 1e9,
-        MAX_MEMORY_FRACTION * 100.0,
-        budget as f64 / 1e9,
-        batch
-    );
-    batch
-}
-
-#[cfg(target_os = "macos")]
-fn total_system_memory_bytes() -> usize {
-    use std::ffi::CString;
-    let name = CString::new("hw.memsize").unwrap();
-    let mut value: u64 = 0;
-    let mut size = std::mem::size_of::<u64>();
-    unsafe {
-        if libc::sysctlbyname(
-            name.as_ptr(),
-            &mut value as *mut _ as *mut libc::c_void,
-            &mut size,
-            std::ptr::null_mut(),
-            0,
-        ) == 0 {
-            value as usize
-        } else {
-            16 * 1024 * 1024 * 1024 // default 16GB
-        }
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-fn total_system_memory_bytes() -> usize {
-    16 * 1024 * 1024 * 1024 // default 16GB
-}
+/// Embedding batch size. Benchmarked on M4 MacBook Pro with MiniLM-L6-v2:
+/// batch=32 gives best sustained throughput (~880 t/s) with ~240MB memory.
+/// Larger batches (64, 128) showed no improvement or regression.
+const BATCH_SIZE: usize = 32;
 
 /// Number of recent commits to embed for temporal context.
 const RECENT_COMMIT_LIMIT: usize = 100;
@@ -109,7 +63,7 @@ async fn embed_texts(texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
         return Ok(Vec::new());
     }
 
-    let batch_size = compute_batch_size();
+    let batch_size = BATCH_SIZE;
     let total_chars: usize = texts.iter().map(|t| t.len()).sum();
     let total_batches = total.div_ceil(batch_size);
     let overall_start = std::time::Instant::now();


### PR DESCRIPTION
## Summary

- Replace adaptive memory-based batch size computation with fixed `BATCH_SIZE = 32`
- Remove `libc` dependency (was only used for `sysctl` memory detection)
- Delete ~50 lines of heuristic code (constants, `compute_batch_size()`, `total_system_memory_bytes()`)

## Rationale

Benchmarked with [embed-bench](https://github.com/open-horizon-labs/metal-candle) on M4 MacBook Pro using MiniLM-L6-v2 on Metal GPU:

| Batch | Throughput | Memory |
|-------|-----------|--------|
| 32 | **880 t/s** | 239MB |
| 64 | 739 t/s | 241MB |
| 128 | ~820 t/s | 243MB |

batch=32 gives the best sustained throughput. The old heuristic was computing batch sizes based on available RAM, but the optimal size is model-dependent, not memory-dependent. Memory usage is stable across batch sizes (~240MB for MiniLM).

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)