### PR TITLE
feat: index Claude Code auto memory as scanner root

### DIFF
--- a/.oh/sessions/claude-memory-108.md
+++ b/.oh/sessions/claude-memory-108.md
@@ -7,10 +7,12 @@ Index Claude Code auto memory (`~/.claude/projects/<project>/memory/`) as a scan
 Add the memory dir as an optional root in the scanner. Path: `~/.claude/projects/{repo_root_slashes_as_dashes}/memory/`. Documented by Anthropic.
 
 ## Execute Status
-- **In progress:** Need to find where roots are constructed in `roots.rs` (not `resolved_roots` which just filters)
-- `resolved_roots()` at `src/roots.rs:210` iterates `self.roots` and filters by `.exists()`
-- Need to find where `self.roots` is populated — likely a `new()` or `from_repo()` constructor
-- Then add the memory dir as an additional root with type "claude-memory" or similar
+- **Complete:** 2026-03-09
+- Added `claude_memory_dir()` helper — computes `~/.claude/projects/-{path}/memory/`
+- Added `WorkspaceConfig::with_claude_memory()` — builder method, adds Notes root if dir exists
+- Wired into all 3 call sites in `server.rs` (background scanner, initial build, list_roots)
+- 3 new tests: path format, adds-when-exists, skips-when-missing
+- 22/22 roots tests pass, clean build
 
 ## Key facts
 - Memory path: `~/.claude/projects/-Users-muness-src-open-horizon-labs-repo-native-alignment/memory/`

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -206,6 +206,29 @@ impl WorkspaceConfig {
         self
     }
 
