### PR TITLE
feat: hierarchical subsystem display — Level 1 architecture, Level 2 sub-modules

### DIFF
--- a/src/graph/index.rs
+++ b/src/graph/index.rs
@@ -694,6 +694,7 @@ impl GraphIndex {
                 cohesion,
                 interfaces,
                 member_ids: member_ids.clone(),
+                children: Vec::new(),
             });
         }
 
@@ -916,6 +917,8 @@ pub struct Subsystem {
     pub interfaces: Vec<SubsystemInterface>,
     /// Stable IDs of all member nodes in this subsystem.
     pub member_ids: Vec<String>,
+    /// Child sub-modules when this is a hierarchical parent subsystem.
+    pub children: Vec<Subsystem>,
 }
 
 /// An interface function at a subsystem boundary.
@@ -927,6 +930,80 @@ pub struct SubsystemInterface {
     pub node_type: String,
     /// Combined interface score: cross_cluster_degree * pagerank.
     pub interface_score: f64,
+}
+
+/// Group flat subsystems by shared first path component into a hierarchy.
+///
+/// When multiple subsystems share the same prefix before `/` (e.g., `extract/Node`,
+/// `extract/enrich`), they become children of a parent subsystem named after the
+/// shared prefix. Single subsystems (no `/` or unique prefix) remain as-is.
+///
+/// Parent stats are aggregated: symbol_count = sum of children, cohesion = weighted
+/// average by symbol count, interfaces = merged and re-sorted top 5, member_ids =
+/// union of all children.
+pub fn group_subsystems_by_prefix(subsystems: Vec<Subsystem>) -> Vec<Subsystem> {
+    // Partition: subsystems with a `/` in their name vs. those without.
+    // Group by first path component for those with `/`.
+    let mut prefix_groups: std::collections::BTreeMap<String, Vec<Subsystem>> =
+        std::collections::BTreeMap::new();
+    let mut standalone: Vec<Subsystem> = Vec::new();
+
+    for s in subsystems {
+        if let Some(slash_pos) = s.name.find('/') {
+            let prefix = s.name[..slash_pos].to_string();
+            prefix_groups.entry(prefix).or_default().push(s);
+        } else {
+            standalone.push(s);
+        }
+    }
+
+    let mut result: Vec<Subsystem> = standalone;
+
+    for (prefix, children) in prefix_groups {
+        if children.len() == 1 {
+            // Single child -- no grouping needed, keep as leaf
+            result.push(children.into_iter().next().unwrap());
+        } else {
+            // Aggregate stats from children
+            let total_symbols: usize = children.iter().map(|c| c.symbol_count).sum();
+            let weighted_cohesion: f64 = if total_symbols > 0 {
+                children
+                    .iter()
+                    .map(|c| c.cohesion * c.symbol_count as f64)
+                    .sum::<f64>()
+                    / total_symbols as f64
+            } else {
+                0.0
+            };
+            let all_member_ids: Vec<String> = children
+                .iter()
+                .flat_map(|c| c.member_ids.iter().cloned())
+                .collect();
+            let mut all_interfaces: Vec<SubsystemInterface> = children
+                .iter()
+                .flat_map(|c| c.interfaces.iter().cloned())
+                .collect();
+            all_interfaces.sort_by(|a, b| {
+                b.interface_score
+                    .partial_cmp(&a.interface_score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            all_interfaces.truncate(5);
+
+            result.push(Subsystem {
+                name: prefix,
+                symbol_count: total_symbols,
+                cohesion: weighted_cohesion,
+                interfaces: all_interfaces,
+                member_ids: all_member_ids,
+                children,
+            });
+        }
+    }
+
+    // Sort by symbol count descending (matching detect_communities output order)
+    result.sort_by(|a, b| b.symbol_count.cmp(&a.symbol_count));
+    result
 }
 
 /// Compute a cluster name from member nodes.
@@ -2377,5 +2454,91 @@ mod tests {
             "should still keep distinct architectural groups separate, got {} subsystem(s)",
             subsystems.len()
         );
+    }
+
+    #[test]
+    fn test_group_subsystems_by_prefix_groups_shared_prefix() {
+        use super::{group_subsystems_by_prefix, Subsystem};
+        let subsystems = vec![
+            Subsystem {
+                name: "extract/Node".into(),
+                symbol_count: 100,
+                cohesion: 0.8,
+                interfaces: vec![],
+                member_ids: vec!["a".into()],
+                children: vec![],
+            },
+            Subsystem {
+                name: "extract/enrich".into(),
+                symbol_count: 50,
+                cohesion: 0.9,
+                interfaces: vec![],
+                member_ids: vec!["b".into()],
+                children: vec![],
+            },
+            Subsystem {
+                name: "graph".into(),
+                symbol_count: 200,
+                cohesion: 0.85,
+                interfaces: vec![],
+                member_ids: vec!["c".into()],
+                children: vec![],
+            },
+        ];
+        let grouped = group_subsystems_by_prefix(subsystems);
+        assert_eq!(grouped.len(), 2, "Should have 2 top-level: graph + extract");
+        // Sorted by symbol_count desc: graph(200), extract(150)
+        assert_eq!(grouped[0].name, "graph");
+        assert!(grouped[0].children.is_empty());
+        assert_eq!(grouped[1].name, "extract");
+        assert_eq!(grouped[1].symbol_count, 150);
+        assert_eq!(grouped[1].children.len(), 2);
+        assert_eq!(grouped[1].member_ids.len(), 2); // "a" + "b"
+    }
+
+    #[test]
+    fn test_group_subsystems_by_prefix_single_child_no_group() {
+        use super::{group_subsystems_by_prefix, Subsystem};
+        let subsystems = vec![Subsystem {
+            name: "embed/model".into(),
+            symbol_count: 30,
+            cohesion: 0.9,
+            interfaces: vec![],
+            member_ids: vec!["x".into()],
+            children: vec![],
+        }];
+        let grouped = group_subsystems_by_prefix(subsystems);
+        assert_eq!(grouped.len(), 1);
+        // Single child: kept as leaf, not wrapped in parent
+        assert_eq!(grouped[0].name, "embed/model");
+        assert!(grouped[0].children.is_empty());
+    }
+
+    #[test]
+    fn test_group_subsystems_weighted_cohesion() {
+        use super::{group_subsystems_by_prefix, Subsystem};
+        let subsystems = vec![
+            Subsystem {
+                name: "md/parse".into(),
+                symbol_count: 60,
+                cohesion: 0.8,
+                interfaces: vec![],
+                member_ids: vec![],
+                children: vec![],
+            },
+            Subsystem {
+                name: "md/search".into(),
+                symbol_count: 40,
+                cohesion: 0.9,
+                interfaces: vec![],
+                member_ids: vec![],
+                children: vec![],
+            },
+        ];
+        let grouped = group_subsystems_by_prefix(subsystems);
+        assert_eq!(grouped.len(), 1);
+        let parent = &grouped[0];
+        // Weighted average: (0.8*60 + 0.9*40) / 100 = 84/100 = 0.84
+        assert!((parent.cohesion - 0.84).abs() < 0.01);
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -219,7 +219,7 @@ async fn flat_code_symbol_search<'a>(
         }
         if let Some(ref sub) = params.subsystem {
             let node_sub = n.metadata.get(crate::server::SUBSYSTEM_KEY).map(|s| s.as_str()).unwrap_or("");
-            if !node_sub.eq_ignore_ascii_case(sub) { return false; }
+            if !subsystem_matches(node_sub, sub) { return false; }
         }
         true
     };
@@ -444,7 +444,7 @@ async fn search_traversal(params: &SearchParams, query: Option<&str>, node: Opti
                             if let Some(ref sub) = params.subsystem {
                                 ctx.graph_state.node_by_stable_id(&r.id, &node_index_map_for_entry)
                                     .and_then(|n| n.metadata.get(crate::server::SUBSYSTEM_KEY))
-                                    .map(|s| s.eq_ignore_ascii_case(sub))
+                                    .map(|s| subsystem_matches(s, sub))
                                     .unwrap_or(false)
                             } else {
                                 true
@@ -515,7 +515,7 @@ async fn search_traversal(params: &SearchParams, query: Option<&str>, node: Opti
             ids.retain(|id| {
                 gs.node_by_stable_id(id, &node_index_map)
                     .and_then(|n| n.metadata.get(crate::server::SUBSYSTEM_KEY))
-                    .map(|s| s.eq_ignore_ascii_case(sub))
+                    .map(|s| subsystem_matches(s, sub))
                     .unwrap_or(false)
             });
         }
@@ -781,7 +781,7 @@ fn resolve_entry_points_by_name<'a>(
         }
         if let Some(ref sub) = params.subsystem {
             let node_sub = n.metadata.get(crate::server::SUBSYSTEM_KEY).map(|s| s.as_str()).unwrap_or("");
-            if !node_sub.eq_ignore_ascii_case(sub) { return false; }
+            if !subsystem_matches(node_sub, sub) { return false; }
         }
         true
     }).collect();
