### PR TITLE
fix: set root slug on incremental graph updates

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -2159,9 +2159,17 @@ impl RnaHandler {
         for node in &mut extraction.nodes {
             node.id.root = primary_slug.clone();
         }
+        // Build file index from existing graph + new extraction for suffix matching
+        let file_index: std::collections::HashSet<String> = graph.nodes
+            .iter()
+            .chain(extraction.nodes.iter())
+            .map(|n| n.id.file.to_string_lossy().to_string())
+            .collect();
         for edge in &mut extraction.edges {
             edge.from.root = primary_slug.clone();
             edge.to.root = primary_slug.clone();
+            // Resolve dangling import edges via suffix match (same as build_full_graph)
+            resolve_edge_target_by_suffix(edge, &file_index);
         }
 
         // Track only the delta (new/changed) for LanceDB upsert — not the full graph.


### PR DESCRIPTION
## Summary
Set root slug on extracted nodes during incremental graph updates, fixing empty root prefixes on symbols from recently-changed files.

Closes #199

## Problem
`update_graph_with_scan()` (the foreground incremental update path called from `get_graph()`) extracts nodes via `extract_scan_result()` but never assigns `node.id.root` to the primary root's slug. The full rebuild path (`build_full_graph`) and background scanner both correctly set the root slug, but the incremental foreground path omits it. This causes ~1885 symbols in the most important files (server.rs, embed.rs, query.rs, etc.) to have empty root prefixes, breaking the `root` filter.

## Solution
**Selected:** Set root slug on extracted nodes and edges in `update_graph_with_scan`, matching the pattern used in `build_full_graph` and the background scanner.

**Level:** Local optimum -- uses `RootConfig::code_project(self.repo_root.clone()).slug()` to compute the primary root slug, then assigns it to all extracted nodes and edges before they enter the graph or LanceDB.

## Changes
- `src/server.rs`: Added root slug assignment after `extract_scan_result()` in `update_graph_with_scan()`
- `src/server.rs`: Added `RootConfig` to imports from `crate::roots`
- `src/server.rs`: Added regression test `test_incremental_update_preserves_root_slug`

## Acceptance Criteria
- [x] All symbols from primary root files have correct root slug
- [x] `root` filter matches symbols from all files including recently-changed ones
- [x] No regression in full rebuild or background scanner paths
- [x] Regression test prevents future recurrence

## Test Plan
- [x] `cargo test` -- 661 tests pass
- [x] `cargo clippy` -- clean (only pre-existing warnings)
- [x] New regression test `test_incremental_update_preserves_root_slug` verifies root slug survives incremental updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incremental graph updates now preserve root metadata on newly added nodes and edges.
  * Dangling imports are more reliably resolved by filename suffix during incremental updates, reducing unresolved links.

* **Tests**
  * Added a regression test to ensure root metadata remains populated across incremental updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->