### PR TITLE
fix: distinguish LSP 'no server available' from 'enriched (0 edges)'

### DIFF
--- a/src/extract/lsp.rs
+++ b/src/extract/lsp.rs
@@ -963,7 +963,7 @@ impl Enricher for LspEnricher {
         // Try to initialize the language server using the repo root from --repo
         if let Err(e) = self.ensure_initialized(repo_root).await {
             tracing::debug!("LSP enrichment skipped for {}: {}", self.language, e);
-            return Ok(result);
+            return Err(e);
         }
 
         let mut state = self.state.lock().await;

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -105,6 +105,10 @@ pub struct EnrichmentResult {
     /// Virtual nodes synthesized for external symbols (e.g., tokio::spawn).
     /// These have `root = "external"` and no body — they must NOT be embedded.
     pub new_nodes: Vec<Node>,
+    /// Whether any enricher actually ran (server was available and initialized).
+    /// When false, all matching enrichers were skipped (server not on PATH, init failed, etc.).
+    /// Callers use this to distinguish "no server available" from "server ran, found nothing."
+    pub any_enricher_ran: bool,
 }
 
 /// Phase 2: Asynchronous enrichment after initial extraction.
@@ -422,6 +426,8 @@ impl EnricherRegistry {
 
             match enricher.enrich(nodes, index, repo_root).await {
                 Ok(enrichment) => {
+                    // If enrich() returned Ok, the server was available and ran.
+                    result.any_enricher_ran = true;
                     tracing::info!(
                         "Enricher {}: {} edges, {} node patches, {} virtual nodes",
                         enricher.name(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -1119,6 +1119,7 @@ impl LspEnrichmentStatus {
     const NOT_STARTED: u8 = 0;
     const RUNNING: u8 = 1;
     const COMPLETE: u8 = 2;
+    const UNAVAILABLE: u8 = 3;
 
     pub fn set_running(&self) {
         self.state.store(Self::RUNNING, std::sync::atomic::Ordering::Release);
@@ -1128,6 +1129,12 @@ impl LspEnrichmentStatus {
         self.edge_count.store(edge_count, std::sync::atomic::Ordering::Release);
         *self.completed_at.lock().unwrap() = Some(std::time::Instant::now());
         self.state.store(Self::COMPLETE, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Mark that no LSP server was available for any of the detected languages.
+    pub fn set_unavailable(&self) {
+        *self.completed_at.lock().unwrap() = Some(std::time::Instant::now());
+        self.state.store(Self::UNAVAILABLE, std::sync::atomic::Ordering::Release);
     }
 
     /// Render a short footer segment, or `None` if nothing useful to show.
@@ -1147,6 +1154,11 @@ impl LspEnrichmentStatus {
                 } else {
                     None
                 }
+            }
+            Self::UNAVAILABLE => {
+                // Always show unavailable status (no 30s auto-hide) so agents
+                // know LSP enrichment didn't run and why.
+                Some("LSP: no server detected".to_string())
             }
             _ => None,
         }
@@ -1756,6 +1768,12 @@ impl RnaHandler {
                 }
             };
 
+            if !enrichment.any_enricher_ran {
+                tracing::info!("[background] LSP enrichment: no server available");
+                bg_lsp_status.set_unavailable();
+                return;
+            }
+
             if enrichment.new_nodes.is_empty()
                 && enrichment.added_edges.is_empty()
                 && enrichment.updated_nodes.is_empty()
@@ -1936,6 +1954,10 @@ impl RnaHandler {
                 .enrich_all(&changed_nodes, &graph.index, &languages, &self.repo_root)
                 .await;
 
+            if !enrichment.any_enricher_ran {
+                self.lsp_status.set_unavailable();
+            }
+
             let incr_edge_count = enrichment.added_edges.len();
 
             // Add virtual nodes synthesized for external symbols.
@@ -2015,7 +2037,9 @@ impl RnaHandler {
                 }
             }
 
-            self.lsp_status.set_complete(incr_edge_count);
+            if enrichment.any_enricher_ran {
+                self.lsp_status.set_complete(incr_edge_count);
+            }
         }
 
         // Re-embed changed-file symbols. Uses the updated graph nodes so enriched
@@ -4090,6 +4114,29 @@ mod tests {
     }
 
     #[test]
+    fn test_lsp_status_unavailable_shows_no_server() {
+        let status = LspEnrichmentStatus::default();
+        status.set_running();
+        status.set_unavailable();
+        assert_eq!(
+            status.footer_segment().unwrap(),
+            "LSP: no server detected"
+        );
+    }
+
+    #[test]
+    fn test_lsp_status_unavailable_no_auto_hide() {
+        // UNAVAILABLE should always show, unlike COMPLETE which hides after 30s.
+        let status = LspEnrichmentStatus::default();
+        status.set_unavailable();
+        // Even without set_running first, should show.
+        assert_eq!(
+            status.footer_segment().unwrap(),
+            "LSP: no server detected"
+        );
+    }
+
+    #[test]
     fn test_format_freshness_without_lsp_status() {
         let result = format_freshness(100, Some(std::time::Instant::now()), None);
         assert!(result.contains("100 symbols"));
@@ -4112,6 +4159,15 @@ mod tests {
         status.set_complete(1247);
         let result = format_freshness(100, Some(std::time::Instant::now()), Some(&status));
         assert!(result.contains("LSP: enriched (1247 edges)"));
+    }
+
+    #[test]
+    fn test_format_freshness_with_unavailable_lsp() {
+        let status = LspEnrichmentStatus::default();
+        status.set_unavailable();
+        let result = format_freshness(100, Some(std::time::Instant::now()), Some(&status));
+        assert!(result.contains("LSP: no server detected"));
+        assert!(result.contains("100 symbols"));
     }
 
     // ── Adversarial LspEnrichmentStatus tests ─────────────────────────
@@ -4145,6 +4201,20 @@ mod tests {
         assert_eq!(status.footer_segment().unwrap(), "LSP: pending");
         status.set_complete(150);
         assert!(status.footer_segment().unwrap().contains("150 edges"));
+    }
+
+    #[test]
+    fn test_lsp_status_unavailable_then_running_then_complete() {
+        // Simulates: first scan finds no server, second scan (after install) finds one
+        let status = LspEnrichmentStatus::default();
+        status.set_running();
+        status.set_unavailable();
+        assert_eq!(status.footer_segment().unwrap(), "LSP: no server detected");
+        // Server installed, new scan starts
+        status.set_running();
+        assert_eq!(status.footer_segment().unwrap(), "LSP: pending");
+        status.set_complete(50);
+        assert!(status.footer_segment().unwrap().contains("50 edges"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Add UNAVAILABLE state to LspEnrichmentStatus so agents see "LSP: no server detected" instead of the misleading "LSP: enriched (0 edges)" when no language server is on PATH.

Closes #161

## Problem
`LspEnrichmentStatus` had three states (NOT_STARTED, RUNNING, COMPLETE). When no LSP server was available, `enrich_all()` returned empty results and the caller called `set_complete(0)` -- same codepath as genuine success with zero edges. Agents couldn't tell whether enrichment actually ran.

## Solution
**Selected:** Add UNAVAILABLE state to status state machine + propagate server availability
**Level:** Local optimum

- Add `UNAVAILABLE = 3` state constant with `set_unavailable()` method
- `set_unavailable()` has no 30s auto-hide -- always visible so agents know enrichment didn't run
- Add `any_enricher_ran: bool` field to `EnrichmentResult` (default false, set true when any enricher's `enrich()` returns Ok)
- `LspEnricher::enrich()` now returns `Err` (instead of `Ok(empty)`) when server is unavailable, so `enrich_all()` can distinguish the cases
- Both initial background enrichment and incremental enrichment paths check the flag and call `set_unavailable()` when appropriate
- Footer renders: "LSP: no server detected" (UNAVAILABLE) vs "LSP: enriched (0 edges)" (COMPLETE with 0) vs "LSP: enriched (N edges)" (COMPLETE with N)

## Acceptance Criteria
- [x] Status distinguishes "LSP: not available" from "LSP: enriched (0 edges)" vs "LSP: enriched (N edges)"
- [x] When no LSP server detected, status says so clearly
- [x] Existing tests pass (480/480)

## Test Plan
- [x] New unit tests for UNAVAILABLE state (footer_segment, no auto-hide, state transitions)
- [x] New format_freshness test with unavailable LSP
- [x] Adversarial test: unavailable -> running -> complete transition
- [x] All 480 existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error propagation during enrichment initialization failures.

* **New Features**
  * Added status indicator displaying "LSP: no server detected" when no language server is available.
  * Enhanced enrichment tracking to distinguish between server unavailability and no results found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->