### PR TITLE
fix: add TypeAlias to parse_node_kind for LanceDB round-trip

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2574,9 +2574,10 @@ mod tests {
     fn test_parse_node_kind_all_variants_round_trip() {
         let variants = vec![
             NodeKind::Function, NodeKind::Struct, NodeKind::Trait,
-            NodeKind::Enum, NodeKind::Module, NodeKind::Import,
-            NodeKind::Const, NodeKind::Impl, NodeKind::ProtoMessage,
-            NodeKind::SqlTable, NodeKind::ApiEndpoint, NodeKind::Macro,
+            NodeKind::Enum, NodeKind::TypeAlias, NodeKind::Module,
+            NodeKind::Import, NodeKind::Const, NodeKind::Impl,
+            NodeKind::ProtoMessage, NodeKind::SqlTable,
+            NodeKind::ApiEndpoint, NodeKind::Macro,
             NodeKind::Field, NodeKind::PrMerge,
         ];
         for variant in variants {

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -117,6 +117,7 @@ pub(crate) fn parse_node_kind(s: &str) -> NodeKind {
         "proto_message" => NodeKind::ProtoMessage,
         "sql_table" => NodeKind::SqlTable,
         "api_endpoint" => NodeKind::ApiEndpoint,
+        "type_alias" => NodeKind::TypeAlias,
         "macro" => NodeKind::Macro,
         "field" => NodeKind::Field,
         "pr_merge" => NodeKind::PrMerge,


### PR DESCRIPTION
## Summary
Add missing `"type_alias" => NodeKind::TypeAlias` case to `parse_node_kind()` so TypeAlias nodes survive the LanceDB persistence round-trip.

Closes #207

## Problem
PR #175 added `TypeAlias` as a first-class `NodeKind` with correct tree-sitter extraction, Display impl, and `is_embeddable()` support. However, `parse_node_kind()` in `store.rs` was never updated to parse `"type_alias"` back into `NodeKind::TypeAlias`. When nodes are loaded from LanceDB, TypeAlias nodes fall through to `NodeKind::Other("type_alias")`, losing their semantic identity.

## Solution
**Selected:** Add the missing match arm
**Level:** Band-aid (1-line fix + test update)

- Add `"type_alias" => NodeKind::TypeAlias` to `parse_node_kind()` in `src/server/store.rs`
- Add `NodeKind::TypeAlias` to the `test_parse_node_kind_all_variants_round_trip` test that should have caught this

## Acceptance Criteria
- [x] `type Foo = Bar;` declarations in Rust produce `TypeAlias` nodes in the symbol index
- [x] `search(kind: "type_alias")` returns results when type aliases exist
- [x] Existing tests pass; round-trip test now covers TypeAlias

## Test Plan
- [x] `cargo test type_alias` -- all 9 type_alias tests pass
- [x] `cargo test test_parse_node_kind` -- round-trip test now includes TypeAlias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to include additional node type variants.

* **Chores**
  * Added support for parsing additional node kind mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->