### PR TITLE
fix: LSP enrichment produces 0 edges (issue #293)

### DIFF
--- a/src/extract/lsp.rs
+++ b/src/extract/lsp.rs
@@ -2431,6 +2431,30 @@ mod tests {
         });
         assert!(!LspEnricher::server_status_is_ready(&no_quiescent),
             "missing quiescent should default to false (not ready)");
+
+        // Adversarial: completely empty params should not be ready
+        let empty_params = serde_json::json!({
+            "method": "experimental/serverStatus",
+            "params": {}
+        });
+        assert!(!LspEnricher::server_status_is_ready(&empty_params),
+            "empty params should not be ready");
+
+        // Adversarial: missing params entirely should not be ready
+        let no_params = serde_json::json!({
+            "method": "experimental/serverStatus"
+        });
+        assert!(!LspEnricher::server_status_is_ready(&no_params),
+            "missing params should not be ready");
+
+        // Adversarial: quiescent as string "true" should not be ready
+        // (must be boolean true, not string)
+        let string_quiescent = serde_json::json!({
+            "method": "experimental/serverStatus",
+            "params": { "health": "ok", "quiescent": "true" }
+        });
+        assert!(!LspEnricher::server_status_is_ready(&string_quiescent),
+            "quiescent as string 'true' should not be ready (must be bool)");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fix LSP enrichment producing 0 call edges by declaring `serverStatusNotification` client capability and increasing request timeout.

Closes #293

## Problem
LSP enrichment produced 0 edges on all repos. rust-analyzer started but all call hierarchy and reference queries returned empty or timed out.

## Root Cause
Two bugs working together:

1. **Missing client capability**: The LSP client did not declare `experimental.serverStatusNotification` in `ClientCapabilities`. Rust-analyzer checks for this capability before sending `experimental/serverStatus` notifications. Without it, the readiness wait loop never received serverStatus, and the 5-second fallback fired while rust-analyzer was still indexing.

2. **5-second request timeout**: The `PipelinedTransport` had a hardcoded 5s timeout per request. When queries arrived while the server was still indexing, rust-analyzer returned `content modified` errors or requests timed out entirely.

## Solution
**Selected:** Local optimum (Option B from solution space)

- Declare `experimental: { serverStatusNotification: true }` in init params
- Increase `PipelinedTransport` request timeout from 5s to 30s
- Track `seen_server_status` to properly wait for `quiescent: true`
- Increase overall readiness deadline from 60s to 120s
- Default missing `quiescent` field to false (conservative)
- Add unit test for capability declaration
- Add integration test (`#[ignore]`): verify >100 LSP edges on RNA repo

## Verification
Before fix: `0 edges from 5233 nodes`
After fix: `16,452 edges from 10,478 nodes (0 errors)`

## Acceptance Criteria
- [x] LSP enrichment produces >0 call edges on the RNA repo
- [x] Enricher properly waits for rust-analyzer serverStatus (quiescent: true)
- [x] PipelinedTransport timeout sufficient for normal queries (30s)
- [x] No regression on enrichment behavior
- [x] Reasonable timeout (120s deadline, doesn't hang forever)
- [x] Integration test added (run with `cargo test -- --ignored test_lsp_enrichment_produces_edges`)

## Test Plan
- [x] `cargo check --tests` passes
- [x] `scan --full` on RNA repo produces 16,452 edges (verified locally)
- [x] Unit test: `test_init_params_declare_server_status_notification` passes
- [ ] CI smoke tests pass
- [ ] CodeRabbit review addressed

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended Language Server Protocol timeouts (5s → 30s) for more stable server communication
  * Increased server readiness deadline (60s → 120s) for better initialization handling
  * Enhanced language server status notifications with improved logging and resilience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->