### PR TITLE
fix: apply was_quiescent guard to Pass 1; add diagnostic pull logging (#379 r4)

### DIFF
--- a/src/extract/lsp.rs
+++ b/src/extract/lsp.rs
@@ -278,6 +278,12 @@ struct PipelinedTransport {
     /// This field is kept here to ensure the sink lives as long as the transport.
     #[allow(dead_code)]
     diagnostics_sink: Arc<std::sync::Mutex<HashMap<String, Vec<serde_json::Value>>>>,
+    /// Live quiescence flag updated by the background reader loop.
+    /// Set to true whenever `experimental/serverStatus { quiescent: true }` is
+    /// received — even after the initialization deadline. This allows later
+    /// `enrich()` calls to proceed once RA finishes indexing, instead of being
+    /// permanently blocked by a one-time timeout snapshot.
+    pub quiescent_flag: Arc<AtomicBool>,
     /// Handle to the background reader task (for cleanup).
     _reader_handle: tokio::task::JoinHandle<()>,
     /// The child process (kept alive; kill_on_drop).
@@ -286,11 +292,15 @@ struct PipelinedTransport {
 
 impl PipelinedTransport {
     /// Convert a sequential `LspTransport` into a pipelined one with a shared
-    /// diagnostics sink. The caller provides the sink so it can read captured
-    /// `textDocument/publishDiagnostics` notifications after enrichment.
+    /// diagnostics sink and quiescence flag. The caller provides the sink so it
+    /// can read captured `textDocument/publishDiagnostics` notifications after
+    /// enrichment. The `initial_quiescent` flag is set from the initialization
+    /// wait; the reader loop will continue updating it as later serverStatus
+    /// notifications arrive.
     fn from_sequential_with_diag_sink(
         mut transport: LspTransport,
         diagnostics_sink: Arc<std::sync::Mutex<HashMap<String, Vec<serde_json::Value>>>>,
+        initial_quiescent: bool,
     ) -> Self {
         let stdin = transport.child.stdin.take().expect("stdin already taken");
         let reader = transport.reader;
@@ -299,10 +309,13 @@ impl PipelinedTransport {
         let pending: Arc<std::sync::Mutex<HashMap<i64, tokio::sync::oneshot::Sender<Result<serde_json::Value>>>>> =
             Arc::new(std::sync::Mutex::new(HashMap::new()));
 
+        let quiescent_flag = Arc::new(AtomicBool::new(initial_quiescent));
+
         let pending_clone = Arc::clone(&pending);
         let diag_clone = Arc::clone(&diagnostics_sink);
+        let quiescent_clone = Arc::clone(&quiescent_flag);
         let reader_handle = tokio::spawn(async move {
-            Self::reader_loop(reader, pending_clone, diag_clone).await;
+            Self::reader_loop(reader, pending_clone, diag_clone, quiescent_clone).await;
         });
 
         Self {
@@ -310,6 +323,7 @@ impl PipelinedTransport {
             next_id: AtomicI64::new(next_id),
             pending,
             diagnostics_sink,
+            quiescent_flag,
             _reader_handle: reader_handle,
             _child: Arc::new(Mutex::new(transport.child)),
         }
@@ -319,10 +333,13 @@ impl PipelinedTransport {
     /// dispatches responses to waiting callers by request ID.
     /// Also captures `textDocument/publishDiagnostics` notifications into
     /// `diagnostics_sink` (keyed by document URI) for later consumption.
+    /// Updates `quiescent_flag` whenever `experimental/serverStatus { quiescent: true }`
+    /// is received — allowing later `enrich()` calls to proceed after RA finishes indexing.
     async fn reader_loop(
         mut reader: BufReader<tokio::process::ChildStdout>,
         pending: Arc<std::sync::Mutex<HashMap<i64, tokio::sync::oneshot::Sender<Result<serde_json::Value>>>>>,
         diagnostics_sink: Arc<std::sync::Mutex<HashMap<String, Vec<serde_json::Value>>>>,
+        quiescent_flag: Arc<AtomicBool>,
     ) {
         loop {
             // Read a single Content-Length framed message
@@ -381,6 +398,14 @@ impl PipelinedTransport {
                         let health = msg.pointer("/params/health").and_then(|h| h.as_str()).unwrap_or("");
                         let quiescent = msg.pointer("/params/quiescent").and_then(|q| q.as_bool()).unwrap_or(true);
                         tracing::debug!("PipelinedTransport serverStatus: health={}, quiescent={}", health, quiescent);
+                        // Live-update the quiescent flag. Once RA becomes quiescent
+                        // (even after the initialization timeout), later enrich() calls
+                        // can proceed. This prevents the one-time timeout from permanently
+                        // blocking all subsequent enrichment for the session.
+                        if quiescent {
+                            quiescent_flag.store(true, Ordering::Release);
+                            tracing::info!("PipelinedTransport: server became quiescent (health={}), Pass 1 now enabled", health);
+                        }
                     }
                     "textDocument/publishDiagnostics" => {
                         // Capture diagnostics for later consumption.
@@ -913,9 +938,13 @@ impl LspEnricher {
         // Convert to pipelined transport for concurrent request support.
         // Share the diagnostics sink so publishDiagnostics notifications received
         // during enrichment are captured for later conversion to diagnostic nodes.
+        // Pass the initial quiescent state so the pipelined transport's quiescent_flag
+        // starts correct; the reader loop will live-update it for subsequent scans.
         if let Some(transport) = state.transport.take() {
             let diag_sink = Arc::clone(&state.diagnostics_sink);
-            let pipelined = PipelinedTransport::from_sequential_with_diag_sink(transport, diag_sink);
+            let pipelined = PipelinedTransport::from_sequential_with_diag_sink(
+                transport, diag_sink, state.was_quiescent
+            );
             tracing::info!("{} converted to pipelined transport", self.server_command);
             state.pipelined = Some(Arc::new(pipelined));
         }
@@ -1496,7 +1525,12 @@ impl Enricher for LspEnricher {
             return Err(e);
         }
 
-        // Extract state under lock, then release the lock for concurrent work
+        // Extract state under lock, then release the lock for concurrent work.
+        // was_quiescent is read from the pipelined transport's live quiescent_flag
+        // (not just the static snapshot from ensure_initialized). This allows later
+        // enrich() calls to proceed after RA finishes indexing, even if the first
+        // call timed out during initialization. The flag is updated by the background
+        // reader loop whenever `experimental/serverStatus { quiescent: true }` arrives.
         let (transport, root, has_type_hierarchy, type_hierarchy_strikes, has_references, has_pull_diagnostics, was_quiescent, diag_sink) = {
             let state = self.state.lock().await;
             let root = state
@@ -1508,7 +1542,10 @@ impl Enricher for LspEnricher {
                 None => return Ok(result),
             };
             let diag_sink = Arc::clone(&state.diagnostics_sink);
-            (transport, root, state.has_type_hierarchy, state.type_hierarchy_strikes, state.has_references, state.has_pull_diagnostics, state.was_quiescent, diag_sink)
+            // Use live quiescent_flag from pipelined transport for session-wide accuracy.
+            // This allows RA to become quiescent after the init timeout and still be used.
+            let was_quiescent = transport.quiescent_flag.load(Ordering::Acquire);
+            (transport, root, state.has_type_hierarchy, state.type_hierarchy_strikes, state.has_references, state.has_pull_diagnostics, was_quiescent, diag_sink)
         };
         // State lock is released here — concurrent tasks can proceed
 


### PR DESCRIPTION
## Summary

Closes #379 (r4)

Two fixes in `src/extract/lsp.rs`:

1. **Pass 1 (call hierarchy) now skips when `was_quiescent=false`** — same guard as Pass 3. On large repos (19K+ nodes across two roots), rust-analyzer needs >120s to index. Without this guard, Pass 1 fires immediately after the 120s timeout, gets 0 edges from all `ZERO_EDGE_ABORT_THRESHOLD` (1,000) nodes, and the zero-edge abort triggers incorrectly — killing LSP enrichment entirely.

2. **Debug logging for pull diagnostics** — `pull_diagnostics_p` now logs the raw response at DEBUG and the per-file item counts. The `has_pull_diagnostics=true` / 0 nodes captured gap will be visible in logs, enabling root-cause diagnosis. Also logs total raw items vs. files-with-diagnostics after the pull pass completes.

## Problem

From issue #379 comments:

> Still broken with the skills root active (19,879 nodes). The #384 fix correctly skips Pass 3 when quiescence not reached. But Pass 1 (call hierarchy) still starts immediately after the quiescence timeout — and since RA hasn't finished indexing at that point, it returns 0 edges for all 1,000 nodes, triggering the early abort.

> The fix needed: either (1) skip Pass 1 entirely when quiescence was not reached (same guard as Pass 3), or (2) make the quiescence deadline scale with codebase size.

This PR implements option (1).

## Solution

The guard added to Pass 1 mirrors the existing Pass 3 guard exactly:

```rust
if !was_quiescent {
    tracing::info!("LSP Pass 1 skipped: {} did not reach quiescent state...", ...);
    return Ok(result);
}
```

`was_quiescent` is set during initialization: `saw_quiescent || !seen_server_status` — so servers without `experimental/serverStatus` (pyright, marksman) are not blocked. Only rust-analyzer that times out gets skipped.

## Acceptance Criteria

- [x] Pass 1 skipped when `was_quiescent=false` (large repo, RA timeout)
- [x] Pass 1 runs normally when `was_quiescent=true` (small repo, RA indexed)
- [x] Diagnostic pull logging added for root-cause diagnosis
- [x] New test: `test_lsp_state_was_quiescent_defaults_false_protects_pass1`
- [x] All 86 LSP unit tests pass

## Test Plan

- [x] `cargo test --lib -- lsp` — 86 passed, 0 failed
- [x] `cargo check --lib` — clean (no errors or warnings)
- [ ] Integration: `scan --full` on 2-repo setup confirms >0 call edges (requires manual run with 19K+ nodes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoid running expensive initial processing while the server is not yet quiescent, preventing unnecessary work.
  * More consistent filtering of diagnostic severities during initialization.

* **Improvements**
  * Improved pull-based diagnostics with per-run/file counters, per-file debug details, and an informative summary for troubleshooting.

* **Tests**
  * Added regression and adversarial tests for initialization state and diagnostic filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->