@@ -797,6 +797,25 @@ fn resolve_entry_points_by_name<'a>(
 
     matches.truncate(limit);
     matches
+}
+
+/// Match a node's subsystem metadata against a filter value.
+///
+/// Supports hierarchical matching: `subsystem="extract"` matches nodes whose
+/// subsystem is exactly "extract" (case-insensitive) OR starts with "extract/"
+/// (i.e., any child sub-module). `subsystem="extract/enrich"` matches only
+/// nodes in that specific sub-module.
+fn subsystem_matches(node_subsystem: &str, filter: &str) -> bool {
+    if node_subsystem.eq_ignore_ascii_case(filter) {
+        return true;
+    }
+    // Parent-level match: filter="extract" should match node_subsystem="extract/Node".
+    // Check without allocating: node_subsystem must start with filter + "/" (case-insensitive).
+    if node_subsystem.len() > filter.len() {
+        let (head, tail) = node_subsystem.split_at(filter.len());
+        return head.eq_ignore_ascii_case(filter) && tail.starts_with('/');
+    }
+    false
 }
 
 pub fn node_passes_root_filter(node_root: &str, root_filter: &Option<String>, non_code_slugs: &HashSet<String>) -> bool {
@@ -1487,6 +1506,56 @@ mod tests {
     }
 
     #[test]
+    fn test_subsystem_matches_exact() {
+        assert!(super::subsystem_matches("extract", "extract"));
+        assert!(super::subsystem_matches("Extract", "extract"));
+        assert!(super::subsystem_matches("extract", "Extract"));
+    }
+
+    #[test]
+    fn test_subsystem_matches_parent_prefix() {
+        // Parent filter matches child sub-modules
+        assert!(super::subsystem_matches("extract/Node", "extract"));
+        assert!(super::subsystem_matches("extract/enrich", "extract"));
+        assert!(super::subsystem_matches("Extract/Node", "extract"));
+    }
+
+    #[test]
+    fn test_subsystem_matches_child_specific() {
+        // Child-specific filter matches only that child
+        assert!(super::subsystem_matches("extract/enrich", "extract/enrich"));
+        assert!(!super::subsystem_matches("extract/Node", "extract/enrich"));
+    }
+
+    #[test]
+    fn test_subsystem_matches_no_false_prefix() {
+        // "extract" should NOT match "extraction" (not a `/`-separated prefix)
+        assert!(!super::subsystem_matches("extraction", "extract"));
+    }
+
+    #[tokio::test]
+    async fn test_flat_search_subsystem_parent_matches_children() {
+        let mut node_a = make_node("enrich", NodeKind::Function, "src/extract/enrich.rs");
+        node_a.metadata.insert(crate::server::SUBSYSTEM_KEY.to_owned(), "extract/enrich".to_string());
+        let mut node_b = make_node("NodeId", NodeKind::Struct, "src/extract/mod.rs");
+        node_b.metadata.insert(crate::server::SUBSYSTEM_KEY.to_owned(), "extract/Node".to_string());
+        let mut node_c = make_node("embed_texts", NodeKind::Function, "src/embed.rs");
+        node_c.metadata.insert(crate::server::SUBSYSTEM_KEY.to_owned(), "embed".to_string());
+        let gs = make_graph_state(vec![node_a, node_b, node_c]);
+        let repo_root = PathBuf::from("/tmp/test");
+        let ctx = make_search_context(&gs, &repo_root);
+        let params = SearchParams {
+            subsystem: Some("extract".into()),
+            ..Default::default()
+        };
+        let result = search(&params, &ctx).await;
+        // Both extract/enrich and extract/Node should match, but not embed
+        assert!(result.contains("enrich"), "Should include extract/enrich child");
+        assert!(result.contains("NodeId"), "Should include extract/Node child");
+        assert!(!result.contains("embed_texts"), "Should NOT include embed subsystem");
+    }
+
+    #[test]
     fn test_format_impact_subsystem_breakdown_empty() {
         let groups = std::collections::BTreeMap::new();
         let gs = make_graph_state(vec![]);
@@ -1652,40 +1721,51 @@ pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
                 }
             }
 
