### PR TITLE
feat: dev-pipeline agent, friction skill, ship improvements

### DIFF
--- a/.claude/agents/dev-pipeline.md
+++ b/.claude/agents/dev-pipeline.md
@@ -1,0 +1,252 @@
+---
+name: dev-pipeline
+description: Full dev pipeline from problem framing through merge. Ensures GitHub issue exists, explores solutions, executes, then ships. Reports RNA tool friction.
+tools: Read, Write, Edit, Grep, Glob, Bash, Agent, WebFetch, WebSearch
+mcpServers:
+  - rna-mcp
+---
+
+# /dev-pipeline
+
+Full development pipeline: **problem-statement → solution-space → execute → ship.**
+
+Takes a feature or bug from framing through merge. Each phase feeds the next via a session file. The pipeline ensures nothing is skipped — no coding without a problem statement, no merging without the /ship quality gate.
+
+> **You are an RNA power user.** Use `oh_search_context`, `search_symbols`, `graph_query`, and `outcome_progress` throughout every phase — for code navigation, guardrail checks, outcome alignment, and context gathering. **Do not fall back to raw Grep/Read for code understanding when an RNA tool would work.** When an RNA tool *doesn't* work well (wrong results, too slow, missing data, awkward API), note the friction in the session file's friction log. These reports directly improve the product.
+
+## Arguments
+
+`/dev-pipeline <issue-number-or-description>`
+
+- If a GitHub issue number is given (e.g., `140`), read it as the starting context.
+- If a description is given, use it to frame the problem in Phase 1.
+- If both, the issue is the source of truth; the description is supplementary context.
+
+## Session File
+
+All phases write to `.oh/sessions/<issue-number>-dev.md` (or `<slug>-dev.md` if no issue yet).
+
+Initialize it at pipeline start:
+
+```markdown
+# Dev Pipeline — <title>
+**Issue:** #<number> (or "pending")
+**PR:** (filled in Phase 3)
+**Started:** <timestamp>
+
+## Phase 1: Problem Statement
+(filled by Phase 1)
+
+## Phase 2: Solution Space
+(filled by Phase 2)
+
+## Phase 3: Execute
+(filled by Phase 3)
+
+## Phase 4: Ship
+(filled by Phase 4)
+
+## RNA Tool Friction Log
+<!-- Append entries as you encounter friction with RNA MCP tools. -->
+<!-- Format: | Phase | Tool | What happened | What you did instead | Severity | -->
+| Phase | Tool | What happened | Workaround | Severity |
+|-------|------|---------------|------------|----------|
+```
+
+---
+
+## Phase 1: Problem Statement → GitHub Issue
+
+**Goal:** Ensure the work has a crisp problem statement captured in a GitHub issue.
+
+### If an issue number was provided:
+1. Read the issue: `gh issue view <number>`
+2. Assess: does it already have a clear problem statement? (outcome-focused, testable, solution-agnostic)
+3. If yes — extract it into the session file, move to Phase 2.
+4. If no — run the `/problem-statement` process against the issue description to reframe it.
+5. Update the issue body with the reframed problem statement: `gh issue edit <number> --body ...`
+
+### If only a description was provided:
+1. Run the `/problem-statement` process to frame the problem.
+2. Create a GitHub issue with the problem statement as the body:
+   ```bash
+   gh issue create --title "<crisp title>" --body "$(cat <<'EOF'
+   ## Problem Statement
+   ...
+
+   ## Acceptance Criteria
+   - [ ] ...
+   EOF
+   )"
+   ```
+3. Record the issue number in the session file.
+
+### Phase 1 output:
+- A GitHub issue with a clear problem statement and acceptance criteria
+- Session file updated with the problem statement
+
+**Gate:** Do not proceed to Phase 2 without acceptance criteria on the issue.
+
+---
+
+## Phase 2: Solution Space → PR Description
+
+**Goal:** Explore candidate solutions and draft a PR with the chosen approach.
+
+1. Run the `/solution-space` process, using the problem statement from Phase 1 as input.
+   - Generate 3-4 candidates at different levels (band-aid → redesign)
+   - Evaluate trade-offs
+   - Recommend with reasoning
+
+2. Create a feature branch:
+   ```bash
+   git checkout -b <issue-number>-<slug> main
+   ```
+
+3. Draft the PR description from the solution space output:
+   ```bash
+   gh pr create --draft --title "<title>" --body "$(cat <<'EOF'
+   ## Summary
+   <1-2 sentence summary of chosen approach>
+
+   Closes #<issue-number>
+
+   ## Problem
+   <from Phase 1>
+
+   ## Solution
+   **Selected:** <recommended option>
+   **Level:** <band-aid / local optimum / reframe / redesign>
+
+   <rationale — why this approach, why not the others>
+
+   ## Acceptance Criteria
+   <copied from issue>
+
+   ## Test Plan
+   - [ ] ...
+   EOF
+   )"
+   ```
+
+4. Update session file with solution space analysis and PR number.
+
+### Phase 2 output:
+- A draft PR with solution exploration in the description
+- Session file updated with solution space and PR number
+
+**Gate:** Do not proceed to Phase 3 without a draft PR.
+
+---
+
+## Phase 3: Execute
+
+**Goal:** Implement the chosen solution.
+
+### Worktree setup (warm build cache)
+
+> **IMPORTANT: Do NOT use `isolation: "worktree"` on the Agent tool to launch this pipeline.**
+> The built-in isolation creates worktrees that lock `main`, doesn't use `prep-worktree.sh` for warm caches, and can create nested worktrees-inside-worktrees. The pipeline manages its own worktree below.
+
+Before building, set up an isolated worktree with a warm Cargo cache:
+
+```bash
+scripts/prep-worktree.sh .claude/worktrees/<issue-number> <branch-name>
+cd .claude/worktrees/<issue-number>
+export CARGO_TARGET_DIR=$PWD/target
+```
+
+This hardlinks the main repo's `target/` directory so `cargo build` only recompiles the delta (seconds, not minutes). All `cargo build`, `cargo test`, and `cargo clippy` commands in Phase 3 and Phase 4 must run inside the worktree with `CARGO_TARGET_DIR` set.
+
+**Cleanup:** After Phase 4 completes (or on pipeline failure), remove the worktree:
+```bash
+git worktree remove .claude/worktrees/<issue-number> --force
+```
+
+### Implementation
+
+Launch the `/execute` process (via the `oh-execute` agent) with the session file as context:
+
+- The agent reads the session file for aim, problem statement, and selected solution
+- Pre-flight, build, drift detection, salvage if needed
+- Commits are pushed to the PR branch
+- Tag commits with `[outcome:X]` if a relevant outcome exists
+
+After execution completes:
+1. Update session file with execution notes
+2. Mark the PR as ready for review: `gh pr ready <PR>`
+3. Push final commits
+
+### Phase 3 output:
+- Implementation committed and pushed to the PR branch
+- PR marked ready (no longer draft)
+- Session file updated with execution status
+
+**Gate:** Do not proceed to Phase 4 if execution produced SALVAGE verdict. Surface the salvage to the user and stop.
+
+---
+
+## Phase 4: Ship
+
+**Goal:** Quality gate and merge via the `ship` agent (`.claude/agents/ship.md`).
+
+> **CRITICAL: You MUST spawn the ship agent. Do NOT inline the ship steps yourself.**
+> The ship agent posts each step's findings as PR comments — review, dissent, adversarial test results, merit assessment, etc. These comments are the auditable quality record. If you simulate the ship steps in your own context instead of spawning the agent, the findings exist only in the session file and are invisible on the PR. This is a process failure — a quality gate that isn't visible is no gate at all.
+>
+> See `.oh/metis/ship-steps-must-be-visible.md` for the full learning.
+
+Spawn the **`ship` agent** (`.claude/agents/ship.md`) with the PR number:
+
+```
+Agent(subagent_type="ship", prompt="/ship <PR-number>")
+```
+
+This launches the full 11-step pipeline as an autonomous agent:
+
+1. Review
+2. Dissent
+3. Fix
+4. Adversarial test
+5. Merit assessment
+6. Resolve TODOs
+7a. Manual verification
+7b. Delivery verification
+8. README
+9. Smoke test
+10. CI green
+11. Merge
+
+The ship agent runs autonomously — do not wait for user prompts between steps. **Each substantive step MUST post its findings as a PR comment** (per `.claude/agents/ship.md`).
+
+### Phase 4 output:
+- PR merged (or stopped with verdict if issues found)
+- Session file updated with ship pipeline results
+
+---
+
+## Automation Rules
+
+- **Do not wait** for user prompts between phases. When one phase completes and its gate passes, immediately start the next.
+- **Stop and ask** only if:
+  - Phase 1 can't determine acceptance criteria (needs user input)
+  - Phase 3 produces a SALVAGE verdict
+  - Phase 4 produces ABANDON/RECONSIDER verdict or CI fails after 2 fix attempts
+- **Record metis** if any phase surfaces a new learning: write to `.oh/metis/<slug>.md`
+
+## RNA Tool Usage & Friction Reporting
+
+**Use RNA MCP tools as your primary codebase interface.** See the `/friction` skill (`.claude/skills/friction.md`) for the full tool reference table and logging format.
+
+When an RNA tool falls short — wrong results, missing data, awkward API, too slow, or you fell back to Grep/Read — log friction per `/friction`: append to the session file's `## RNA Tool Friction Log` table.
+
+**At pipeline end**, run `/friction summary` to produce a friction summary with recommendations (file issue, update existing issue, or note as known limitation).
+
+## Position in Framework
+
+**This is the full pipeline.** It composes:
+- `/problem-statement` (Phase 1)
+- `/solution-space` (Phase 2)
+- `/execute` (Phase 3)
+- `/ship` (Phase 4)
+
+For partial runs, use the individual skills directly. `/dev-pipeline` is for end-to-end delivery of a single issue.

