### PR TITLE
fix: replace merge_insert with delete+add to fix enrichment re-embed

### DIFF
--- a/src/embed.rs
+++ b/src/embed.rs
@@ -909,7 +909,7 @@ impl EmbeddingIndex {
         );
 
         // --- Stream embeddings in batches (#298) ---
-        // Embed WRITE_BATCH_SIZE texts at a time and merge_insert each batch
+        // Embed WRITE_BATCH_SIZE texts at a time and persist each batch
         // immediately, so we never hold all embedding vectors in memory.
         let embed_start = std::time::Instant::now();
         let mut embedded_count = 0usize;
@@ -1034,8 +1034,8 @@ impl EmbeddingIndex {
         );
 
         // --- Delete stale rows (#298) ---
-        // If we used merge_insert (table already existed), there may be rows
-        // for nodes that no longer exist in the graph. Delete them.
+        // If the table already existed, there may be rows for nodes that no
+        // longer exist in the graph. Delete them.
         // Uses current_ids captured before partitioning to avoid re-loading
         // commits/merges from git.
         if table_exists {
@@ -1072,7 +1072,7 @@ impl EmbeddingIndex {
     }
 
     /// Delete embedding rows for IDs that are no longer in the current graph.
-    /// Called after merge_insert to clean up stale entries from previous builds.
+    /// Called after rebuild to clean up stale entries from previous builds.
     async fn delete_stale_rows_with_ids(&self, current_ids: &std::collections::HashSet<String>) -> Result<()> {
         use futures::TryStreamExt;
 


### PR DESCRIPTION
## Summary

Fixes #332. `scan --full` fails on the enrichment re-embed path because `merge_insert` fails on LanceDB tables created by the same process.

- Replace `merge_insert` with delete-then-`add()` in both `index_all_inner` (full rebuild) and `reindex_nodes` (incremental)
- Preserves BLAKE3 hash optimization: unchanged rows stay in the table, only changed rows are deleted and re-added
- Adds regression test `enrichment_re_embed_succeeds_on_existing_table`

## Root cause

During `scan --full`, the embedding table is created during graph build (first `index_all_with_symbols` call). After LSP enrichment completes, `index_all_with_symbols` is called again. The second call finds `table_exists=true` and routes to the `merge_insert` branch, which fails on a table created by the same process.

## Fix approach

Instead of `merge_insert` (upsert), use delete + `add()`:
1. Before the batch loop, delete all rows whose IDs are about to be re-embedded
2. Use `add()` (simple append) for all batches, since duplicates are now impossible

This is both simpler and more reliable than `merge_insert`, with no behavioral change -- the BLAKE3 hash check already ensures only changed rows reach the write path.

## Test plan

- [x] `cargo check --lib` passes
- [x] All 68 embed tests pass (67 existing + 1 new regression test)
- [x] New test `enrichment_re_embed_succeeds_on_existing_table` covers the exact failure scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-embedding now deletes stale rows before adding updated embeddings to prevent duplicates and re-embed failures on existing tables; reindexing and streaming batch paths are more reliable while preserving search behavior and schema resilience.

* **Tests**
  * Added a regression test ensuring re-embedding succeeds on existing tables when node content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->