### PR TITLE
fix: acquire lance_write_lock before delete_nodes_for_roots in background scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6274,7 +6274,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "repo-native-alignment"
-version = "0.1.7"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repo-native-alignment"
-version = "0.1.11"
+version = "0.1.13"
 edition = "2024"
 description = "Agentic harness: business outcomes, SLO signals, constraints, and learnings as queryable repo artifacts"
 license = "MIT"

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -335,6 +335,7 @@ impl RnaHandler {
 
                 // Purge removed worktree slugs from LanceDB.
                 if !removed_slugs.is_empty() {
+                    let _lance_guard = lance_write_lock.lock().await;
                     if let Err(e) = delete_nodes_for_roots(&repo_root, &removed_slugs).await {
                         tracing::warn!(
                             "Failed to delete LanceDB rows for removed worktrees: {}",


### PR DESCRIPTION
## Summary

- Closes the last unprotected LanceDB write in the background scanner path
- `delete_nodes_for_roots` at enrichment.rs:338 was callable concurrently with `persist_graph_incremental` in the LSP enrichment task
- Adds `let _lance_guard = lance_write_lock.lock().await;` before the call, matching the pattern used by every other LanceDB write in the scanner loop (lines 283, 301, 541, 555, 695, 708, 866, 879)
- Bumps version to 0.1.13

Low-frequency path (only triggered when a git worktree is physically removed), but the race was real.

Closes #366

## Test plan

- [x] `cargo check --lib` passes
- [ ] Verify background scanner runs without warnings when a worktree is removed
- [ ] CI smoke tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 0.1.13

* **Bug Fixes**
  * Enhanced data consistency during background cleanup operations by ensuring proper synchronization of database maintenance tasks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->