### PR TITLE
fix: LSP early bail should be time-based too

### DIFF
--- a/src/extract/lsp.rs
+++ b/src/extract/lsp.rs
@@ -513,6 +513,11 @@ const MAX_TYPE_HIERARCHY_STRIKES: u32 = 3;
 /// without a venv, or a server that can't resolve any references).
 const ZERO_EDGE_ABORT_THRESHOLD: u32 = 1_000;
 
+/// Time-based abort: if no edges after this duration, abort enrichment.
+/// On slow LSP servers (e.g., pyright without warm cache), reaching the
+/// node-count threshold can take 100+ minutes. This caps the wait at 2 minutes.
+const ZERO_EDGE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 impl LspEnricher {
     /// Create a new LSP enricher for the given language server.
     ///
@@ -1690,12 +1695,15 @@ impl Enricher for LspEnricher {
                 last_logged_count = done;
             }
 
-            // Early abort: if we've processed >= 1,000 nodes with 0 edges,
-            // the language server is likely misconfigured (e.g., missing venv).
-            if result.added_edges.is_empty() && attempted >= ZERO_EDGE_ABORT_THRESHOLD {
+            // Early abort: if we've processed >= 1,000 nodes OR spent >= 2 minutes
+            // with 0 edges, the language server is likely misconfigured (e.g., missing venv).
+            if result.added_edges.is_empty()
+                && (attempted >= ZERO_EDGE_ABORT_THRESHOLD
+                    || pass1_start.elapsed() > ZERO_EDGE_TIMEOUT)
+            {
                 tracing::warn!(
-                    "LSP: {} produced 0 edges after {}/{} nodes — aborting (likely misconfigured)",
-                    self.server_command, attempted, total_nodes,
+                    "LSP: {} produced 0 edges after {}/{} nodes ({:.1}s) — aborting (likely misconfigured)",
+                    self.server_command, attempted, total_nodes, pass1_start.elapsed().as_secs_f64(),
                 );
                 join_set.abort_all();
                 break;
@@ -1780,11 +1788,14 @@ impl Enricher for LspEnricher {
                     pass2_last_count = pass2_done;
                 }
 
-                // Early abort: 0 new edges after 1,000 type hierarchy nodes
-                if result.added_edges.len() == edges_before_pass2 && pass2_done >= ZERO_EDGE_ABORT_THRESHOLD as u64 {
+                // Early abort: 0 new edges after 1,000 nodes OR 2 minutes
+                if result.added_edges.len() == edges_before_pass2
+                    && (pass2_done >= ZERO_EDGE_ABORT_THRESHOLD as u64
+                        || pass2_start.elapsed() > ZERO_EDGE_TIMEOUT)
+                {
                     tracing::warn!(
-                        "LSP: {} type hierarchy produced 0 edges after {}/{} nodes — aborting (likely misconfigured)",
-                        self.server_command, pass2_done, pass2_total,
+                        "LSP: {} type hierarchy produced 0 edges after {}/{} nodes ({:.1}s) — aborting (likely misconfigured)",
+                        self.server_command, pass2_done, pass2_total, pass2_start.elapsed().as_secs_f64(),
                     );
                     break;
                 }


### PR DESCRIPTION
## Summary

- Add `ZERO_EDGE_TIMEOUT` (2 minutes) alongside existing `ZERO_EDGE_ABORT_THRESHOLD` (1,000 nodes) for both Pass 1 (call hierarchy) and Pass 2 (type hierarchy)
- Whichever threshold fires first aborts enrichment when zero edges have been produced
- Fixes slow LSP servers (e.g., pyright at 0.17 nodes/s) stalling for 100+ minutes before the count threshold triggers

Closes #342

## Test plan

- [x] `cargo check --lib` passes
- [x] All 65 LSP-related tests pass
- [ ] Manual test with slow pyright server confirms abort fires at ~2 minutes instead of ~100 minutes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of slow language servers by introducing a 120-second timeout mechanism for code indexing operations. The system now uses a hybrid count-or-time-based approach to better manage indexing and reduce incomplete results on slower servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->