### PR TITLE
fix: address review findings from #336

### DIFF
--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -1022,7 +1022,7 @@ impl RnaHandler {
             let guard = self.graph.read().await;
             let gs = guard.as_ref().unwrap();
             gs.nodes.iter()
-                .filter(|n| changed_file_set.iter().any(|f| n.id.file == *f))
+                .filter(|n| changed_file_set.contains(&n.id.file))
                 .cloned()
                 .collect()
         };
@@ -1048,6 +1048,8 @@ impl RnaHandler {
 
         let t2 = std::time::Instant::now();
         let enricher_registry = EnricherRegistry::with_builtins();
+        let supported = enricher_registry.supported_languages();
+        let has_supported_language = languages.iter().any(|l| supported.contains(l));
         let graph_index = {
             let guard = self.graph.read().await;
             guard.as_ref().unwrap().index.clone()
@@ -1059,8 +1061,13 @@ impl RnaHandler {
 
         let lsp_edge_count;
         if !enrichment.any_enricher_ran {
-            on_progress(&format!("LSP: no server available ({:.1}s)", lsp_time.as_secs_f64()));
-            self.lsp_status.set_unavailable();
+            if has_supported_language {
+                on_progress(&format!("LSP: no server available ({:.1}s)", lsp_time.as_secs_f64()));
+                self.lsp_status.set_unavailable();
+            } else {
+                on_progress(&format!("LSP: no supported enrichers for changed files ({:.1}s)", lsp_time.as_secs_f64()));
+                self.lsp_status.set_complete(0);
+            }
             lsp_edge_count = 0;
         } else {
             lsp_edge_count = enrichment.added_edges.len();
@@ -1089,8 +1096,15 @@ impl RnaHandler {
                 }
                 gs.edges.extend(enrichment.added_edges);
 
+                // Build index for O(1) lookup instead of O(N) find per patch.
+                let node_pos: std::collections::HashMap<String, usize> = gs.nodes
+                    .iter()
+                    .enumerate()
+                    .map(|(i, n)| (n.stable_id(), i))
+                    .collect();
                 for (node_id, patches) in &enrichment.updated_nodes {
-                    if let Some(node) = gs.nodes.iter_mut().find(|n| n.stable_id() == *node_id) {
+                    if let Some(&idx) = node_pos.get(node_id) {
+                        let node = &mut gs.nodes[idx];
                         for (key, value) in patches {
                             node.metadata.insert(key.clone(), value.clone());
                         }
@@ -1411,8 +1425,15 @@ impl RnaHandler {
                 }
                 gs.edges.extend(enrichment.added_edges);
 
+                // Build index for O(1) lookup instead of O(N) find per patch.
+                let node_pos: std::collections::HashMap<String, usize> = gs.nodes
+                    .iter()
+                    .enumerate()
+                    .map(|(i, n)| (n.stable_id(), i))
+                    .collect();
                 for (node_id, patches) in &enrichment.updated_nodes {
-                    if let Some(node) = gs.nodes.iter_mut().find(|n| n.stable_id() == *node_id) {
+                    if let Some(&idx) = node_pos.get(node_id) {
+                        let node = &mut gs.nodes[idx];
                         for (key, value) in patches {
                             node.metadata.insert(key.clone(), value.clone());
                         }


### PR DESCRIPTION
## Summary

Addresses 3 unaddressed CodeRabbit findings from PR #336 (incremental scan --full).

## Findings Fixed

1. **[Major] O(N^2) changed-file membership check** -- `changed_file_set.iter().any(|f| n.id.file == *f)` replaced with `changed_file_set.contains(&n.id.file)`. The set was already a `HashSet<PathBuf>` but `.contains()` wasn't being used.

2. **[Minor] LSP marked unavailable for unsupported-language deltas** -- When changed files are only in languages without an enricher (e.g., YAML), the foreground incremental path now calls `set_complete(0)` instead of `set_unavailable()`, matching the existing background incremental behavior in `spawn_incremental_lsp_enrichment`.

3. **[Major] O(N*M) linear find for enrichment patches** -- `gs.nodes.iter_mut().find(|n| n.stable_id() == *node_id)` replaced with `HashMap<stable_id, index>` lookup at both call sites in the new incremental foreground code.

## Test plan
- [x] `cargo check --lib` passes
- [x] All 879 tests pass
- [x] No new clippy warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error state handling and status messaging for enrichment operations when language support is unavailable or not configured for changed files.
  * Improved distinction between "language server unavailable" and "unsupported language configuration" error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->