### PR TITLE
fix: retry LanceDB writes on conflict for multi-process safety

### DIFF
--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -304,18 +304,21 @@ pub(crate) async fn delete_nodes_for_roots(repo_root: &Path, slugs: &[String]) -
     Ok(())
 }
 
-/// Persist graph nodes and edges to LanceDB tables.
 /// Returns `true` if the error looks like a LanceDB concurrent-write conflict.
 ///
 /// LanceDB uses optimistic concurrency and surfaces conflicts as errors whose
-/// messages contain "conflict", "concurrent", or "commit" (the internal transaction
-/// terminology).  We match on the string representation because the upstream error
-/// types are not exposed as a public enum.
+/// messages contain "conflict" or "concurrent" in their description.  We match on
+/// the string representation because the upstream error types are not exposed as a
+/// public enum.
+///
+/// Note: "commit" is intentionally excluded — it appears in many non-conflict contexts
+/// (git history, schema version strings, log messages) and would cause false positives.
 fn is_conflict_error(e: &anyhow::Error) -> bool {
     let msg = e.to_string().to_lowercase();
-    msg.contains("conflict") || msg.contains("concurrent") || msg.contains("commit")
+    msg.contains("conflict") || msg.contains("concurrent")
 }
 
+/// Persist graph nodes and edges to LanceDB tables.
 pub(crate) async fn persist_graph_to_lance(
     repo_root: &Path,
     nodes: &[Node],
@@ -1195,14 +1198,20 @@ mod tests {
     /// `is_conflict_error` correctly identifies conflict-like messages and ignores others.
     #[test]
     fn test_is_conflict_error_detection() {
-        let conflict = anyhow::anyhow!("concurrent write conflict detected");
+        // These should match.
+        let conflict = anyhow::anyhow!("write conflict detected");
         assert!(is_conflict_error(&conflict));
-
-        let commit = anyhow::anyhow!("failed to commit transaction");
-        assert!(is_conflict_error(&commit));
 
         let concurrent = anyhow::anyhow!("concurrent modification");
         assert!(is_conflict_error(&concurrent));
+
+        let both = anyhow::anyhow!("concurrent write conflict");
+        assert!(is_conflict_error(&both));
+
+        // These should NOT match — "commit" excluded to avoid false positives in
+        // non-conflict contexts (git messages, schema strings, log lines).
+        let commit_only = anyhow::anyhow!("failed to commit transaction");
+        assert!(!is_conflict_error(&commit_only));
 
         let unrelated = anyhow::anyhow!("table not found");
         assert!(!is_conflict_error(&unrelated));


### PR DESCRIPTION
Closes #375

## Problem

Multiple RNA processes (MCP server + CLI scan) each have their own per-process `Arc<Mutex<()>>` for LanceDB writes. These don't coordinate across process boundaries. When two processes call `merge_insert` or `drop_table`/`create_table` on the same LanceDB simultaneously, one fails with a conflict error.

## Fix

Adds three things:

1. `is_conflict_error(e: &anyhow::Error) -> bool` — detects LanceDB concurrent-write conflicts by matching "conflict", "concurrent", or "commit" in the error message. String matching is used because LanceDB doesn't expose conflict errors as a public enum type.

2. Retry loop in `persist_graph_incremental` — both the symbols and edges `merge_insert` calls retry up to 3 times with exponential backoff (100ms, 200ms, 300ms) on conflict. The `RecordBatch` (Arc-wrapped Arrow data) and schema are cheaply cloned for each retry. The merge builder must be recreated per attempt since `execute()` consumes it.

3. Retry loop in `persist_graph_to_lance` — the `drop_table` + `create_table` sequence for both symbols and edges retries up to 3 times on conflict. Each retry re-drops to ensure the table is replaced cleanly.

## Tests

- `test_is_conflict_error_detection` — unit test covering all three trigger keywords and two non-matching messages
- `test_concurrent_incremental_persist_both_succeed` — spawns two tokio tasks writing to the same LanceDB table concurrently; both must succeed

## Acceptance criteria

- [x] `persist_graph_incremental` retries up to 3 times on conflict with exponential backoff
- [x] Error message distinguishes "conflict (retried)" from "other LanceDB error" via context string
- [x] No infinite retry loops (bounded at 3 attempts)
- [x] Test: two concurrent persist calls to same table succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of concurrent data writes by adding automatic retry with incremental backoff for transient write conflicts.
  * Better error classification and clearer retry-aware error reporting when writes fail due to concurrent access.

* **Tests**
  * Added tests validating concurrent write resilience and conflict-detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->