-            // Cap output to top 15 subsystems by symbol count.
-            let shown = subsystems.len().min(15);
-            let total_detected = subsystems.len();
-            subsystems.truncate(shown);
+            // Group flat subsystems by shared module prefix into a hierarchy.
+            let grouped = crate::graph::index::group_subsystems_by_prefix(subsystems);
 
-            if !subsystems.is_empty() {
-                let md: String = subsystems
+            // Cap output to top 15 top-level subsystems by symbol count.
+            let total_detected = grouped.len();
+            let shown = grouped.len().min(15);
+            let displayed: Vec<_> = grouped.into_iter().take(shown).collect();
+
+            if !displayed.is_empty() {
+                let format_interfaces = |s: &crate::graph::index::Subsystem| -> String {
+                    if s.interfaces.is_empty() {
+                        return String::new();
+                    }
+                    let iface_list: Vec<String> = s
+                        .interfaces
+                        .iter()
+                        .map(|iface| {
+                            let short_name = iface
+                                .node_id
+                                .split(':')
+                                .rev()
+                                .nth(1)
+                                .unwrap_or(&iface.node_id);
+                            if iface.node_type == "function" {
+                                format!("{}()", short_name)
+                            } else {
+                                short_name.to_string()
+                            }
+                        })
+                        .collect();
+                    format!("\n  Interfaces: {}", iface_list.join(", "))
+                };
+
+                let md: String = displayed
                     .iter()
                     .map(|s| {
-                        let interfaces_str = if s.interfaces.is_empty() {
+                        let sub_modules = if s.children.is_empty() {
                             String::new()
                         } else {
-                            let iface_list: Vec<String> = s
-                                .interfaces
-                                .iter()
-                                .map(|iface| {
-                                    let short_name = iface
-                                        .node_id
-                                        .split(':')
-                                        .rev()
-                                        .nth(1)
-                                        .unwrap_or(&iface.node_id);
-                                    if iface.node_type == "function" {
-                                        format!("{}()", short_name)
-                                    } else {
-                                        short_name.to_string()
-                                    }
-                                })
-                                .collect();
-                            format!("\n  Interfaces: {}", iface_list.join(", "))
+                            format!(", {} sub-modules", s.children.len())
                         };
+                        let interfaces_str = format_interfaces(s);
                         format!(
-                            "- **{}** ({} symbols, cohesion: {:.2}){}",
-                            s.name, s.symbol_count, s.cohesion, interfaces_str
+                            "- **{}** ({} symbols{}, cohesion: {:.2}){}",
+                            s.name, s.symbol_count, sub_modules, s.cohesion, interfaces_str
                         )
                     })
                     .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary

Closes #327

- **Group by shared module prefix** (`src/graph/index.rs`): New `group_subsystems_by_prefix()` function groups flat Louvain communities that share the same first path component into parent `Subsystem` with `children: Vec<Subsystem>`. Aggregates stats (symbol_count = sum, cohesion = weighted average, interfaces = merged top 5, member_ids = union).
- **`repo_map` renders Level 1** (`src/service.rs`): Shows parent subsystems with "(N sub-modules)" annotation instead of flat list. Reduces visual noise from 96 flat subsystems to 23 grouped top-level entries.
- **`search(subsystem=...)` matches both levels** (`src/service.rs`): New `subsystem_matches()` helper supports hierarchical matching — `subsystem="extract"` matches nodes in `extract/Node`, `extract/enrich`, etc. `subsystem="extract/enrich"` matches only that specific sub-module.

## Delivery verification

Before (main): `## Subsystems (96 detected (showing top 15))` — flat list, no hierarchy
After (this PR): `## Subsystems (23 detected (showing top 15))` — grouped with sub-module counts

```
- **extract** (983 symbols, 27 sub-modules, cohesion: 0.66)
- **server** (219 symbols, 12 sub-modules, cohesion: 0.75)
- **graph** (211 symbols, 4 sub-modules, cohesion: 0.73)
- **embed** (110 symbols, 6 sub-modules, cohesion: 0.70)
- **markdown** (99 symbols, 4 sub-modules, cohesion: 0.82)
```

## Test plan

- [x] `cargo check --lib` passes
- [x] `cargo test --lib` passes (869 tests, 8 new)
- [x] New unit tests for `group_subsystems_by_prefix` (grouping, single-child passthrough, weighted cohesion)
- [x] New unit tests for `subsystem_matches` (exact, parent prefix, child-specific, no false prefix)
- [x] New integration test for parent-level subsystem filter in flat search
- [x] Built from source and ran `repo-map --repo .` — verified hierarchical output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hierarchical subsystem grouping with parent–child support for clearer code-structure visualization
  * Search now matches hierarchies so querying a parent includes its child subsystems

* **Improvements**
  * Repository map displays subsystem hierarchy, sub-module counts, and aggregated interface summaries
  * More accurate aggregated statistics and cohesion for grouped subsystems

* **Tests**
  * Expanded tests covering grouping, matching, and formatting behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->