### PR TITLE
fix: friction logging captures skipped RNA tools, not just failures

### DIFF
--- a/.claude/agents/dev-pipeline.md
+++ b/.claude/agents/dev-pipeline.md
@@ -12,7 +12,7 @@ Full development pipeline: **problem-statement → solution-space → execute �
 
 Takes a feature or bug from framing through merge. Each phase feeds the next via a session file. The pipeline ensures nothing is skipped — no coding without a problem statement, no merging without the /ship quality gate.
 
-> **You are an RNA power user.** Use `oh_search_context`, `search_symbols`, `graph_query`, and `outcome_progress` throughout every phase — for code navigation, guardrail checks, outcome alignment, and context gathering. **Do not fall back to raw Grep/Read for code understanding when an RNA tool would work.** When an RNA tool *doesn't* work well (wrong results, too slow, missing data, awkward API), note the friction in the session file's friction log. These reports directly improve the product.
+> **You are an RNA power user.** Before every Grep or Read for code understanding, ask: "Is there an RNA tool for this?" Check the table in `/friction` (`.claude/skills/friction.md`). Use `oh_search_context`, `search_symbols`, `graph_query`, and `outcome_progress` as your FIRST choice for code navigation, guardrail checks, outcome alignment, and context gathering. **Every Grep/Read you use instead of an RNA tool is a friction event — log it with severity `skipped`.** When an RNA tool fails, log that too. See `/friction` for the full protocol. A pipeline with 0 friction events and 30 Grep calls isn't frictionless — it's unmonitored.
 
 ## Arguments
 

--- a/.claude/agents/ship.md
+++ b/.claude/agents/ship.md
@@ -10,7 +10,7 @@ mcpServers:
 
 The full quality gate for this project. Run sequentially — each step must complete before the next begins. **Do not wait for user prompts between steps.** When one step completes, immediately start the next.
 
-> **You are an RNA power user.** Use `oh_search_context`, `search_symbols`, `graph_query`, and `outcome_progress` as your primary codebase interface — for review context, dissent grounding, impact analysis, and guardrail checks. **Do not fall back to raw Grep/Read for code understanding when an RNA tool would work.** When an RNA tool falls short, log friction per `/friction` (`.claude/skills/friction.md`): append to the session file's friction log table, or to `.oh/friction-logs/` if no session file is active.
+> **You are an RNA power user.** Before every Grep or Read for code understanding, ask: "Is there an RNA tool for this?" Check the table in `/friction` (`.claude/skills/friction.md`). Use `oh_search_context`, `search_symbols`, `graph_query`, and `outcome_progress` as your FIRST choice — for review context, dissent grounding, impact analysis, and guardrail checks. **Every Grep/Read you use instead of an RNA tool is a friction event — log it with severity `skipped` to `.oh/friction-logs/`.** When an RNA tool fails, log that too. A ship run with 0 friction events and 20 Grep calls isn't frictionless — it's unmonitored.
 
 ## Arguments
 

--- a/.claude/skills/friction.md
+++ b/.claude/skills/friction.md
@@ -7,7 +7,24 @@ description: Log RNA MCP tool friction. Use whenever an RNA tool fails, frustrat
 
 Log a friction event with an RNA MCP tool. This is how the product improves — every friction point is signal.
 
-## When to Use
+## The Rule
+
+**Before every Grep or Read for code understanding, ask: "Is there an RNA tool for this?"**
+
+- If yes and you use it → great, no log needed (unless it fails)
+- If yes and it fails → log the failure
+- If yes and you skip it → **log why you skipped it** (this IS friction)
+- If no RNA tool applies → no log needed
+
+**Using Grep/Read for code understanding without trying the RNA tool first is itself a friction event.** Not trying is not "no friction" — it's the worst kind of friction, because it means the tool wasn't even worth attempting. That's critical signal.
+
+The only Grep/Read uses that are NOT friction events:
+- Searching for non-code content (config files, CI yaml, shell scripts)
+- Reading a specific file you already know the path to (e.g., after RNA told you the file)
+- Searching for string literals, error messages, or log output
+- Grep/Read that RNA genuinely can't do (regex patterns, multi-file sed-like operations)
+
+## When to Log
 
 Call `/friction` (or apply this process inline) whenever:
 
@@ -15,7 +32,7 @@ Call `/friction` (or apply this process inline) whenever:
 - An RNA tool was **missing data** you expected (symbol, edge, metadata)
 - The API was **awkward** — needed N calls where 1 should suffice, params confusing
 - A tool was **too slow** and disrupted your flow
-- You **fell back to Grep/Read** because the RNA tool wasn't sufficient
+- You **used Grep/Read instead of an RNA tool** — log which RNA tool you should have used and why you didn't
 - A tool **errored or hung**
 
 ## How to Log
