### PR TITLE
fix: preserve LSP edges across incremental rebuilds, improve subsystem detection

### DIFF
--- a/src/graph/index.rs
+++ b/src/graph/index.rs
@@ -433,10 +433,13 @@ impl GraphIndex {
     ) -> Vec<Subsystem> {
         // Step 1: Build coupling subgraph as an undirected adjacency list.
         // We work with NodeIndex values directly for performance.
+        // Edge selection: only edges that represent actual coupling between
+        // symbols. DependsOn (imports) is excluded because it creates trivially
+        // large clusters -- every file that imports a common type ends up in one
+        // giant community. Calls and Implements are the strongest coupling signals.
         let coupling_kinds = [
             EdgeKind::Calls,
             EdgeKind::Implements,
-            EdgeKind::DependsOn,
             EdgeKind::ReferencedBy,
             EdgeKind::References,
             EdgeKind::ConnectsTo,
@@ -469,6 +472,15 @@ impl GraphIndex {
         }
 
         if total_weight == 0.0 {
+            return Vec::new();
+        }
+
+        // Guard: require a minimum density of coupling edges relative to node
+        // count. Without enough edges (e.g., no LSP data), the graph is too
+        // sparse for Louvain to find meaningful communities. We require at
+        // least 5% of nodes to have coupling edges for large graphs.
+        let nodes_with_edges = adj.iter().filter(|nbrs| !nbrs.is_empty()).count();
+        if nodes_with_edges < 3 || (n > 100 && (nodes_with_edges as f64) < (n as f64 * 0.05)) {
             return Vec::new();
         }
 
@@ -546,8 +558,10 @@ impl GraphIndex {
             comm_members.entry(comm).or_default().push(node_idx);
         }
 
-        // Filter out tiny clusters (< 3 members) -- merge into nearest large cluster
-        let min_cluster_size = 3;
+        // Filter out tiny clusters -- merge into nearest large cluster.
+        // Scale threshold: for small graphs 3 is fine, for larger graphs require
+        // at least 5 members per cluster to avoid noise from test helper groups.
+        let min_cluster_size = if n < 50 { 3 } else { 5 };
         let large_comms: HashSet<usize> = comm_members
             .iter()
             .filter(|(_, members)| members.len() >= min_cluster_size)
@@ -1697,5 +1711,79 @@ mod tests {
             &file_map,
         );
         assert_eq!(name, "graph");
+    }
+
+    #[test]
+    fn test_detect_communities_excludes_depends_on() {
+        // DependsOn edges should NOT contribute to community detection.
+        // Two separate groups connected only by DependsOn should not form one community.
+        let mut index = GraphIndex::new();
+
+        // Group A: connected via Calls (real coupling)
+        index.add_edge("a1", "fn", "a2", "fn", EdgeKind::Calls);
+        index.add_edge("a2", "fn", "a1", "fn", EdgeKind::Calls);
+        index.add_edge("a2", "fn", "a3", "fn", EdgeKind::Calls);
+        index.add_edge("a3", "fn", "a2", "fn", EdgeKind::Calls);
+        index.add_edge("a1", "fn", "a3", "fn", EdgeKind::Calls);
+        index.add_edge("a3", "fn", "a1", "fn", EdgeKind::Calls);
+
+        // Group B: connected via Calls (real coupling)
+        index.add_edge("b1", "fn", "b2", "fn", EdgeKind::Calls);
+        index.add_edge("b2", "fn", "b1", "fn", EdgeKind::Calls);
+        index.add_edge("b2", "fn", "b3", "fn", EdgeKind::Calls);
+        index.add_edge("b3", "fn", "b2", "fn", EdgeKind::Calls);
+        index.add_edge("b1", "fn", "b3", "fn", EdgeKind::Calls);
+        index.add_edge("b3", "fn", "b1", "fn", EdgeKind::Calls);
+
+        // Connect A and B ONLY via DependsOn edges (should be ignored for clustering)
+        index.add_edge("a1", "fn", "b1", "module", EdgeKind::DependsOn);
+        index.add_edge("a2", "fn", "b2", "module", EdgeKind::DependsOn);
+
+        let pagerank = index.compute_pagerank(0.85, 20);
+        let file_map = make_file_map(&[
+            ("a1", "src/alpha/mod.rs"),
+            ("a2", "src/alpha/mod.rs"),
+            ("a3", "src/alpha/mod.rs"),
+            ("b1", "src/beta/mod.rs"),
+            ("b2", "src/beta/mod.rs"),
+            ("b3", "src/beta/mod.rs"),
+        ]);
+
+        let subsystems = index.detect_communities(&pagerank, &file_map);
+        // Should detect 2 separate clusters (A and B), not merge them via DependsOn
+        assert!(
+            subsystems.len() >= 2,
+            "Groups connected only by DependsOn edges should remain separate clusters, got {} subsystem(s)",
+            subsystems.len()
+        );
+    }
+
+    #[test]
+    fn test_detect_communities_density_guard() {
+        // A large sparse graph with very few coupling edges should produce no subsystems.
+        // This tests the density guard that prevents garbage results when LSP data
+        // is unavailable.
+        let mut index = GraphIndex::new();
+
+        // Add 200 nodes connected only by Defines edges (no coupling signal)
+        for i in 0..100 {
+            index.add_edge(
+                &format!("struct_{}", i),
+                "struct",
+                &format!("field_{}", i),
+                "field",
+                EdgeKind::Defines,
+            );
+        }
+        // Add just 2 coupling edges (far below 5% of 200 nodes)
+        index.add_edge("struct_0", "struct", "struct_1", "struct", EdgeKind::Calls);
+        index.add_edge("struct_1", "struct", "struct_0", "struct", EdgeKind::Calls);
+
+        let subsystems = index.detect_communities(&HashMap::new(), &HashMap::new());
+        assert!(
+            subsystems.is_empty(),
+            "Sparse graph with minimal coupling edges should produce no subsystems, got {}",
+            subsystems.len()
+        );
     }
 }

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -391,12 +391,42 @@ impl RnaHandler {
                 helpers::resolve_edge_target_by_suffix(edge, &file_index);
             }
 
