### PR TITLE
fix: always build M4 release artifact on push to main

### DIFF
--- a/.github/workflows/rust-main-merge.yml
+++ b/.github/workflows/rust-main-merge.yml
@@ -172,8 +172,7 @@ jobs:
   # M4-optimized build runs first (this is what developers install).
   # Warms sccache for the M1 baseline build that follows.
   build-release-fast:
-    needs: changes
-    if: needs.changes.outputs.rust == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: namespace-profile-tahoe
     timeout-minutes: 60
 


### PR DESCRIPTION
## Summary
Remove paths-filter gate from `build-release-fast` job. This artifact is the install binary — it should build on every push to main.

The paths-filter from #297 was correct for `lint`, `test`, and `smoke` (skip for version-bump PRs) but wrong for the release build.

## Test Plan
- [ ] Merge this PR, verify build-release-fast runs on the merge commit