### PR TITLE
fix: address CodeRabbit review findings from #349

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -2090,7 +2090,12 @@ pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
             .iter()
             .filter(|n| n.id.root != "external")
             .filter(|n| node_passes_root_filter(&n.id.root, &params.root_filter, &params.non_code_slugs))
-            .map(|n| (n.stable_id(), n.id.file.display().to_string()))
+            .map(|n| {
+                // Normalize to forward slashes so child_name_from_files works
+                // on all platforms (Path::display uses OS-native separators).
+                let path = n.id.file.to_string_lossy().replace('\\', "/");
+                (n.stable_id(), path)
+            })
             .collect();
 
         // Build pagerank scores map from node metadata
@@ -2133,6 +2138,21 @@ pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
                         &s.name,
                     );
                     s.name = format!("{}/{}", s.name, suffix);
+                }
+            }
+
+            // Ensure final names are globally unique after disambiguation.
+            // Two clusters could still collide if they share the same dominant
+            // directory component (e.g., both get "server/graph").
+            {
+                let mut seen: std::collections::HashMap<String, usize> =
+                    std::collections::HashMap::new();
+                for s in &mut subsystems {
+                    let count = seen.entry(s.name.clone()).or_default();
+                    *count += 1;
+                    if *count > 1 {
+                        s.name = format!("{}-{}", s.name, *count);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

- Normalize file paths to forward slashes when building `node_file_map` so `child_name_from_files` works on all platforms (Windows backslash separators from `Path::display()`)
- Add post-disambiguation uniqueness guarantee: if two clusters still collide after directory-component naming, append a numeric suffix

## Context

CodeRabbit posted two Minor findings on #349 after merge:
1. Disambiguation pass does not guarantee final uniqueness -- two clusters could converge to the same `name/component`
2. `Path::display().to_string()` produces OS-native separators, which would break `split('/')` on Windows

## Test plan

- [x] `cargo check --lib` passes
- [x] All existing tests pass (6 related tests verified)
- [x] Both fixes are defensive -- they handle edge cases that are unlikely in practice but valid

Fixes review findings from #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cross-platform path compatibility by standardizing path format handling.
  * Enhanced subsystem name resolution to ensure consistent unique naming across the system.
  * Refined file mapping processes for better accuracy in repository structure analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->