### PR TITLE
ci: build optimized release artifacts on merge to main

### DIFF
--- a/.github/workflows/rust-main-merge.yml
+++ b/.github/workflows/rust-main-merge.yml
@@ -121,3 +121,71 @@ jobs:
 
       - name: MCP stdio smoke test
         run: node .github/scripts/mcp-smoke.mjs ./target/release/repo-native-alignment .
+
+  build-release:
+    if: github.event_name == 'push'
+    needs: [test, smoke]
+    strategy:
+      matrix:
+        include:
+          - os: namespace-profile-tahoe
+            target: aarch64-apple-darwin
+            features: ""
+            artifact: repo-native-alignment-darwin-arm64
+            rustflags: "-C target-cpu=apple-m1 -C link-arg=-Wl,-dead_strip"
+          - os: namespace-profile-tahoe
+            target: aarch64-apple-darwin
+            features: ""
+            artifact: repo-native-alignment-darwin-arm64-fast
+            rustflags: "-C target-cpu=apple-m4 -C link-arg=-Wl,-dead_strip"
+          - os: namespace-profile-cached
+            target: x86_64-unknown-linux-gnu
+            features: "--no-default-features"
+            artifact: repo-native-alignment-linux-x86_64
+            rustflags: ""
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Configure Namespace sccache cache
+        run: nsc cache sccache setup --cache_name default >> "$GITHUB_ENV"
+
+      - name: Cache Rust
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: rust
+
+      - name: Build optimized release binary
+        run: cargo build --release --target ${{ matrix.target }} ${{ matrix.features }}
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+          RUSTC_WRAPPER: sccache
+
+      - name: Strip and compress binary
+        run: |
+          strip target/${{ matrix.target }}/release/repo-native-alignment
+          tar czf ${{ matrix.artifact }}.tar.gz -C target/${{ matrix.target }}/release repo-native-alignment
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.tar.gz
+          retention-days: 30


### PR DESCRIPTION
## Summary
- Adds `build-release` job to `rust-main-merge.yml` that runs on push to main (after merge)
- Builds all 3 platform targets (M1, M4, Linux x86_64) with same optimization flags as `release.yml`
- Strips and compresses binaries, uploads as artifacts with 30-day retention
- Only runs after test + smoke jobs pass

## Why
Currently optimized binaries only exist when a `v*` tag is pushed. Every merge to main should produce installable artifacts so we can test with the latest code immediately.

## Test plan
- [ ] Verify workflow syntax is valid (GitHub Actions linter)
- [ ] Merge a PR and confirm 3 artifacts appear on the workflow run
- [ ] Download and verify binary runs `--version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->