@@ -33,12 +50,19 @@ Write friction to `.oh/friction-logs/<pipeline-or-context>.md` — one file per 
 | <phase> | <tool name> | <what happened> | <what you did instead> | <severity> |
 ```
 
+**For skipped-RNA events, use this format:**
+
+| Phase/Step | Tool | What happened | Workaround | Severity |
+|------------|------|---------------|------------|----------|
+| Phase 3 | search_symbols (skipped) | Needed to find all functions in embed.rs | Used Grep for "fn " | skipped |
+
 Also append to the active session file's `## RNA Tool Friction Log` table if one exists — this keeps friction visible in the session while the canonical log lives in `.oh/friction-logs/`.
 
 **Severity levels:**
 - **blocker** — had to abandon the tool entirely, couldn't complete the task with it
 - **friction** — worked around it, but it cost time or context window
 - **papercut** — minor annoyance, still usable
+- **skipped** — didn't try the RNA tool at all; used Grep/Read instead
 
 ## Friction Summary
 
@@ -47,11 +71,16 @@ At the end of a pipeline run (or on explicit `/friction summary`), review the ac
 ```markdown
 ## Friction Summary
 
-**Total events:** N (X blockers, Y friction, Z papercuts)
+**Total events:** N (X blockers, Y friction, Z papercuts, W skipped)
+**RNA adoption rate:** X RNA calls / (X RNA calls + W skipped) = N%
 
 ### Patterns
 - <pattern 1>: <description> (N occurrences)
 - <pattern 2>: <description> (N occurrences)
+
+### Skipped — Why?
+- <reason 1>: (N occurrences) — e.g., "didn't think of it", "Grep felt faster", "wasn't sure which RNA tool"
+- <reason 2>: (N occurrences)
 
 ### Recommendations
 - **File issue:** <description> — severity warrants tracking
@@ -59,17 +88,20 @@ At the end of a pipeline run (or on explicit `/friction summary`), review the ac
 - **Known limitation:** <description> — not actionable yet, note for context
 ```
 
+The `skipped` count and adoption rate are the most important metrics. A pipeline with 0 friction events and 30 Grep calls isn't frictionless — it's unmonitored.
+
 ## RNA Tool Quick Reference
 
-Use RNA tools as your primary codebase interface. Log friction when they fall short.
+**Before using Grep or Read for code understanding, check this table.**
 
-| Need | RNA tool | Friction if you reach for... |
-|------|----------|------------------------------|
-| Find code by intent | `oh_search_context(query)` | Grep for keywords |
-| Find symbols by name/kind | `search_symbols(query, kind, ...)` | Grep for definitions |
-| Trace dependencies | `graph_query(node, mode: "neighbors")` | Reading imports manually |
-| Assess blast radius | `graph_query(node, mode: "impact")` | Guessing from file structure |
-| Check outcome alignment | `outcome_progress(outcome_id)` | Reading `.oh/outcomes/` manually |
-| Find guardrails | `oh_search_context(query, artifact_types: ["guardrail"])` | Grepping `.oh/guardrails/` |
+| Need | RNA tool to try FIRST | Grep/Read is friction if... |
+|------|----------------------|---------------------------|
+| Find code by intent | `oh_search_context(query)` | You Grep for keywords instead |
+| Find symbols by name/kind | `search_symbols(query, kind, ...)` | You Grep for `fn `, `struct `, `impl ` |
+| Trace dependencies | `graph_query(node, mode: "neighbors")` | You Read imports manually |
+| Assess blast radius | `graph_query(node, mode: "impact")` | You guess from file structure |
+| Check outcome alignment | `outcome_progress(outcome_id)` | You Read `.oh/outcomes/` manually |
+| Find guardrails | `oh_search_context(query, artifact_types: ["guardrail"])` | You Grep `.oh/guardrails/` |
+| Understand a function's role | `graph_query(node, mode: "neighbors")` | You Read the file and scan context |
 
-**The rule:** Try the RNA tool first. If it doesn't work, use whatever does — but log why.
+**The rule:** Try the RNA tool first. If it doesn't work, use whatever does — but log why. If you don't try it, log why not.


### PR DESCRIPTION
## Problem

Batch 1 pipeline agents (#140, #143, #147) used Grep/Read ~80% of the time but logged only 4 friction events total. "Didn't try RNA" wasn't treated as friction, so the logs showed a falsely clean picture.

## Fix

- New `skipped` severity: logged when Grep/Read is used instead of an RNA tool
- Inverted rule: "log the fallback, not just the failure"
- RNA adoption rate metric in friction summary: `RNA calls / (RNA calls + skipped)`
- Explicit list of Grep/Read uses that are NOT friction (config files, known paths, regex)
- Updated nudges in dev-pipeline and ship agents

A pipeline with 0 friction events and 30 Grep calls isn't frictionless — it's unmonitored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development guidelines and policies to improve development workflows and quality assurance processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->