### PR TITLE
chore: add dogfood-rna-tools guardrail, fix stale refs

### DIFF
--- a/.claude/agents/dev-pipeline.md
+++ b/.claude/agents/dev-pipeline.md
@@ -12,7 +12,7 @@ Full development pipeline: **problem-statement → solution-space → execute �
 
 Takes a feature or bug from framing through merge. Each phase feeds the next via a session file. The pipeline ensures nothing is skipped — no coding without a problem statement, no merging without the /ship quality gate.
 
-> **You are an RNA power user.** Before every Grep or Read for code understanding, ask: "Is there an RNA tool for this?" Check the table in `/friction` (`.claude/skills/friction.md`). Use `search`, `search_symbols`, `graph_query`, and `outcome_progress` as your FIRST choice for code navigation, guardrail checks, outcome alignment, and context gathering. **Every Grep/Read you use instead of an RNA tool is a friction event — log it with severity `skipped`.** When an RNA tool fails, log that too. See `/friction` for the full protocol. A pipeline with 0 friction events and 30 Grep calls isn't frictionless — it's unmonitored.
+> **Friction logging:** When an RNA tool falls short or you fall back to Grep/Read, append to the session file's `## RNA Tool Friction Log` table. See guardrail: `dogfood-rna-tools`.
 
 > **CARGO BUILD GUARDRAIL:** Never run two cargo builds against the same `target/` directory. Each pipeline gets its own worktree with its own `CARGO_TARGET_DIR` (see Phase 3 worktree setup). Before building, sanity-check you're not duplicating: `ps aux | grep cargo | grep -v grep`. A second cargo process targeting the same directory blocks silently on the file lock, hanging indefinitely. See `.oh/guardrails/no-parallel-cargo-agents.md`.
 
@@ -195,7 +195,7 @@ After execution completes:
 > **CRITICAL: You MUST spawn the ship agent. Do NOT inline the ship steps yourself.**
 > The ship agent posts each step's findings as PR comments — review, dissent, adversarial test results, merit assessment, etc. These comments are the auditable quality record. If you simulate the ship steps in your own context instead of spawning the agent, the findings exist only in the session file and are invisible on the PR. This is a process failure — a quality gate that isn't visible is no gate at all.
 >
-> See `.oh/metis/ship-steps-must-be-visible.md` for the full learning.
+> See guardrail: `ship-steps-visible-on-pr`.
 
 Spawn the **`ship` agent** using the **Agent tool** with the PR number:
 
@@ -238,13 +238,11 @@ The ship agent runs autonomously — do not wait for user prompts between steps.
   - Phase 4 produces ABANDON/RECONSIDER verdict or CI fails after 2 fix attempts
 - **Record metis** if any phase surfaces a new learning: write to `.oh/metis/<slug>.md`
 
-## RNA Tool Usage & Friction Reporting
+## Friction Reporting
 
-**Use RNA MCP tools as your primary codebase interface.** See the `/friction` skill (`.claude/skills/friction.md`) for the full tool reference table and logging format.
+When an RNA tool falls short — wrong results, missing data, too slow, or you fell back to Grep/Read — append to the session file's `## RNA Tool Friction Log` table.
 
-When an RNA tool falls short — wrong results, missing data, awkward API, too slow, or you fell back to Grep/Read — log friction per `/friction`: append to the session file's `## RNA Tool Friction Log` table.
-
-**At pipeline end**, run `/friction summary` to produce a friction summary with recommendations (file issue, update existing issue, or note as known limitation).
+**At pipeline end**, summarize friction events with recommendations (file issue, update existing issue, or note as known limitation).
 
 ## Position in Framework
 

--- a/.oh/guardrails/dogfood-rna-tools.md
+++ b/.oh/guardrails/dogfood-rna-tools.md
@@ -1,0 +1,24 @@
+---
+id: dogfood-rna-tools
+outcome: context-assembly
+severity: hard
+statement: This project IS the RNA MCP server. Use its own tools for code exploration, not Grep/Read/Bash. Every fallback is a friction event that must be logged.
+---
+
+## Rationale
+
+If the tools aren't good enough for the project that builds them, they aren't good enough for anyone. Dogfooding surfaces friction that tests and benchmarks miss — real usage in real workflows.
+
+## What this means
+
+- Use RNA MCP tools as the primary interface for code navigation, artifact search, and context gathering
+- When RNA tools fall short, **log the friction** in the session's friction log table with severity
+- A session with 0 logged friction events and many Grep/Read calls is unmonitored, not frictionless
+
+## Override Protocol
+
+Grep/Read are acceptable for targeted file edits (after RNA has oriented you), files not in the scan path, or when the index is genuinely down (say so explicitly).
+
+## Evidence
+
+Multiple sessions where agents defaulted to Grep/Read despite RNA tools being available. The friction was invisible until explicitly tracked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ No step is optional. "Merge when green" is not ship. Steps answer different ques
 - Merit assessment: "Does this deliver outcome value?"
 - Resolve TODOs: "Is everything accounted for?"
 - Manual verification: "Does the computation work with real data?"
