### PR TITLE
fix: address review findings from #318

### DIFF
--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -407,7 +407,14 @@ impl RnaHandler {
                         if edge.source == crate::graph::ExtractionSource::Lsp {
                             let from_id = edge.from.to_stable_id();
                             let to_id = edge.to.to_stable_id();
-                            if node_ids.contains(&from_id) || node_ids.contains(&to_id) {
+                            // Require the source node to still exist. For the
+                            // target, only require existence if it belongs to
+                            // the same dirty root -- external/virtual targets
+                            // may not be in our extraction node set.
+                            let from_exists = node_ids.contains(&from_id);
+                            let to_exists = edge.to.root != *root_slug
+                                || node_ids.contains(&to_id);
+                            if from_exists && to_exists {
                                 extraction.edges.push(edge);
                                 lsp_carry_count += 1;
                             }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1424,10 +1424,13 @@ pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
 
         let mut subsystems = graph_state.index.detect_communities(&pagerank_scores, &node_file_map);
         if !subsystems.is_empty() {
-            let total_symbols: usize = subsystems.iter().map(|s| s.symbol_count).sum();
-            // Filter out giant clusters that contain >50% of all symbols --
+            // Use the filtered node count (from node_file_map, which respects
+            // root_filter) as the denominator for giant-cluster detection. This
+            // avoids unrelated roots skewing the cutoff in multi-root mode.
+            let filtered_node_count = node_file_map.len();
+            // Filter out giant clusters that contain >50% of the filtered nodes --
             // they are not informative (everything is lumped together).
-            subsystems.retain(|s| (s.symbol_count as f64) < (total_symbols as f64 * 0.5));
+            subsystems.retain(|s| (s.symbol_count as f64) < (filtered_node_count as f64 * 0.5));
 
             // Deduplicate names: when multiple clusters share a name, append
             // a distinguishing suffix from their top interface function.


### PR DESCRIPTION
## Summary

Fixes two CodeRabbit findings from #318 (subsystem detection integration fix).

- **Half-stale LSP edge carry-forward**: Changed `||` to `&&` with external root exemption. Source must exist in freshly extracted nodes; target must exist if it belongs to the same dirty root (external targets pass through).
- **Giant-cluster cutoff denominator**: Use `node_file_map.len()` (filtered by root_filter) instead of subsystem symbol sum. Prevents unrelated roots from skewing the 50% threshold in multi-root mode.

## Test plan

- [x] All 850 existing tests pass
- [x] No new tests needed -- these are guard condition tightenings on existing logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of incremental extraction logic by stricter validation of preserved LSP edges, preventing invalid edge references from being carried forward.
  * Enhanced giant-cluster detection to align with applied filters, ensuring more precise cluster identification across root contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->