--- a/.claude/agents/ship.md
+++ b/.claude/agents/ship.md
@@ -10,6 +10,8 @@ mcpServers:
 
 The full quality gate for this project. Run sequentially — each step must complete before the next begins. **Do not wait for user prompts between steps.** When one step completes, immediately start the next.
 
+> **You are an RNA power user.** Use `oh_search_context`, `search_symbols`, `graph_query`, and `outcome_progress` as your primary codebase interface — for review context, dissent grounding, impact analysis, and guardrail checks. **Do not fall back to raw Grep/Read for code understanding when an RNA tool would work.** When an RNA tool falls short, log friction per `/friction` (`.claude/skills/friction.md`): append to the session file's friction log table, or to `.oh/friction-logs/` if no session file is active.
+
 ## Arguments
 
 `/ship <PR-number>` — run the pipeline against a specific PR.

--- a/.claude/skills/friction.md
+++ b/.claude/skills/friction.md
@@ -1,0 +1,75 @@
+---
+name: friction
+description: Log RNA MCP tool friction. Use whenever an RNA tool fails, frustrates, or gets skipped in favor of Grep/Read.
+---
+
+# /friction
+
+Log a friction event with an RNA MCP tool. This is how the product improves — every friction point is signal.
+
+## When to Use
+
+Call `/friction` (or apply this process inline) whenever:
+
+- An RNA tool returned **wrong or irrelevant results**
+- An RNA tool was **missing data** you expected (symbol, edge, metadata)
+- The API was **awkward** — needed N calls where 1 should suffice, params confusing
+- A tool was **too slow** and disrupted your flow
+- You **fell back to Grep/Read** because the RNA tool wasn't sufficient
+- A tool **errored or hung**
+
+## How to Log
+
+Write friction to `.oh/friction-logs/<pipeline-or-context>.md` — one file per pipeline run or work session. Create the file if it doesn't exist, append if it does.
+
+**File format:**
+```markdown
+# Friction Log: <context>
+**Date:** <date>
+**Pipeline/Issue:** #<number> or <description>
+
+| Phase/Step | Tool | What happened | Workaround | Severity |
+|------------|------|---------------|------------|----------|
+| <phase> | <tool name> | <what happened> | <what you did instead> | <severity> |
+```
+
+Also append to the active session file's `## RNA Tool Friction Log` table if one exists — this keeps friction visible in the session while the canonical log lives in `.oh/friction-logs/`.
+
+**Severity levels:**
+- **blocker** — had to abandon the tool entirely, couldn't complete the task with it
+- **friction** — worked around it, but it cost time or context window
+- **papercut** — minor annoyance, still usable
+
+## Friction Summary
+
+At the end of a pipeline run (or on explicit `/friction summary`), review the accumulated friction log and produce:
+
+```markdown
+## Friction Summary
+
+**Total events:** N (X blockers, Y friction, Z papercuts)
+
+### Patterns
+- <pattern 1>: <description> (N occurrences)
+- <pattern 2>: <description> (N occurrences)
+
+### Recommendations
+- **File issue:** <description> — severity warrants tracking
+- **Update existing issue:** #<number> — <how this friction relates>
+- **Known limitation:** <description> — not actionable yet, note for context
+```
+
+## RNA Tool Quick Reference
+
+Use RNA tools as your primary codebase interface. Log friction when they fall short.
+
+| Need | RNA tool | Friction if you reach for... |
+|------|----------|------------------------------|
+| Find code by intent | `oh_search_context(query)` | Grep for keywords |
+| Find symbols by name/kind | `search_symbols(query, kind, ...)` | Grep for definitions |
+| Trace dependencies | `graph_query(node, mode: "neighbors")` | Reading imports manually |
+| Assess blast radius | `graph_query(node, mode: "impact")` | Guessing from file structure |
+| Check outcome alignment | `outcome_progress(outcome_id)` | Reading `.oh/outcomes/` manually |
+| Find guardrails | `oh_search_context(query, artifact_types: ["guardrail"])` | Grepping `.oh/guardrails/` |
+
+**The rule:** Try the RNA tool first. If it doesn't work, use whatever does — but log why.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
           sed -i 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml
           sed -i 's/"version": "[^"]*"/"version": "'"$VERSION"'"/g' .claude-plugin/marketplace.json
 
