### PR TITLE
feat: add --version flag to CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use repo_native_alignment::smoke::{self, TestArgs};
 #[derive(Parser, Debug)]
 #[command(
     name = "repo-native-alignment",
+    version,
     about = "Repo-Native Alignment MCP Server",
     long_about = None,
 )]


### PR DESCRIPTION
## Summary
Add `version` to the clap command derive so `repo-native-alignment --version` works.

Closes #189

## Problem
`repo-native-alignment --version` returns an error. Users have no way to verify which build they're running.

## Solution
One-line change: add `version` to `#[command(...)]` on the `Cli` struct. Clap pulls the version from `Cargo.toml` automatically.

```
$ repo-native-alignment --version
repo-native-alignment 0.1.6
```

## Test Plan
- [x] `cargo build` compiles
- [x] `cargo run -- --version` outputs `repo-native-alignment 0.1.6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now exposes version information, allowing users to check the program version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->