### PR TITLE
fix: update deprecated tool names in outcome_progress response

### DIFF
--- a/src/extract/string_literals.rs
+++ b/src/extract/string_literals.rs
@@ -2,7 +2,7 @@
 //!
 //! Captures string literals appearing in source code as synthetic Const nodes.
 //! This surfaces cross-language literal values (e.g. `"application/json"`) so that
-//! `search_symbols` can find all places a given string is used — even across language
+//! `search` can find all places a given string is used — even across language
 //! boundaries.
 
 use std::collections::BTreeMap;

--- a/src/graph/index.rs
+++ b/src/graph/index.rs
@@ -630,7 +630,7 @@ mod tests {
     // ── Multi-entry traversal tests (PR #113 semantic graph entry) ──────
 
     /// Helper: simulate the multi-entry traversal + dedup pattern from the
-    /// graph_query handler. Returns (all_ids_deduped, entry_nodes_stripped).
+    /// graph traversal handler. Returns (all_ids_deduped, entry_nodes_stripped).
     fn multi_entry_neighbors(
         index: &GraphIndex,
         entry_ids: &[&str],

--- a/src/ranking.rs
+++ b/src/ranking.rs
@@ -1,6 +1,6 @@
 //! Shared ranking logic for code symbol search results.
 //!
-//! Both `search` (flat mode) and deprecated `search_symbols` rank code nodes using the same
+//! Both `search` (flat mode) and its deprecated aliases rank code nodes using the same
 //! 5-tier cascade. This module extracts that logic into a single function so
 //! ranking changes propagate to all call sites without copy-paste drift.
 

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -56,8 +56,7 @@ impl RnaHandler {
     }
 
     /// Flat symbol search (no `mode` parameter) plus optional artifact and markdown search.
-    /// Combines the old `search_symbols` (code) and `oh_search_context` (artifacts/markdown)
-    /// into a single unified search path.
+    /// Unified search path for code symbols, artifacts, and markdown.
     async fn handle_search_flat(
         &self,
         args: &Search,
@@ -308,7 +307,7 @@ impl RnaHandler {
         }
     }
 
-    /// Graph traversal search (with `mode` parameter). Equivalent to the old `graph_query`.
+    /// Graph traversal search (with `mode` parameter).
     async fn handle_search_traversal(
         &self,
         args: &Search,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1760,7 +1760,7 @@ fn build_context_preamble(root: &Path) -> String {
     }
 
     let mut out = format!("---\n# Business Context (auto-injected on first tool call)\n\n{}\n", parts.join("\n"));
-    out.push_str("**Code exploration:** use `search` (not Grep/Read) for code symbols, artifacts, commits, and markdown in one call. `search_symbols` and `graph_query` are deprecated aliases for `search`.\n");
+    out.push_str("**Code exploration:** use `search` (not Grep/Read) for code symbols, artifacts, commits, and markdown in one call. Use `search(node: \"<id>\", mode: \"neighbors\")` for graph traversal.\n");
     out.push_str("---\n\n");
     out
 }

--- a/src/server/tools.rs
+++ b/src/server/tools.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 #[macros::mcp_tool(
     name = "outcome_progress",
-    description = "Track progress on a business outcome. Finds tagged commits, code symbols in changed files, and related markdown. Returns a navigable summary with stable Node IDs for use with search_symbols and graph_query. Set include_impact=true to add risk-classified blast radius showing which symbols are affected by the changes and how critical they are. Results default to the primary workspace root; pass root: \"all\" for cross-root search."
+    description = "Track progress on a business outcome. Finds tagged commits, code symbols in changed files, and related markdown. Returns a navigable summary with stable Node IDs for use with search. Use search(node: \"<id>\", mode: \"neighbors\") for graph traversal. Set include_impact=true to add risk-classified blast radius showing which symbols are affected by the changes and how critical they are. Results default to the primary workspace root; pass root: \"all\" for cross-root search."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct OutcomeProgress {
@@ -22,9 +22,9 @@ pub struct OutcomeProgress {
 }
 
 // ── Unified search tool ─────────────────────────────────────────────
-// Combines the functionality of the former `search_symbols` (flat search)
-// and `graph_query` (graph traversal) into a single tool. The old tools
-// are kept as deprecated aliases that route here.
+// Unified search tool combining flat symbol search and graph traversal.
+// Deprecated aliases (`search_symbols`, `graph_query`) are kept below
+// and route here.
 
 #[macros::mcp_tool(
     name = "search",
@@ -169,7 +169,7 @@ impl SearchSymbols {
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct GraphQuery {
-    /// Stable ID from search_symbols results. Takes precedence over query if both provided.
+    /// Stable ID from search results. Takes precedence over query if both provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub node_id: Option<String>,
     /// Natural language query to find entry nodes via semantic search (e.g. "authentication handler", "database connection pool"). Used when node_id is not provided.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -657,9 +657,9 @@ const MCP_GUIDANCE_BLOCK: &str = r#"
 
 | Instead of... | Use this MCP tool |
 |---|---|
-| `Grep` for symbol names | `search_symbols(query, kind, language, file)` |
-| `Read` to trace function calls | `graph_query(node_id, mode: "neighbors")` |
-| `Grep` for "who calls X" | `graph_query(node_id, mode: "impact")` |
+| `Grep` for symbol names | `search(query, kind, language, file)` |
+| `Read` to trace function calls | `search(node: "<id>", mode: "neighbors")` |
+| `Grep` for "who calls X" | `search(node: "<id>", mode: "impact")` |
 | `Read` to find .oh/ artifacts | `search(query, include_artifacts=true)` |
 | `Bash` with `grep -rn` | `search(query)` — searches code, artifacts, and markdown |
 | Recording learnings/signals | Write to `.oh/metis/`, `.oh/signals/`, `.oh/guardrails/` (YAML frontmatter + markdown) |

--- a/src/types.rs
+++ b/src/types.rs
@@ -353,7 +353,7 @@ impl QueryResult {
             }
 
             out.push_str(
-                "Use `search_symbols` to explore further, `graph_query` with any ID above for impact/neighbors\n\n",
+                "Use `search` to explore further, `search(node: \"<id>\", mode: \"neighbors\")` with any ID above for impact/neighbors\n\n",
             );
         }
 


### PR DESCRIPTION
## Summary
Update response footers, tool descriptions, CLAUDE.md template, business context banner, and doc comments to reference the current `search` tool instead of deprecated `search_symbols`, `graph_query`, and `oh_search_context` aliases.

Closes #217

## Problem
User-facing text in `outcome_progress` response footers, tool descriptions, and the CLAUDE.md template still reference deprecated tool names. This misleads agents into calling deprecated aliases instead of the primary `search` tool.

## Solution
**Selected:** Direct string replacement in 8 source files
**Level:** band-aid (trivial correctness fix)

Changes:
- `src/types.rs`: Response footer now says `search` and `search(node: "<id>", mode: "neighbors")`
- `src/server/tools.rs`: `outcome_progress` description references `search`, internal comments updated
- `src/setup.rs`: CLAUDE.md template guidance table uses `search` with correct parameters
- `src/server/mod.rs`: Business context banner uses `search` with mode parameter syntax
- `src/ranking.rs`, `src/server/handlers.rs`, `src/extract/string_literals.rs`, `src/graph/index.rs`: Doc comments updated

Note: Deprecated alias struct names, match arms, function names, and test names are intentionally kept -- they implement the backward-compatible routing layer.

## Acceptance Criteria
- [x] `outcome_progress` response footer uses `search` instead of deprecated names
- [x] `outcome_progress` tool description references `search`
- [x] `setup.rs` CLAUDE.md template uses `search` with appropriate parameters
- [x] All tests pass (`cargo test`)
- [x] `cargo clippy` clean (no new warnings)

## Test Plan
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [x] Verified no remaining deprecated name references in user-facing response strings

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal guidance and code comments throughout the system to reflect unified search patterns and provide clearer guidance on code exploration and traversal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->