-      - name: Create PR
+      - name: Create and merge PR
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -150,8 +150,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "chore: bump version to $VERSION"
           git push origin "$BRANCH"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "chore: bump version to $VERSION" \
             --body "Auto-generated from release ${{ github.ref_name }}." \
             --base main \
-            --head "$BRANCH"
+            --head "$BRANCH")
+          gh pr merge "$PR_URL" --squash --auto

--- a/.oh/friction-logs/143-test-coverage.md
+++ b/.oh/friction-logs/143-test-coverage.md
@@ -1,0 +1,23 @@
+# Friction Log: #143 Test Coverage Mapping
+
+## Summary
+
+One RNA tool friction event. One tooling/environment friction event (not RNA-specific).
+
+## Friction Events
+
+### 1. search_symbols: enum variants not indexed
+- **Phase:** 1 (Problem Statement)
+- **Tool:** search_symbols
+- **Severity:** Low
+- **What happened:** Searching for `Calls` with `kind=enum` returned no results, even though `EdgeKind::Calls` exists at `src/graph/mod.rs:136`. Enum variants (the individual arms of an enum) are not indexed as standalone symbols -- only the enum itself is indexed.
+- **Workaround:** Read the file directly to find the EdgeKind definition.
+- **Recommendation:** Known limitation. Enum variants would need to be emitted as separate symbols (kind=variant or kind=const) during tree-sitter extraction. Low priority since the enum itself is findable.
+
+### 2. Edit tool path confusion in worktrees (not RNA)
+- **Phase:** 3 (Execute)
+- **Tool:** Claude Edit tool (not RNA)
+- **Severity:** Medium
+- **What happened:** The Edit tool applied changes to the main repo's `src/server.rs` instead of the worktree copy. Since worktrees have separate working directories, the changes were invisible to the worktree's cargo build. This caused ~15 minutes of debugging "why aren't my tests showing up."
+- **Workaround:** Manually copied the file to the worktree, then used explicit worktree paths for all subsequent edits.
+- **Recommendation:** Not an RNA issue. This is a Claude Code / worktree interaction issue.

