### PR TITLE
fix: suppress lance library log noise during scan

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,9 +69,16 @@ fn server_details() -> InitializeResult {
             icons: vec![], title: Some("Repo-Native Alignment".into()), website_url: None } }
 }
 
+/// Baseline directives that suppress noisy library internals.
+/// These are prepended to whatever default_filter the caller provides,
+/// so caller-level directives (e.g. `info`) win for RNA's own crate while
+/// lance internals stay at WARN unless RUST_LOG explicitly overrides.
+const LIBRARY_NOISE_FILTER: &str = "lance=warn,lance_index=warn,lance_file=warn,lancedb=warn";
+
 fn init_tracing(default_filter: &str, log_path: Option<&std::path::Path>) {
     use tracing_subscriber::prelude::*;
-    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| default_filter.into());
+    let composite_default = format!("{},{}", LIBRARY_NOISE_FILTER, default_filter);
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| composite_default.into());
     let effective_log_path = log_path.map(|p| p.to_path_buf()).or_else(|| std::env::var("RNA_LOG_FILE").ok().map(PathBuf::from));
     if let Some(ref file_path) = effective_log_path {
         if let Some(parent) = file_path.parent() { let _ = std::fs::create_dir_all(parent); }


### PR DESCRIPTION
## Summary

- Add `LIBRARY_NOISE_FILTER` constant that sets `lance=warn,lance_index=warn,lance_file=warn,lancedb=warn`
- Prepend these directives to the default filter in `init_tracing()`, so all commands automatically suppress lance internal logs
- RNA's own crate continues to log at the caller-specified level (INFO for scan, WARN for search/stdio, etc.)
- `RUST_LOG` env var still overrides everything for debugging

## Test plan

- [x] `cargo check` passes with no warnings
- [ ] Run `rna scan --path .` and verify lance partition merge / FTS index build messages no longer appear at INFO
- [ ] Set `RUST_LOG=lance=debug` and verify lance messages reappear (override works)

Closes #305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logging configuration to suppress excessive noise from library internals. The logging system now automatically filters out noisy library messages by default, providing users with significantly cleaner and more focused output. This makes it easier to identify important information when debugging issues, allowing for more efficient troubleshooting without information overload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->