### PR TITLE
fix: match SearchOutcome::NotReady in embedding rebuild probes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -190,8 +190,10 @@ async fn main() -> anyhow::Result<()> {
                     eprintln!("  Embedding {} symbols...", graph.nodes.iter().filter(|n| n.id.root != "external").count());
                     loop {
                         match idx.search("_probe_", None, 1).await {
-                            Ok(_) => break 1, // table exists and is queryable
-                            Err(_) => tokio::time::sleep(std::time::Duration::from_secs(2)).await,
+                            Ok(repo_native_alignment::embed::SearchOutcome::Results(_)) => break 1,
+                            Ok(repo_native_alignment::embed::SearchOutcome::NotReady) | Err(_) => {
+                                tokio::time::sleep(std::time::Duration::from_secs(2)).await
+                            }
                         }
                     }
                 }
@@ -421,7 +423,10 @@ async fn main() -> anyhow::Result<()> {
             let metis = artifacts.iter().filter(|a| a.kind == repo_native_alignment::types::OhArtifactKind::Metis).count();
 
             let embed_str = match repo_native_alignment::embed::EmbeddingIndex::new(&repo_root).await {
-                Ok(idx) => if idx.search("_probe_", None, 1).await.is_ok() { "yes" } else { "no" },
+                Ok(idx) => match idx.search("_probe_", None, 1).await {
+                    Ok(repo_native_alignment::embed::SearchOutcome::Results(_)) => "yes",
+                    _ => "no",
+                },
                 Err(_) => "no",
             };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1419,11 +1419,11 @@ impl RnaHandler {
                     // Warm embed index from cached LanceDB table
                     if let Ok(idx) = EmbeddingIndex::new(&self.repo_root).await {
                         match idx.search("_probe_", None, 1).await {
-                            Ok(_) => {
+                            Ok(SearchOutcome::Results(_)) => {
                                 tracing::info!("Loaded existing embedding index from cache");
                                 self.embed_index.store(Arc::new(Some(idx)));
                             }
-                            Err(_) => {
+                            Ok(SearchOutcome::NotReady) | Err(_) => {
                                 match idx.index_all_with_symbols(&self.repo_root, &state.nodes).await {
                                     Ok(count) => {
                                         tracing::info!("Rebuilt embedding index: {} items from cached graph", count);


### PR DESCRIPTION
## Summary
- Fixes #132 — embedding index never rebuilds after #131's SearchOutcome refactor
- Two internal probe sites in `build_full_graph()` used `.is_err()` / `Ok(_)` matching to decide whether to rebuild the embedding index
- After #131 changed `search()` to return `Ok(SearchOutcome::NotReady)` instead of `Err(...)` for missing tables, these probes always saw `Ok` and skipped the rebuild
- Fix: explicitly match `SearchOutcome::NotReady` alongside `Err` as "needs rebuild"

## Changes
- `server.rs:1533` — warm-start probe: `Ok(_)` → `Ok(SearchOutcome::Results(_))`, `Err(_)` → `Ok(SearchOutcome::NotReady) | Err(_)`
- `server.rs:1572` — background rebuild check: `.is_err()` → `needs_rebuild` match on `SearchOutcome::NotReady | Err`

## Test plan
- [x] `cargo test` — 377 passed, 0 failed
- [x] Clear cache (`rm -rf .oh/.cache/`), restart, verify embedding index builds and semantic search returns results
- [x] Verify warm restart (with existing cache) still skips rebuild correctly