+            // For dirty roots, carry forward cached LSP edges whose endpoints
+            // still exist in the freshly extracted node set. Tree-sitter re-extraction
+            // only produces tree-sitter edges; LSP edges (Calls, ReferencedBy from LSP)
+            // are produced by the background enricher and would otherwise be lost on
+            // every incremental rebuild.
+            let mut lsp_carry_count = 0usize;
+            if *root_changed && has_cached_graph {
+                if let Some(cached_edges) = cached_edges_by_root.remove(root_slug) {
+                    let node_ids: std::collections::HashSet<String> = extraction.nodes
+                        .iter()
+                        .map(|n| n.stable_id())
+                        .collect();
+                    for edge in cached_edges {
+                        if edge.source == crate::graph::ExtractionSource::Lsp {
+                            let from_id = edge.from.to_stable_id();
+                            let to_id = edge.to.to_stable_id();
+                            if node_ids.contains(&from_id) || node_ids.contains(&to_id) {
+                                extraction.edges.push(edge);
+                                lsp_carry_count += 1;
+                            }
+                        }
+                    }
+                }
+            }
+
             tracing::info!(
-                "Extracted from '{}'{}: {} nodes, {} edges",
+                "Extracted from '{}'{}: {} nodes, {} edges{}",
                 root_slug,
                 if *root_changed { " (dirty)" } else { " (no cache)" },
                 extraction.nodes.len(),
-                extraction.edges.len()
+                extraction.edges.len(),
+                if lsp_carry_count > 0 {
+                    format!(" (carried forward {} LSP edges)", lsp_carry_count)
+                } else {
+                    String::new()
+                }
             );
 
             all_nodes.extend(extraction.nodes);

--- a/src/service.rs
+++ b/src/service.rs
@@ -1422,46 +1422,76 @@ pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
             })
             .collect();
 
