### PR TITLE
fix: address review findings from #313

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1441,7 +1441,11 @@ pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
                                     .rev()
                                     .nth(1)
                                     .unwrap_or(&iface.node_id);
-                                format!("{}()", short_name)
+                                if iface.node_type == "function" {
+                                    format!("{}()", short_name)
+                                } else {
+                                    short_name.to_string()
+                                }
                             })
                             .collect();
                         format!("\n  Interfaces: {}", iface_list.join(", "))


### PR DESCRIPTION
## Summary

- Fixes CodeRabbit nitpick from #313: interface display now conditionally appends `()` only for function-type interfaces, not structs/traits/other types

## Finding addressed

From CodeRabbit review on #313 (lines 1436-1448 of `src/service.rs`):
> The formatting appends `()` to all interface names, which implies they're functions. However, `SubsystemInterface` has a `node_type` field that could be "struct" or other types.

## Test plan

- [x] `cargo check --lib` passes
- [x] All 848 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed interface formatting in the repository map to correctly distinguish between interface types. Function-type interfaces now display with parentheses, while other interface types display without parentheses for accurate representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->