-- **Delivery verification: "Can an agent actually see this through MCP tools?"** *(added after PR #137 — see `.oh/metis/computed-but-not-delivered.md`)*
+- **Delivery verification: "Can an agent actually see this through MCP tools?"** *(see guardrail: computed-but-not-delivered)*
 
 **Key insight:** Enter at the altitude you need. Climb back up when you drift.
 
@@ -48,31 +48,30 @@ No step is optional. "Merge when green" is not ship. Steps answer different ques
 
 This project IS the RNA MCP server. When working here, use its own tools.
 
-**IMPORTANT: Use MCP tools for code exploration, NOT grep/Read/Bash.**
+**IMPORTANT: Use RNA MCP tools for code exploration, NOT Grep/Read/Bash. This project IS the RNA MCP server — dogfood it.**
 
-| Instead of... | Use this MCP tool |
+| Instead of... | Use RNA MCP |
 |---|---|
-| `Grep` for symbol names | `search_symbols(query, kind, language, file)` |
-| `Read` to trace function calls | `graph_query(node_id, mode: "neighbors")` |
-| `Grep` for "who calls X" | `graph_query(node_id, mode: "impact")` |
+| `Grep` for symbol names | `search(query, kind, language, file)` |
+| `Read` to trace function calls | `search(node, mode: "neighbors")` |
+| `Grep` for "who calls X" | `search(node, mode: "impact")` |
 | `Read` to find .oh/ artifacts | `search(query, include_artifacts=true)` |
 | `Bash` with `grep -rn` | `search(query)` — searches code, artifacts, and markdown |
 | Recording learnings/signals | Write to `.oh/metis/`, `.oh/signals/`, `.oh/guardrails/` (YAML frontmatter + markdown) |
 | Searching git history | `search(query)` — returns commits; use `git show <hash>` via Bash for diffs |
 
 **If RNA returns empty results — diagnose before falling back:**
-- Empty `search` means the symbol isn't indexed OR the query is wrong — try a broader query, different `kind`, or no filters first
-- Empty artifact results means the embedding index hasn't built yet OR the query is too specific — try simpler terms
-- Do NOT silently fall back to Grep/Read on empty RNA results — that defeats the purpose
+- Try a broader query, different `kind`, or no filters first
+- Do NOT silently fall back to Grep/Read — that defeats the purpose
 - If the index is genuinely stale, say so explicitly rather than substituting file reads
 
-**6 MCP Tools (read + query only):**
+**Every Grep/Read used instead of an RNA tool is a friction event.** Log it in the session's friction log table. A session with 0 friction events and 30 Grep calls isn't frictionless — it's unmonitored.
+
+**MCP Tools:**
 1. `search` -- all-in-one: code symbols, .oh/ artifacts, commits, markdown, and graph traversal
-2. `outcome_progress` -- structural join for outcome tracking (with optional `include_impact: true` for risk-classified blast radius)
-3. `search_symbols` -- DEPRECATED alias for `search` (flat mode)
-4. `graph_query` -- DEPRECATED alias for `search` (with mode)
-5. `list_roots` -- workspace root management
-6. `repo_map` -- repository orientation (top symbols, hotspots, outcomes, entry points)
+2. `outcome_progress` -- structural join for outcome tracking
+3. `list_roots` -- workspace root management
+4. `repo_map` -- repository orientation (top symbols, hotspots, outcomes, entry points)
 
 **Writing business artifacts:** Write directly to `.oh/` using the Write tool. See `.oh/metis/`, `.oh/signals/`, `.oh/guardrails/` for frontmatter templates.
 
@@ -105,6 +104,7 @@ MCP server with a workspace-wide context engine. Incrementally scans repos, extr
 - **no-language-conditionals-in-generic**: All per-language behavior goes through LangConfig, never `if language ==` in generic.rs. [Details](.oh/guardrails/no-language-conditionals-in-generic.md)
 - **no-parallel-cargo-agents**: One cargo build per target directory; use worktrees for parallel builds. [Details](.oh/guardrails/no-parallel-cargo-agents.md)
 - **computed-but-not-delivered**: New metadata must wire through 3 layers — extraction, LanceDB schema, MCP rendering. [Details](.oh/guardrails/computed-but-not-delivered.md)
+- **dogfood-rna-tools**: Use RNA's own tools for code exploration; every Grep/Read fallback is a friction event to log. [Details](.oh/guardrails/dogfood-rna-tools.md)
 
 ### Soft guardrails
 - **extractors-are-pluggable**: Don't hardcode extraction strategy per file type. [Details](.oh/guardrails/extractors-are-pluggable.md)
@@ -139,11 +139,11 @@ MCP server with a workspace-wide context engine. Incrementally scans repos, extr
 Solo developer. PRs go through the full /ship pipeline (12 steps). "Done" = all TODOs resolved, manually verified with real data, tests pass, MCP client connects. Session learnings recorded as metis via MCP tools.
 
 ## Key Modules
+- `src/service.rs` — shared service layer (CLI and MCP both delegate here — no capability drift)
 - `src/graph/` — unified graph model (types, LanceDB schemas, petgraph index)
 - `src/scanner.rs` — incremental file scanner (mtime + git + configurable excludes)
 - `src/extract/` — pluggable extractors (Extractor trait + Enricher trait)
-- `src/extract/{rust,python,typescript,go,markdown}.rs` — language-specific extractors
-- `src/server.rs` — MCP server (9 intent-based tools)
+- `src/server/` — MCP server (thin adapters to service layer)
 - `src/embed.rs` — semantic search (fastembed + LanceDB)
 - `src/query.rs` — outcome_progress structural joins
 


### PR DESCRIPTION
## Summary

- Add hard guardrail `dogfood-rna-tools`: use RNA's own tools, log friction on fallback
- Fix stale deprecated tool names in AGENTS.md (search_symbols, graph_query → search)
- Fix stale metis reference in dev-pipeline.md (deleted file → guardrail)
- Add service layer to Key Modules
- Trim dev-pipeline.md — AGENTS.md is the authority for RNA tool guidance

## Test plan

- [ ] AGENTS.md has no references to search_symbols or graph_query as separate tools
- [ ] dev-pipeline.md references guardrails not deleted metis files
- [ ] dogfood-rna-tools.md exists with hard severity

🤖 Generated with [Claude Code](https://claude.com/claude-code)