-        let subsystems = graph_state.index.detect_communities(&pagerank_scores, &node_file_map);
+        let mut subsystems = graph_state.index.detect_communities(&pagerank_scores, &node_file_map);
         if !subsystems.is_empty() {
-            let md: String = subsystems
-                .iter()
-                .map(|s| {
-                    let interfaces_str = if s.interfaces.is_empty() {
-                        String::new()
-                    } else {
-                        let iface_list: Vec<String> = s
-                            .interfaces
-                            .iter()
-                            .map(|iface| {
-                                // Extract short name from node ID (last colon-separated segment before kind)
-                                let short_name = iface
-                                    .node_id
-                                    .split(':')
-                                    .rev()
-                                    .nth(1)
-                                    .unwrap_or(&iface.node_id);
-                                if iface.node_type == "function" {
-                                    format!("{}()", short_name)
-                                } else {
-                                    short_name.to_string()
-                                }
-                            })
-                            .collect();
-                        format!("\n  Interfaces: {}", iface_list.join(", "))
-                    };
-                    format!(
-                        "- **{}** ({} symbols, cohesion: {:.2}){}",
-                        s.name, s.symbol_count, s.cohesion, interfaces_str
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join("\n");
-            sections.push(format!(
-                "## Subsystems ({} detected)\n\n{}",
-                subsystems.len(),
-                md
-            ));
+            let total_symbols: usize = subsystems.iter().map(|s| s.symbol_count).sum();
+            // Filter out giant clusters that contain >50% of all symbols --
+            // they are not informative (everything is lumped together).
+            subsystems.retain(|s| (s.symbol_count as f64) < (total_symbols as f64 * 0.5));
+
+            // Deduplicate names: when multiple clusters share a name, append
+            // a distinguishing suffix from their top interface function.
+            let mut name_counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+            for s in &subsystems {
+                *name_counts.entry(s.name.clone()).or_default() += 1;
+            }
+            for s in &mut subsystems {
+                if name_counts.get(&s.name).copied().unwrap_or(0) > 1 {
+                    if let Some(iface) = s.interfaces.first() {
+                        let short = iface.node_id.split(':').rev().nth(1).unwrap_or(&iface.node_id);
+                        s.name = format!("{}/{}", s.name, short);
+                    }
+                }
+            }
+
+            // Cap output to top 15 subsystems by symbol count.
+            let shown = subsystems.len().min(15);
+            let total_detected = subsystems.len();
+            subsystems.truncate(shown);
+
+            if !subsystems.is_empty() {
+                let md: String = subsystems
+                    .iter()
+                    .map(|s| {
+                        let interfaces_str = if s.interfaces.is_empty() {
+                            String::new()
+                        } else {
+                            let iface_list: Vec<String> = s
+                                .interfaces
+                                .iter()
+                                .map(|iface| {
+                                    let short_name = iface
+                                        .node_id
+                                        .split(':')
+                                        .rev()
+                                        .nth(1)
+                                        .unwrap_or(&iface.node_id);
+                                    if iface.node_type == "function" {
+                                        format!("{}()", short_name)
+                                    } else {
+                                        short_name.to_string()
+                                    }
+                                })
+                                .collect();
+                            format!("\n  Interfaces: {}", iface_list.join(", "))
+                        };
+                        format!(
+                            "- **{}** ({} symbols, cohesion: {:.2}){}",
+                            s.name, s.symbol_count, s.cohesion, interfaces_str
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let suffix = if total_detected > shown {
+                    format!(" (showing top {})", shown)
+                } else {
+                    String::new()
+                };
+                sections.push(format!(
+                    "## Subsystems ({} detected{})\n\n{}",
+                    total_detected, suffix, md
+                ));
+            }
         }
     }
     { let mut fc: std::collections::HashMap<(String, String), usize> = std::collections::HashMap::new();


### PR DESCRIPTION
## Summary

Fixes the integration bug where `repo_map` shows no Subsystems section even after `scan --full` produces 8,000+ LSP call edges (#311).

Three root causes found and fixed:

- **LSP edge loss on dirty roots**: When source files changed between `scan --full` and `repo-map`, `build_full_graph` re-extracted with tree-sitter only, discarding all cached LSP edges. Now carries forward LSP-sourced edges whose endpoints still exist in the freshly extracted node set.
- **DependsOn created giant clusters**: Import edges connected nearly every file into one trivial community (8,000+ symbols). Removed DependsOn from coupling edge set -- Calls and Implements are the meaningful coupling signals.
- **Output quality issues**: 190+ micro-clusters with duplicate names. Added density guard (skip when <5% of nodes have coupling edges), scaled min cluster size, filtered >50% giant clusters, deduplicated names, capped output to top 15.

## Changes

- `src/server/graph.rs` -- Carry forward cached LSP edges for dirty roots during incremental rebuild
- `src/graph/index.rs` -- Remove DependsOn from coupling edges, add density guard, scale min cluster size, add 2 new tests
- `src/service.rs` -- Filter giant clusters, deduplicate names, cap to top 15

## Test plan

- [x] All 850 existing tests pass (including 9 community detection tests)
- [x] New `test_detect_communities_excludes_depends_on` -- verifies DependsOn exclusion
- [x] New `test_detect_communities_density_guard` -- verifies sparse graph guard
- [x] Manual: `scan --full` then `repo-map` shows Subsystems section with module-aligned clusters
- [x] Manual: editing source files then running `repo-map` preserves LSP edges (logged as "carried forward N LSP edges")

Closes #311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subsystems list now intelligently filters and deduplicates results, displaying the top 15 subsystems and removing oversized clusters for clearer organization.

* **Improvements**
  * Enhanced community detection algorithm for more accurate subsystem identification.
  * Optimized cache handling during incremental graph updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->