### PR TITLE
fix: remove dead artifacts.lance embedding path

### DIFF
--- a/src/embed.rs
+++ b/src/embed.rs
@@ -327,7 +327,7 @@ impl SearchResult {
 impl EmbeddingIndex {
     /// Create or open the embedding index. Stores data in memory.
     pub async fn new(repo_root: &Path) -> Result<Self> {
-        let db_path = repo_root.join(".oh").join(".cache").join("embeddings");
+        let db_path = repo_root.join(".oh").join(".cache").join("lance");
         std::fs::create_dir_all(&db_path)?;
         tracing::debug!("EmbeddingIndex: opening LanceDB at {}", db_path.display());
         let open_start = std::time::Instant::now();

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1,8 +1,8 @@
 //! LanceDB table schemas for the graph model.
 //!
 //! Defines Arrow schemas for the `symbols`, `edges`, and `file_index` tables.
-//! These are additive — the existing `EmbeddingIndex` in `embed.rs` continues
-//! to handle `.oh/` artifact embeddings.
+//! The `EmbeddingIndex` in `embed.rs` shares this same LanceDB directory,
+//! storing its `artifacts` table alongside `symbols`, `edges`, etc.
 
 use std::sync::Arc;
 


### PR DESCRIPTION
## Summary
Move EmbeddingIndex from separate `.oh/.cache/embeddings/` directory to the unified `.oh/.cache/lance/` directory, eliminating the redundant 13MB artifacts.lance store.

Closes #263

## Problem
PR #248 (#246) unified artifact embedding into graph nodes, but the `EmbeddingIndex` still opened a separate LanceDB at `.oh/.cache/embeddings/`, creating `artifacts.lance` there. Two LanceDB directories existed when only one should.

## Solution
**Selected:** Change DB path in `EmbeddingIndex::new()`
**Level:** band-aid (dead code path removal)

One-line fix: change the DB path from `.oh/.cache/embeddings/` to `.oh/.cache/lance/`. The `artifacts` table now lives alongside `symbols`, `edges`, and other tables in the unified directory. Also updated a stale comment in `graph/store.rs`.

## Acceptance Criteria
- [x] No code path creates `.oh/.cache/embeddings/artifacts.lance`
- [x] The unified path `.oh/.cache/lance/` is the sole LanceDB location
- [x] `cargo test` passes (766 tests, 0 failures)
- [x] Tagged with [outcome:context-assembly]

## Test Plan
- [x] `cargo build` succeeds
- [x] `cargo test` passes (766/766)
- [x] Grep confirms no remaining references to `.oh/.cache/embeddings/` in source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the internal storage directory for embedding index data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->