### PR TITLE
fix: show sub-module names in repo_map subsystem output

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1760,12 +1760,20 @@ pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
                         let sub_modules = if s.children.is_empty() {
                             String::new()
                         } else {
-                            format!(", {} sub-modules", s.children.len())
+                            let child_names: Vec<String> = s.children.iter()
+                                .map(|c| {
+                                    // Strip parent prefix for cleaner display
+                                    let short = c.name.strip_prefix(&format!("{}/", s.name))
+                                        .unwrap_or(&c.name);
+                                    format!("{} ({})", short, c.symbol_count)
+                                })
+                                .collect();
+                            format!("\n  Sub-modules: {}", child_names.join(", "))
                         };
                         let interfaces_str = format_interfaces(s);
                         format!(
-                            "- **{}** ({} symbols{}, cohesion: {:.2}){}",
-                            s.name, s.symbol_count, sub_modules, s.cohesion, interfaces_str
+                            "- **{}** ({} symbols, cohesion: {:.2}){}{}",
+                            s.name, s.symbol_count, s.cohesion, sub_modules, interfaces_str
                         )
                     })
                     .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary
Sub-modules were showing as "(2 sub-modules)" without listing what they are. Now shows the names and sizes inline.

**Before:**
```
- **extract** (716 symbols, 2 sub-modules, cohesion: 0.91)
```

**After:**
```
- **extract** (716 symbols, cohesion: 0.91)
  Sub-modules: NodeKind (692), ExtractionResult (438)
  Interfaces: Node, collect_nodes(), ExtractionSource, enrich(), Edge
```

## Test Plan
- [ ] `repo-map --repo .` shows sub-module names with symbol counts
- [ ] Cohesion stays on the first line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced repository map rendering with detailed sub-modules display, replacing the previous inline count format with a formatted list showing each sub-module with symbol counts.
  * Improved symbol line formatting for better information organization and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->