### PR TITLE
fix: add .fastembed_cache/ to scanner excludes + confirm CLI/MCP parity

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -32,6 +32,7 @@ pub const DEFAULT_EXCLUDES: &[&str] = &[
     "vendor/",
     ".build/",
     ".cache/",
+    ".fastembed_cache/",
     "*.pyc",
     "*.o",
     "*.so",
@@ -1131,6 +1132,8 @@ mod tests {
     fn test_dir_excluded() {
         assert!(is_dir_excluded("node_modules/", "node_modules"));
         assert!(is_dir_excluded("target/", "some/target"));
+        assert!(is_dir_excluded(".fastembed_cache/", ".fastembed_cache"));
+        assert!(is_dir_excluded(".cache/", ".oh/.cache"));
         assert!(!is_dir_excluded("target/", "src"));
         assert!(!is_dir_excluded("*.pyc", "some_dir"));
     }
@@ -1355,27 +1358,27 @@ mod tests {
     }
 
     #[test]
-    fn test_project_config_applies_to_custom_excludes() {
+    fn test_fastembed_cache_excluded_by_default() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
 
         create_file(root, "src/main.rs", "fn main() {}\n");
         create_file(root, ".fastembed_cache/model.onnx", "model bytes");
+        create_file(root, ".fastembed_cache/tokenizer.json", "{}");
         fs::create_dir_all(root.join(".oh/.cache")).unwrap();
-        fs::write(
-            root.join(".oh/config.toml"),
-            "[scanner]\nexclude = [\".fastembed_cache/\"]\n",
-        )
-        .unwrap();
 
-        let excludes = DEFAULT_EXCLUDES.iter().map(|s| s.to_string()).collect();
-        let mut scanner = Scanner::with_excludes(root.to_path_buf(), excludes).unwrap();
+        let mut scanner = Scanner::new(root.to_path_buf()).unwrap();
         let result = scanner.scan().unwrap();
 
         let all: Vec<_> = result.files_to_extract().into_iter().cloned().collect();
         assert!(
             !all.contains(&PathBuf::from(".fastembed_cache/model.onnx")),
-            "Config exclude should apply to custom scanners: {:?}",
+            ".fastembed_cache should be excluded by default: {:?}",
+            all
+        );
+        assert!(
+            !all.contains(&PathBuf::from(".fastembed_cache/tokenizer.json")),
+            ".fastembed_cache subdirs should be excluded by default: {:?}",
             all
         );
         assert!(all.contains(&PathBuf::from("src/main.rs")));


### PR DESCRIPTION
## Summary

Add `.fastembed_cache/` to `DEFAULT_EXCLUDES` so model blobs stop being indexed as source code. Audit and confirm CLI/MCP search parameter parity (no drift).

Closes #265
Closes #266

## Problem

**#266:** The scanner indexes `.fastembed_cache/` model files (ONNX blobs, tokenizer files, lock files) as source code. ~493 file reads attempted, most fail with "stream did not contain valid UTF-8". This pollutes the graph with garbage nodes and wastes scan time.

**#265:** The `rerank` parameter was added to MCP `search` but allegedly not to CLI `SearchArgs`. Investigation shows `--rerank` is already present and wired -- no code change needed, but the audit confirms no remaining drift between MCP Search struct fields and CLI SearchArgs.

## Solution

**Selected:** Add `.fastembed_cache/` to DEFAULT_EXCLUDES (band-aid level)

- Added `.fastembed_cache/` to `DEFAULT_EXCLUDES` in `src/scanner.rs`
- `.oh/.cache/` is already excluded by the existing `.cache/` pattern (matches any path component)
- Updated test from config-based `.fastembed_cache` exclusion to default-based exclusion test
- Added `.fastembed_cache/` and `.oh/.cache` assertions to `test_dir_excluded`
- Full audit of MCP `Search` struct vs CLI `SearchArgs`: all 18 parameters present in both interfaces

## Acceptance Criteria

- [x] `.fastembed_cache/` in DEFAULT_EXCLUDES
- [x] Scanner test validates .fastembed_cache exclusion as default behavior
- [x] No CLI/MCP search parameter drift
- [x] `cargo test` passes (799 passed, 0 failed)

## Test Plan

- [x] `cargo test --lib scanner` -- all 38 scanner tests pass
- [x] `cargo test` -- all 799 tests pass
- [ ] CI green

[outcome:context-assembly]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated scanner default exclusion patterns to include additional cache directory coverage, expanding the default set of excluded files and directories during scanning operations.

* **Tests**
  * Test suite updated to verify that new default exclusion patterns are correctly applied and validated during scanner operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->