### PR TITLE
fix: graceful messaging when embedding index is building

### DIFF
--- a/src/embed.rs
+++ b/src/embed.rs
@@ -227,6 +227,14 @@ pub struct EmbeddingIndex {
     table_name: String,
 }
 
+/// Result of a semantic search — either results or "not ready yet."
+pub enum SearchOutcome {
+    /// Index is ready; here are the results (may be empty).
+    Results(Vec<SearchResult>),
+    /// Embedding table hasn't been created yet — index is still building.
+    NotReady,
+}
+
 /// A search result with the artifact and its relevance score.
 pub struct SearchResult {
     pub id: String,
@@ -286,15 +294,7 @@ impl EmbeddingIndex {
         })
     }
 
-    /// Check whether the embedding table has been created yet.
-    /// Returns false during initial indexing before the first batch is written.
-    pub async fn is_ready(&self) -> bool {
-        self.db
-            .open_table(&self.table_name)
-            .execute()
-            .await
-            .is_ok()
-    }
+
 
     /// Index all .oh/ artifacts, git commits, and optionally code symbols.
     /// Call with symbols from the graph to enable semantic code search.
@@ -678,12 +678,14 @@ impl EmbeddingIndex {
     }
 
     /// Semantic search over indexed artifacts.
+    /// Returns `SearchOutcome::NotReady` if the table hasn't been created yet,
+    /// `SearchOutcome::Results(vec)` otherwise (may be empty).
     pub async fn search(
         &self,
         query: &str,
         artifact_types: Option<&[String]>,
         limit: usize,
-    ) -> Result<Vec<SearchResult>> {
+    ) -> Result<SearchOutcome> {
         let table = match self
             .db
             .open_table(&self.table_name)
@@ -691,11 +693,12 @@ impl EmbeddingIndex {
             .await
         {
             Ok(t) => t,
-            Err(_) => {
-                // Table doesn't exist yet — embedding index is still building.
-                // Return empty results instead of erroring so callers can show
-                // a "building" status rather than an opaque error.
-                return Ok(vec![]);
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("was not found") || msg.contains("does not exist") || msg.contains("not found") {
+                    return Ok(SearchOutcome::NotReady);
+                }
+                return Err(e).context("Failed to open embedding table");
             }
         };
 
@@ -797,7 +800,7 @@ impl EmbeddingIndex {
         search_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
         search_results.truncate(limit);
 
-        Ok(search_results)
+        Ok(SearchOutcome::Results(search_results))
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,7 +14,7 @@ use rust_mcp_sdk::schema::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::embed::EmbeddingIndex;
+use crate::embed::{EmbeddingIndex, SearchOutcome};
 use crate::extract::{ExtractorRegistry, EnricherRegistry};
 use crate::graph::{self, EdgeKind, Node, Edge, Confidence, ExtractionSource, NodeId, NodeKind};
 use crate::graph::index::GraphIndex;
@@ -2094,26 +2094,25 @@ impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
                     let embed_guard = self.embed_index.load();
                     match embed_guard.as_ref() {
                         Some(index) => {
-                            if !index.is_ready().await {
-                                sections.push("Embedding index: building — semantic results will appear shortly. Retry in a few seconds.".to_string());
-                            } else {
-                                match index.search(query, args.artifact_types.as_deref(), limit).await {
-                                    Ok(results) => {
-                                        if !results.is_empty() {
-                                            let md: String = results
-                                                .iter()
-                                                .map(|r| r.to_markdown())
-                                                .collect::<Vec<_>>()
-                                                .join("\n");
-                                            sections.push(format!(
-                                                "### Artifacts ({} result(s))\n\n{}",
-                                                results.len(),
-                                                md
-                                            ));
-                                        }
+                            match index.search(query, args.artifact_types.as_deref(), limit).await {
+                                Ok(SearchOutcome::Results(results)) => {
+                                    if !results.is_empty() {
+                                        let md: String = results
+                                            .iter()
+                                            .map(|r| r.to_markdown())
+                                            .collect::<Vec<_>>()
+                                            .join("\n");
+                                        sections.push(format!(
+                                            "### Artifacts ({} result(s))\n\n{}",
+                                            results.len(),
+                                            md
+                                        ));
                                     }
-                                    Err(e) => sections.push(format!("Artifact search error: {}", e)),
                                 }
+                                Ok(SearchOutcome::NotReady) => {
+                                    sections.push("Embedding index: building — semantic results will appear shortly. Retry in a few seconds.".to_string());
+                                }
+                                Err(e) => sections.push(format!("Artifact search error: {}", e)),
                             }
                         }
                         None => sections.push("Embedding index not yet available".to_string()),
@@ -2404,17 +2403,12 @@ impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
                     let embed_guard = self.embed_index.load();
                     match embed_guard.as_ref() {
                         Some(embed_idx) => {
-                            if !embed_idx.is_ready().await {
-                                return Ok(text_result(
-                                    "Embedding index: building — semantic graph queries will work shortly. Use node_id from search_symbols instead, or retry in a few seconds.".to_string()
-                                ));
-                            }
                             // Search without type filter, then keep only code:* kinds.
                             // This is robust to new code kinds added to the embedding pipeline
                             // (the pipeline already gates what gets indexed via is_embeddable()).
                             // We over-fetch by 3x to have enough results after filtering.
                             match embed_idx.search(query_text, None, top_k.min(50) * 3).await {
-                                Ok(results) if !results.is_empty() => {
+                                Ok(SearchOutcome::Results(results)) if !results.is_empty() => {
                                     // Filter to code symbols only and take top_k
                                     let code_results: Vec<_> = results.into_iter()
                                         .filter(|r| r.kind.starts_with("code:"))
@@ -2440,6 +2434,11 @@ impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
                                         .collect();
                                     header.push('\n');
                                     (ids, header)
+                                }
+                                Ok(SearchOutcome::NotReady) => {
+                                    return Ok(text_result(
+                                        "Embedding index: building — semantic graph queries will work shortly. Use node_id from search_symbols instead, or retry in a few seconds.".to_string()
+                                    ));
                                 }
                                 Ok(_) => {
                                     return Ok(text_result(format!(

--- a/src/smoke.rs
+++ b/src/smoke.rs
@@ -173,7 +173,7 @@ pub async fn run(args: &TestArgs) -> Result<bool> {
         Ok(idx) => {
             // Probe first: if the table already exists, reuse it; otherwise rebuild.
             match idx.search("_probe_", None, 1).await {
-                Ok(_) => {
+                Ok(crate::embed::SearchOutcome::Results(_)) => {
                     tracing::info!(
                         "Smoke: embedding index reused in {:?}",
                         embed_start.elapsed()
@@ -181,7 +181,7 @@ pub async fn run(args: &TestArgs) -> Result<bool> {
                     checks.push(Check::pass("embed_index", "Persisted embedding index reused"));
                     Some(idx)
                 }
-                Err(_) => {
+                Ok(crate::embed::SearchOutcome::NotReady) | Err(_) => {
                     let embeddable: Vec<_> = all_nodes.iter()
                         .filter(|n| n.id.root != "external")
                         .take(50)
@@ -225,8 +225,11 @@ pub async fn run(args: &TestArgs) -> Result<bool> {
     match &embed_index {
         Some(idx) => {
             match idx.search("main", None, 5).await {
-                Ok(results) if !results.is_empty() => {
+                Ok(crate::embed::SearchOutcome::Results(results)) if !results.is_empty() => {
                     checks.push(Check::pass("oh_search_context", format!("{} results for query \"main\"", results.len())));
+                }
+                Ok(crate::embed::SearchOutcome::NotReady) => {
+                    checks.push(Check::skip("oh_search_context", "Embedding table not built yet"));
                 }
                 Ok(_) => {
                     checks.push(Check::fail("oh_search_context", "Query \"main\" returned 0 results"));
@@ -1226,16 +1229,10 @@ async fn run_oh_search_context_check(embed_index: &Option<EmbeddingIndex>) -> Ch
     };
 
     match index.search("alignment", None, 5).await {
-        Err(e) => {
-            // Table-not-found means indexing was skipped — not a hard failure
-            let msg = e.to_string();
-            if msg.contains("Table not found") {
-                Check::skip("oh_search_context", "Embedding table not found — run index_all first")
-            } else {
-                Check::fail("oh_search_context", format!("Semantic search failed: {}", e))
-            }
+        Ok(crate::embed::SearchOutcome::NotReady) => {
+            Check::skip("oh_search_context", "Embedding table not built yet — index is still building")
         }
-        Ok(results) => {
+        Ok(crate::embed::SearchOutcome::Results(results)) => {
             if results.is_empty() {
                 Check::skip(
                     "oh_search_context",
@@ -1252,6 +1249,9 @@ async fn run_oh_search_context_check(embed_index: &Option<EmbeddingIndex>) -> Ch
                     ),
                 )
             }
+        }
+        Err(e) => {
+            Check::fail("oh_search_context", format!("Semantic search failed: {}", e))
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #130

When the embedding index hasn't been built yet (fresh install, cache cleared), `oh_search_context` and `graph_query` returned opaque errors:
- `"Artifact search error: Table not found — run index_all first"`
- `"Semantic search failed: Table not found — run index_all first"`

Now they return actionable messages:
- `"Embedding index: building — semantic results will appear shortly. Retry in a few seconds."`

## Changes

- `src/embed.rs`: `search()` returns `Ok(vec![])` instead of error when table doesn't exist. Added `is_ready()` method to check table existence.
- `src/server.rs`: `oh_search_context` and `graph_query` check `is_ready()` before searching, show "building" message if not ready.

## Test plan

- [ ] `cargo check` passes
- [ ] `cargo test --lib` passes
- [ ] Fresh cache: `oh_search_context` shows "building" message instead of error
- [ ] After index built: `oh_search_context` returns normal results
- [ ] `graph_query` with `query` param shows "building" instead of error