### PR TITLE
docs: list valid kind filter values in search tool description

### DIFF
--- a/src/server/tools.rs
+++ b/src/server/tools.rs
@@ -79,7 +79,7 @@ pub struct Search {
     /// Filter edge types: calls, depends_on, implements, defines, etc. Only used with mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub edge_types: Option<Vec<String>>,
-    /// Filter by symbol kind (function, struct, trait, enum, module, import, etc.)
+    /// Filter by symbol kind. Valid values: function, struct, trait, enum, type_alias, module, import, const, impl, proto_message, sql_table, api_endpoint, macro, enum_variant, field, pr_merge
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     /// Filter by language (rust, python, typescript, go, markdown)
@@ -124,7 +124,7 @@ pub struct Search {
 pub struct SearchSymbols {
     /// Search query string (matched against symbol name and signature)
     pub query: String,
-    /// Optional: filter by symbol kind (function, struct, trait, enum, module, import, etc.)
+    /// Optional: filter by symbol kind. Valid values: function, struct, trait, enum, type_alias, module, import, const, impl, proto_message, sql_table, api_endpoint, macro, enum_variant, field, pr_merge
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     /// Optional: filter by language (rust, python, typescript, go, markdown)


### PR DESCRIPTION
## Summary

Lists all 16 valid `kind` filter values in the `search` and `search_symbols` tool descriptions so agents can discover them without trial and error.

Closes #218

## Problem

Agents using the `search` tool's `kind` filter had to guess values. The description said `(function, struct, trait, enum, module, import, etc.)` -- the "etc." hid most values (e.g., `enum_variant`, `type_alias`, `proto_message`). Each wrong guess wastes tokens.

## Solution

**Selected:** Option A -- List valid kinds in the tool description (zero runtime cost, always visible)

Updated the `kind` field doc comments on both `Search` and `SearchSymbols` structs to enumerate all values from `NodeKind::Display`: `function, struct, trait, enum, type_alias, module, import, const, impl, proto_message, sql_table, api_endpoint, macro, enum_variant, field, pr_merge`

## Acceptance Criteria

- [x] The `search` tool description lists all valid `kind` values from `NodeKind::Display`
- [x] The deprecated `search_symbols` tool description also lists all valid values
- [x] The listed values exactly match what `NodeKind::Display` produces
- [ ] Builds and tests pass (CI)

## Test Plan

- [ ] CI build passes (doc-comment-only change, no logic affected)
- [ ] Verify the generated MCP tool schema includes the enumerated values in the `kind` field description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified API documentation by explicitly listing valid values for configuration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->