### PR TITLE
fix: persist graph after LSP enrichment in foreground pipeline

### DIFF
--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -954,7 +954,7 @@ impl RnaHandler {
                 lsp_time.as_secs_f64(),
             ));
 
-            // Apply enrichment to graph
+            // Apply enrichment to in-memory graph
             let mut guard = self.graph.write().await;
             if let Some(ref mut gs) = *guard {
                 for vnode in &enrichment.new_nodes {
@@ -962,7 +962,6 @@ impl RnaHandler {
                 }
                 gs.nodes.extend(enrichment.new_nodes);
 
-                let persist_edges = enrichment.added_edges.clone();
                 for edge in &enrichment.added_edges {
                     let from_id = edge.from.to_stable_id();
                     let to_id = edge.to.to_stable_id();
@@ -976,9 +975,6 @@ impl RnaHandler {
                 }
                 gs.edges.extend(enrichment.added_edges);
 
-                let enriched_node_ids: std::collections::HashSet<String> = enrichment.updated_nodes.iter()
-                    .map(|(id, _)| id.clone())
-                    .collect();
                 for (node_id, patches) in &enrichment.updated_nodes {
                     if let Some(node) = gs.nodes.iter_mut().find(|n| n.stable_id() == *node_id) {
                         for (key, value) in patches {
@@ -987,37 +983,31 @@ impl RnaHandler {
                     }
                 }
 
-                let upsert_nodes: Vec<Node> = gs.nodes.iter()
-                    .filter(|n| enriched_node_ids.contains(&n.stable_id()))
-                    .cloned()
-                    .collect();
                 drop(guard);
-                match persist_graph_incremental(
-                    &self.repo_root, &upsert_nodes, &persist_edges, &[], &[],
-                ).await {
-                    Ok(true) => {
-                        tracing::info!("Foreground LSP enrichment: schema migrated; performing full persist");
-                        let snapshot = {
-                            let g = self.graph.read().await;
-                            g.as_ref().map(|gs| (gs.nodes.clone(), gs.edges.clone()))
-                        };
-                        if let Some((nodes, edges)) = snapshot {
-                            if let Err(e) = persist_graph_to_lance(&self.repo_root, &nodes, &edges).await {
-                                tracing::error!("Foreground LSP enrichment: full persist after migration failed: {}", e);
-                                self.lsp_status.set_complete_persist_failed(lsp_edge_count);
-                                return Err(e.context("LSP enrichment full persist after migration failed"));
-                            }
-                        }
-                    }
-                    Ok(false) => {}
-                    Err(e) => {
-                        tracing::error!("Foreground LSP enrichment persist failed: {}", e);
-                        self.lsp_status.set_complete_persist_failed(lsp_edge_count);
-                        return Err(e.context("LSP enrichment persist failed during foreground pipeline"));
-                    }
-                }
             }
             self.lsp_status.set_complete(lsp_edge_count);
+        }
+
+        // Phase 3: Full persist — write the complete graph (tree-sitter + LSP edges)
+        // to LanceDB. build_full_graph_inner(false) deferred persistence so we can
+        // include LSP edges in a single atomic write (#311).
+        {
+            let snapshot = {
+                let g = self.graph.read().await;
+                g.as_ref().map(|gs| (gs.nodes.clone(), gs.edges.clone()))
+            };
+            if let Some((nodes, edges)) = snapshot {
+                tracing::info!(
+                    "Foreground full persist: {} nodes, {} edges (including {} LSP)",
+                    nodes.len(),
+                    edges.len(),
+                    lsp_edge_count,
+                );
+                if let Err(e) = persist_graph_to_lance(&self.repo_root, &nodes, &edges).await {
+                    tracing::error!("Foreground full persist failed: {}", e);
+                    return Err(e.context("Full persist failed during foreground pipeline"));
+                }
+            }
         }
 
         // Phase 4: Summary

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -521,20 +521,32 @@ impl RnaHandler {
         tracing::info!("Computed PageRank importance for {} nodes", pagerank_scores.len());
 
         // 7. Persist graph to LanceDB
-        if let Err(e) = persist_graph_to_lance(&self.repo_root, &all_nodes, &all_edges).await {
-            tracing::error!("Failed to persist graph to LanceDB: {}", e);
-            return Err(e.context("LanceDB full persist failed during graph build"));
+        //
+        // When `spawn_background=true` (MCP server path), persist NOW so the
+        // graph is queryable immediately while background LSP+embed run.
+        // The background enrichment task re-persists after adding LSP edges.
+        //
+        // When `spawn_background=false` (CLI `--full` path via run_pipeline_foreground),
+        // skip the early persist -- the caller runs LSP synchronously and then
+        // does a full persist with the complete graph (tree-sitter + LSP edges).
+        // Persisting here would write only tree-sitter edges, and a subsequent
+        // `repo-map` loading from LanceDB cache would miss LSP edges (#311).
+        if spawn_background {
+            if let Err(e) = persist_graph_to_lance(&self.repo_root, &all_nodes, &all_edges).await {
+                tracing::error!("Failed to persist graph to LanceDB: {}", e);
+                return Err(e.context("LanceDB full persist failed during graph build"));
+            }
         }
 
-        // Persist succeeded -- commit scanner state for all roots so the
-        // next scan doesn't re-process the same files.
+        // Persist succeeded (or deferred) -- commit scanner state for all roots
+        // so the next scan doesn't re-process the same files.
         for (_slug, scanner, _scan, _path, _changed) in &scanners {
             if let Err(e) = scanner.commit_state() {
                 tracing::error!("Failed to commit scanner state: {}", e);
             }
         }
 
-        // Graph is persisted -- return immediately so agents can query.
+        // Graph is ready -- return immediately so agents can query.
         // Embedding and LSP enrichment run in background via the shared graph lock.
         let symbols_ready_at = std::time::Instant::now();
 


### PR DESCRIPTION
## Summary

Fixes #311 — `repo_map` shows no Subsystems section after `scan --full` because LanceDB only contains tree-sitter edges (~4K), not LSP call edges (~8K+).

**Root cause:** `build_full_graph_inner` persisted the graph to LanceDB (DROP+CREATE) at step 7 before LSP enrichment ran. The foreground pipeline (`scan --full`) then did an incremental persist of LSP edges, but a subsequent `repo-map` loading from LanceDB cache still only saw the initial tree-sitter edges.

**Fix (two changes):**

- `build_full_graph_inner`: only persist early when `spawn_background=true` (MCP server path). When `spawn_background=false` (CLI `--full` path), skip the early persist — the caller handles it after LSP completes.
- `run_pipeline_foreground`: replace the incremental persist with a single full `persist_graph_to_lance` after LSP enrichment. This writes the complete graph (tree-sitter + LSP edges) atomically.

The background MCP path is unchanged — it persists early for fast agent queries, then the background enrichment task re-persists incrementally after adding LSP edges.

## Test plan

- [x] `cargo check --lib` passes
- [x] All 850 existing tests pass
- [ ] Manual: `scan --full` then `repo-map` shows Subsystems section with LSP call edges
- [ ] Manual: LanceDB edge count after `scan --full` matches in-memory count (16K+, not 4K)

Closes #311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized graph enrichment and persistence workflow to consolidate multiple database writes into a single atomic operation, improving system efficiency and data consistency.
  * Enhanced persistence scheduling to defer writes based on execution context for more efficient resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->