### PR TITLE
fix: filter empty-slug ghost root from list_roots output

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -2784,6 +2784,23 @@ mod tests {
         assert!(result.contains("1 root(s)"), "should show exactly 1 root (external excluded)");
     }
 
+    /// Adversarial: empty slug + external + a real orphan all in active_slugs at once.
+    /// Only the real orphan should appear; empty and external must both be excluded.
+    #[test]
+    fn test_list_roots_from_slugs_empty_external_and_real_orphan_mixed() {
+        let repo = std::env::current_dir().unwrap();
+        let mut active_slugs = std::collections::HashSet::new();
+        active_slugs.insert("".to_string());
+        active_slugs.insert("external".to_string());
+        active_slugs.insert("only-real-zzz".to_string());
+
+        let result = list_roots_from_slugs(&repo, &active_slugs, None, None);
+        assert!(!result.contains("- ****: (path unknown"), "empty slug must be excluded");
+        assert!(!result.contains("**external**"), "external must be excluded");
+        assert!(result.contains("only-real-zzz"), "real orphan must appear");
+        assert!(result.contains("1 root(s)"), "should show exactly 1 root");
+    }
+
     // ── list_roots_from_slugs stats tests ────────────────────────────────────
 
     use crate::graph::{Edge, EdgeKind};


### PR DESCRIPTION
## Summary

Filter out empty-string slugs from the orphaned-slug path in `list_roots_from_slugs()`, preventing stale LanceDB entries from pruned worktrees from appearing as ghost roots in the output.

Closes #380

## Problem

After pruning a worktree, LanceDB can retain nodes with an empty root slug. These leaked through the orphaned-slug path in `list_roots`, producing:

```
- ****: (path unknown — root was scanned but not in current config)
```

The `"external"` pseudo-slug was already excluded; empty slugs were not.

## Solution

**Selected:** Add `!s.is_empty()` guard to the orphaned filter (band-aid, appropriate here — stale LanceDB cleanup is a separate concern).

**One-line change:**
```rust
// Before
.filter(|s| !config_slugs.contains(*s) && *s != "external")
// After
.filter(|s| !s.is_empty() && !config_slugs.contains(*s) && *s != "external")
```

## Acceptance Criteria

- [x] Empty-slug entries never appear in `list_roots` output
- [x] `"external"` pseudo-slug continues to be filtered (existing behavior)
- [x] Two new unit tests verify the empty-slug filter
- [x] All 17 list_roots tests pass
- [x] `cargo check --lib` clean

## Test Plan

- [x] `cargo test list_roots` — 17/17 pass (15 existing + 2 new)
- [x] `cargo check --lib` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where empty slugs were incorrectly included in output results.

* **Tests**
  * Added test coverage for empty slug handling in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->