### PR TITLE
fix: friendly error for missing MCP tool arguments

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -2498,9 +2498,10 @@ impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
 fn parse_args<T: serde::de::DeserializeOwned>(
     arguments: Option<serde_json::Map<String, serde_json::Value>>,
 ) -> Result<T, CallToolError> {
-    let value = arguments
-        .map(serde_json::Value::Object)
-        .unwrap_or(serde_json::Value::Null);
+    let value = match arguments {
+        Some(map) => serde_json::Value::Object(map),
+        None => serde_json::Value::Object(serde_json::Map::new()), // empty object, not null
+    };
     serde_json::from_value(value)
         .map_err(|e| CallToolError::from_message(format!("Invalid arguments: {}", e)))
 }


### PR DESCRIPTION
## Summary
- When an MCP client sends no arguments (`None`), `parse_args` was converting it to `Value::Null`, producing unhelpful serde errors like `"invalid type: null, expected struct GraphQuery"`
- Now passes an empty object `{}` instead of `null`, so `#[serde(default)]` fields work and required-field errors say `"missing field 'query'"` instead of the opaque null type error
- All 226 tests pass, no behavioral change for callers that already provide arguments

## Test plan
- [x] `cargo test` — 226 passed, 0 failed
- [ ] Manual: call a tool with no arguments via MCP client, confirm error message is friendly