### PR TITLE
fix: Louvain produces 95 clusters -- filter tests, add Phase 2 contraction, tune resolution

### DIFF
--- a/src/graph/index.rs
+++ b/src/graph/index.rs
@@ -508,7 +508,7 @@ impl GraphIndex {
 
         // Step 3: Louvain Phase 2 -- contract communities into super-nodes and
         // repeat Phase 1 on the coarsened graph until no further improvement.
-        let mut community = louvain_phase2(&adj, community, total_weight, gamma, n);
+        let mut community = louvain_phase2(&adj, community, gamma, n);
 
         // Step 4: Collect communities, compute stats, and build Subsystem structs.
         // Group production nodes by community
@@ -804,7 +804,6 @@ fn louvain_phase1(
 fn louvain_phase2(
     adj: &[Vec<(usize, f64)>],
     mut community: Vec<usize>,
-    _total_weight: f64,
     gamma: f64,
     n: usize,
 ) -> Vec<usize> {
@@ -827,6 +826,12 @@ fn louvain_phase2(
     let target_k = 12.0_f64;
     let ratio = (target_k / initial_comm_count.max(1) as f64).min(1.0);
     let merge_threshold = gamma * ratio.sqrt();
+
+    // Size cap: don't merge if the result would exceed 30% of production
+    // nodes. This prevents the "snowball" effect where one cluster absorbs
+    // everything through incremental merges.
+    let prod_count = (0..n).filter(|&i| !adj[i].is_empty()).count();
+    let max_community_size = (prod_count as f64 * 0.30) as usize;
 
     let max_rounds = 200;
 
@@ -855,11 +860,6 @@ fn louvain_phase2(
         }
 
         // Find the pair with the highest merge score.
-        // Size cap: don't merge if either community already exceeds a
-        // maximum size or the merged result would. This prevents the
-        // "snowball" effect where the largest cluster absorbs everything.
-        let prod_count = (0..n).filter(|&i| !adj[i].is_empty()).count();
-        let max_community_size = (prod_count as f64 * 0.30) as usize;
         let mut best_pair: Option<(usize, usize)> = None;
         let mut best_score = 0.0_f64;
 


### PR DESCRIPTION
## Summary

Closes #325. Reduces Louvain community detection from 95 clusters to 12 by addressing three root causes:

- **Filter test nodes** before running Louvain. Test functions (62% of symbols) formed small tight clusters that aren't architectural units. They're now excluded from the coupling subgraph and assigned to their nearest production subsystem post-hoc via `is_test_path()`.
- **Phase 2 hierarchical contraction**: After Phase 1 converges, greedily merge community pairs by coupling density (cross-weight / min-size). Threshold scales inversely with initial community count (sqrt(target_k / initial_count)), and a size cap (30% of production nodes) prevents snowball merging.
- **Resolution parameter gamma=0.8**: Added to the modularity gain formula, penalizing small communities. Lower gamma = fewer, larger clusters.

Additional tuning:
- `min_cluster_size` scales with graph size (5-10 for large graphs) to absorb tiny fragments
- Extracted `louvain_phase1` and `louvain_phase2` as standalone functions
- Updated existing tests to use 6-node cliques (robust under gamma<1.0)
- Added 2 new tests: test-node exclusion, Phase 2 contraction behavior

**Delivery verification**: `repo-map --repo .` produces 12 subsystems matching actual architecture: server, extract (x3), git, setup, markdown (x2), oh, embed, process, types.

## Test plan

- [x] All 863 existing tests pass (12 detect_communities tests, 2 new)
- [x] `cargo clippy --lib` clean on changed file
- [x] `repo-map --repo .` shows 12 subsystems (down from 95)
- [x] No test-only subsystems in output
- [x] Key architectural units visible: server, extract, embed, markdown, git, setup

[outcome:subsystem-detection]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  - Two-phase clustering with tunable resolution for more stable subsystem detection
  - Test-code files are excluded from core clustering and reattached to nearest production subsystems afterward
  - Density-based guards and scalable minimum cluster sizing to avoid spurious small clusters
  - Enhanced naming and scoring: module-aware names, recomputed cohesion/interface scores, and interfaces trimmed to top 5

* **Tests**
  - Expanded coverage for test-node handling, phase-2 contraction, naming, and interface detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->