--- a/.oh/friction-logs/147-unified-search.md
+++ b/.oh/friction-logs/147-unified-search.md
@@ -1,0 +1,20 @@
+# Friction Log: #147 Unified Search Tool
+**Date:** 2026-03-12
+**Pipeline/Issue:** #147 / PR #148
+
+| Phase/Step | Tool | What happened | Workaround | Severity |
+|------------|------|---------------|------------|----------|
+| Phase 1 (problem statement) | search_symbols | Compound queries like "search_symbols handler" return no results | Searched each term separately | papercut |
+| Phase 1 (problem statement) | search_symbols | String constants (tool descriptions, error messages) indexed as symbols, cluttering results | Mentally filtered out const results | papercut |
+
+## Friction Summary
+
+**Total events:** 2 (0 blockers, 0 friction, 2 papercuts)
+
+### Patterns
+- Multi-word search doesn't work as expected — agent expects phrase search, gets AND/OR confusion (1 occurrence)
+- Synthetic constants noise — string literals surfacing alongside real symbols (1 occurrence)
+
+### Recommendations
+- **Update existing issue:** #118 or new — multi-word query handling in search_symbols could split on spaces and AND the terms
+- **Known limitation:** synthetic constants are deliberate (#119 tracks NodeId collision); consider a `exclude_synthetic: true` default or lower ranking tier for synthetic Const nodes

--- a/.oh/metis/ship-steps-must-be-visible.md
+++ b/.oh/metis/ship-steps-must-be-visible.md
@@ -1,0 +1,33 @@
+---
+title: Ship pipeline steps must be visible on the PR
+type: metis
+date: 2026-03-12
+trigger: PRs #148, #149, #150 merged with no ship step comments
+---
+
+## The Problem
+
+The dev-pipeline agent was instructed to spawn the `ship` agent for Phase 4, but instead simulated the ship steps internally — review, dissent, tests, merit — and recorded findings only in the session file. The PRs were merged with no visible quality gate: no posted review, no posted dissent, no adversarial test results.
+
+## Why It Happened
+
+The dev-pipeline agent treated "run the ship pipeline" as "think through the ship steps" rather than "spawn a separate agent that posts to the PR." The instruction `Agent(subagent_type="ship", prompt="/ship <PR-number>")` was present but not forceful enough — the agent optimized for speed over process.
+
+## The Metis
+
+**A quality gate that only exists in a session file is no gate at all.** The ship pipeline's value is not just that the steps happen — it's that each step's findings are posted as PR comments where they are:
+
+1. **Visible** to reviewers (human and bot)
+2. **Auditable** in GitHub's permanent record
+3. **Referenceable** in future discussions
+4. **Independent** of the agent's context window (which gets garbage collected)
+
+Session file notes are private scratchpad. PR comments are public record.
+
+## The Fix
+
+Dev-pipeline Phase 4 now has a CRITICAL callout: "You MUST spawn the ship agent. Do NOT inline the ship steps yourself." With explanation of why — the PR comment trail is the audit record.
+
+## Pattern
+
+This is a variant of "computed but not delivered" (`.oh/metis/computed-but-not-delivered.md`) — but applied to process rather than data. The quality assessment was computed (in the session file) but not delivered (to the PR).

--- a/.oh/sessions/143-dev.md
+++ b/.oh/sessions/143-dev.md
@@ -1,0 +1,56 @@
+# Dev Pipeline -- Test coverage mapping
+
+**Issue:** #143 (CLOSED)
+**PR:** #149 (MERGED)
+**Started:** 2026-03-12
+**Completed:** 2026-03-12
+
+## Phase 1: Problem Statement
+
+**Problem:** `outcome_progress` shows which symbols changed for an outcome, but not which tests verify those symbols. An agent assessing "is this outcome safe to ship?" has to manually trace test coverage through Grep. RNA already extracts test files and demotes them in ranking -- but does not surface the reverse lookup: "given production symbol X, which test symbols call it?"
+
+**Acceptance Criteria:**
+- [x] Given a production symbol's node_id, the user can query which test functions call it
+- [x] Uses existing `Calls` edges and `is_test_file` heuristics -- no new extraction needed
+- [x] Results include the test function name, file, and signature
+- [x] Works through `search` tool (new mode) and `graph_query` deprecated alias
+
+## Phase 2: Solution Space
+
+**Candidates evaluated:**
+
+1. **Band-aid: Document existing workaround** -- Not viable. `impact()` doesn't support edge_type filtering, so there is no workaround.
+2. **Local optimum: New `tests_for` mode on `search`** -- SELECTED. Minimal API change, builds on existing primitives, single-step for agents.
+3. **Reframe: `tested_by` field on `search` output** -- Too invasive, changes every search result.
+4. **Redesign: Test coverage section in `outcome_progress`** -- Good idea but should build on the primitive, not be the primitive.
+
+**Decision:** Option 2. One new mode string, no new parameters. Composable -- outcome_progress can use this later.
+
+## Phase 3: Execute
+
+**Implementation (1 commit, 1 file: `src/server.rs`):**
+- Added `tests_for` mode to the `run_traversal` closure in `handle_search_traversal`
+- Walks incoming Calls edges (1-hop) from target node(s)
+- Post-traversal filter: retains only callers where `ranking::is_test_file` is true
+- Custom heading ("Test coverage for X") and helpful empty-result message
+- Updated tool descriptions for `search`, `Search.mode` field, and deprecated `graph_query`
+- 4 unit tests: deserialization (2), filter logic (1), no-test-callers (1)
+- All 413 tests pass
+
+**Note:** Had to rebase after main moved (PR #148 merged, collapsing search_symbols + graph_query into unified search). Re-implemented cleanly against the new `handle_search_traversal` method.
+
+## Phase 4: Ship
+
+**Ship verdict: MERGED.**
+
+- Review: Clean, focused diff. 171 lines added (mostly tests). Core logic is ~15 lines.
+- Dissent: `is_test_file` false positives are pre-existing limitation, not introduced here. O(n*m) lookup acceptable for typical repos.
+- Tests: 4 unit tests covering deserialization and filter logic.
+- CI: Runs on merge to main (no PR-branch CI). All 413 tests pass locally.
+- Merged: 2026-03-12T23:14:55Z
+
+## RNA Tool Friction Log
+| Phase | Tool | What happened | Workaround | Severity |
+|-------|------|---------------|------------|----------|
+| 1 | search_symbols | Searching for "Calls" with kind=enum returned no results, even though EdgeKind::Calls exists in graph/mod.rs. Enum variants are not indexed as standalone symbols. | Read the file directly to find EdgeKind enum. | low |
+| 3 | N/A | Edit tool wrote to main repo path instead of worktree path. Not an RNA tool issue per se, but caused significant debugging time (~15 min). | Copied file manually to worktree, then used worktree paths for subsequent edits. | medium |


### PR DESCRIPTION
## Summary

Adds the dev-pipeline agent, /friction skill, and several fixes discovered during the first batch of automated pipeline runs (#148, #149, #150).

## Changes

- **dev-pipeline agent** (`.claude/agents/dev-pipeline.md`): 4-phase pipeline from problem-statement → solution-space → execute → ship agent. RNA-first with friction logging.
- **/friction skill** (`.claude/skills/friction.md`): Structured RNA tool friction logging — severity levels, tool reference table, summary process. Logs to `.oh/friction-logs/`.
- **ship agent nudge**: RNA power-user instruction + friction logging reference
- **Phase 4 fix**: CRITICAL callout — must spawn ship agent, not inline steps. Metis: `ship-steps-must-be-visible.md`
- **Worktree fix**: Don't use `isolation: "worktree"` — use `prep-worktree.sh` for warm cache + cleanup
- **Release workflow**: Auto-merge version bump PR (`--squash --auto`)
- **Friction logs**: From #143 and #147 pipeline runs (dogfooding signal)

## Origin

First automated pipeline runs (#148, #149, #150) revealed:
1. Ship steps were inlined, not posted to PRs (invisible quality gate)
2. Built-in worktree isolation fights with prep-worktree.sh (cold builds, locked main)
3. Friction logging needed a canonical location

## Test plan

- [ ] Verify dev-pipeline agent is available after restart
- [ ] Next pipeline run posts ship steps as PR comments
- [ ] Next pipeline run uses prep-worktree.sh for warm builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow now automatically creates and merges pull requests via squash merge, streamlining the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->