### PR TITLE
feat: add smoke test checks for subsystem detection, impact size, short ID resolution, edge persist parity

### DIFF
--- a/src/smoke_test.rs
+++ b/src/smoke_test.rs
@@ -1526,14 +1526,7 @@ async fn run_impact_output_size_check(index: &GraphIndex, nodes: &[Node]) -> Che
 
     let node_id = best_node.stable_id();
 
-    // Build a GraphState for the search context
-    let mut gs_index = GraphIndex::new();
-    let edges_for_index: Vec<Edge> = Vec::new();
-    gs_index.rebuild_from_edges(&edges_for_index);
-    for n in nodes {
-        gs_index.ensure_node(&n.stable_id(), &n.id.kind.to_string());
-    }
-    // Copy the actual index so we have real edges
+    // Build a GraphState using the caller's index (which has real edges)
     let graph_state = GraphState {
         nodes: nodes.to_vec(),
         edges: Vec::new(),


### PR DESCRIPTION
## Summary

Closes #353.

- Adds 4 new regression-catching smoke test checks to `rna test` (checks 26-29)
- **subsystem_detection**: verifies `detect_communities()` returns >0 subsystems when coupling edges exist; gracefully skips if fixture is too small
- **impact_output_size**: runs impact traversal on the highest-PageRank node and asserts output stays under 50K chars
- **short_id_resolution**: strips root prefix from a stable ID, passes the short form to `GraphState.resolve_node_id()`, verifies it resolves back
- **edge_persist_parity**: persists graph to LanceDB, reloads, compares edge counts (must match within 5%)

## Test plan

- [x] `cargo check --lib` passes
- [x] `cargo test --lib` passes (889 tests, 0 failures)
- [x] `cargo run -- test --repo .github/fixtures/smoke` passes (29 checks: 26 PASS, 3 SKIP)
- [x] New checks produce correct PASS/SKIP behavior on the small fixture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced new regression test suite with validation checks for subsystem detection, short ID resolution, output performance constraints, and data persistence parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->