+    /// Add the Claude Code auto-memory directory as a `Notes` root.
+    ///
+    /// Claude Code stores per-project memory at
+    /// `~/.claude/projects/-{path-with-slashes-as-dashes}/memory/`.
+    /// If that directory exists it is added as a Notes root so
+    /// `oh_search_context` can surface operational knowledge.
+    pub fn with_claude_memory(mut self, repo_root: &Path) -> Self {
+        if let Some(memory_dir) = claude_memory_dir(repo_root) {
+            // Skip if already present (e.g. user added it in roots.toml).
+            if self.roots.iter().any(|r| r.resolved_path() == memory_dir) {
+                return self;
+            }
+
+            self.roots.push(RootConfig {
+                path: memory_dir,
+                root_type: RootType::Notes,
+                git_aware: false,
+                excludes: vec![],
+            });
+        }
+        self
+    }
+
     /// Get all roots with their resolved paths and slugs.
     pub fn resolved_roots(&self) -> Vec<ResolvedRoot> {
         self.roots
@@ -300,6 +323,29 @@ fn path_to_slug(path: &Path) -> String {
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("-")
+}
+
+/// Compute the Claude Code auto-memory directory for a given repo root.
+///
+/// Claude Code encodes the absolute path by stripping the leading `/`,
+/// replacing non-alphanumeric non-hyphen characters (including `/` and `.`)
+/// with `-`, and prefixing with `-`. Case is preserved.
+///
+/// e.g. `/Users/foo/src/bar` → `~/.claude/projects/-Users-foo-src-bar/memory/`
+///      `/tmp/my.project`    → `~/.claude/projects/-tmp-my-project/memory/`
+///
+/// Returns `None` if `HOME` is not set.
+pub fn claude_memory_dir(repo_root: &Path) -> Option<PathBuf> {
+    let home = home_dir()?;
+    let canonical = expand_tilde(repo_root);
+    let encoded: String = canonical
+        .to_string_lossy()
+        .trim_start_matches('/')
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' { c } else { '-' })
+        .collect();
+    let key = format!("-{}", encoded);
+    Some(home.join(".claude").join("projects").join(key).join("memory"))
 }
 
 /// Path for per-root scan state cache.
@@ -594,5 +640,77 @@ excludes = ["*.iso", "*.dmg"]
 
         // Verify state was persisted at the custom path
         assert!(notes_state.exists(), "Notes scan state should be persisted at custom path");
+    }
+
+    #[test]
+    fn test_claude_memory_dir_format() {
+        let dir = claude_memory_dir(Path::new("/Users/foo/src/bar"));
+        assert!(dir.is_some());
+        let dir = dir.unwrap();
+        let dir_str = dir.to_string_lossy();
+        assert!(
+            dir_str.ends_with("/.claude/projects/-Users-foo-src-bar/memory"),
+            "Got: {}",
+            dir_str
+        );
+    }
+
+    #[test]
+    fn test_claude_memory_dir_replaces_dots() {
+        // Claude Code replaces '.' with '-' in the project key
+        let dir = claude_memory_dir(Path::new("/Users/foo/Downloads/improve-deployments.md"))
+            .unwrap();
+        let dir_str = dir.to_string_lossy();
+        assert!(
+            dir_str.ends_with("/.claude/projects/-Users-foo-Downloads-improve-deployments-md/memory"),
+            "Dots should become dashes. Got: {}",
+            dir_str
+        );
+    }
+
+    #[test]
+    fn test_with_claude_memory_adds_root_when_dir_exists() {
+        // Use the real HOME to compute where claude_memory_dir would point,
+        // then create that directory so the test can verify it gets added.
+        let cwd = std::env::current_dir().unwrap();
+        let memory_dir = match claude_memory_dir(&cwd) {
+            Some(d) => d,
+            None => return, // No HOME set, can't test
+        };
+
+        if !memory_dir.exists() {
+            // If the real memory dir doesn't exist, we can't create it
+            // without side effects. Just verify the method is a no-op.
+            let config = WorkspaceConfig::default()
+                .with_primary_root(cwd.clone())
+                .with_claude_memory(&cwd);
+            // Memory root added but resolved_roots filters non-existent
+            let resolved = config.resolved_roots();
+            assert_eq!(resolved.len(), 1, "Only primary root when memory dir missing");
+            return;
+        }
+
+        // Memory dir exists — verify it gets added
+        let config = WorkspaceConfig::default()
+            .with_primary_root(cwd.clone())
+            .with_claude_memory(&cwd);
+        let resolved = config.resolved_roots();
+        assert!(resolved.len() >= 2, "Expected primary + memory root");
+        let memory_root = resolved.iter().find(|r| r.path == memory_dir);
+        assert!(memory_root.is_some(), "Memory root should be in resolved roots");
+        assert_eq!(memory_root.unwrap().config.root_type, RootType::Notes);
+    }
+
+    #[test]
+    fn test_with_claude_memory_skips_when_dir_missing() {
+        // Memory dir won't exist for a random path
+        let tmp = TempDir::new().unwrap();
+        let config = WorkspaceConfig::default()
+            .with_primary_root(tmp.path().to_path_buf())
+            .with_claude_memory(tmp.path());
+
+        // resolved_roots filters non-existent, so memory root won't appear
+        let resolved = config.resolved_roots();
+        assert_eq!(resolved.len(), 1, "Only primary root should be present");
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1095,10 +1095,11 @@ impl RnaHandler {
                         tokio::time::sleep(tokio::time::Duration::from_secs(900)).await;
                     }
 
-                    // Resolve current roots (primary + any live worktrees).
+                    // Resolve current roots (primary + any live worktrees + claude memory).
                     let workspace = WorkspaceConfig::load()
                         .with_primary_root(repo_root.clone())
-                        .with_worktrees(&repo_root);
+                        .with_worktrees(&repo_root)
+                        .with_claude_memory(&repo_root);
                     let resolved_roots = workspace.resolved_roots();
                     let current_root_slugs: std::collections::HashSet<String> =
                         resolved_roots.iter().map(|r| r.slug.clone()).collect();
@@ -1312,11 +1313,12 @@ impl RnaHandler {
         }
 
         // Load workspace config and merge with --repo as primary root.
-        // Also auto-detect any live git worktrees so all roots are indexed
-        // on the first full build (mirrors the background scanner path).
+        // Also auto-detect any live git worktrees and Claude Code memory
+        // so all roots are indexed on the first full build.
         let workspace = WorkspaceConfig::load()
             .with_primary_root(self.repo_root.clone())
-            .with_worktrees(&self.repo_root);
+            .with_worktrees(&self.repo_root)
+            .with_claude_memory(&self.repo_root);
         let resolved_roots = workspace.resolved_roots();
 
         // 1. Scan all roots to detect changes
@@ -2473,7 +2475,8 @@ impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
             "list_roots" => {
                 let workspace = WorkspaceConfig::load()
                     .with_primary_root(self.repo_root.clone())
-                    .with_worktrees(&self.repo_root);
+                    .with_worktrees(&self.repo_root)
+                    .with_claude_memory(&self.repo_root);
                 let resolved = workspace.resolved_roots();
 
                 if resolved.is_empty() {


### PR DESCRIPTION
## Summary
- Auto-detects `~/.claude/projects/{key}/memory/` and adds it as a `Notes` root
- Path encoding matches Claude Code convention: non-alphanumeric non-hyphen chars → `-`, case preserved
- Wired into all 3 `WorkspaceConfig` construction sites (background scanner, initial build, list_roots)
- Graceful degradation: if memory dir doesn't exist, `resolved_roots()` silently skips it

## Test plan
- [x] 4 new unit tests (path format, dot replacement, adds-when-exists, skips-when-missing)
- [x] 23/23 roots tests pass, 194/194 full suite pass
- [ ] CI green
- [ ] Verify `list_roots` shows memory root after rebuild