### PR TITLE
feat: git blame metadata per symbol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6274,7 +6274,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "repo-native-alignment"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -39,6 +39,7 @@ use std::path::Path;
 
 use anyhow::Result;
 
+use crate::git::blame::BlameEnricher;
 use crate::graph::{Edge, Node};
 use crate::graph::index::GraphIndex;
 use crate::scanner::ScanResult;
@@ -127,6 +128,13 @@ pub trait Enricher: Send + Sync {
     /// Whether the enricher is ready to run.
     /// For LSP enrichers, this indicates the language server has finished indexing.
     fn is_ready(&self) -> bool;
+
+    /// Whether this enricher should run regardless of the languages detected in
+    /// the graph. Language-agnostic enrichers (e.g., git-blame) return `true`.
+    /// Default: `false` (only run when `languages()` overlaps graph languages).
+    fn runs_regardless_of_language(&self) -> bool {
+        false
+    }
 
     /// Enrich the graph with additional edges and metadata.
     ///
@@ -402,6 +410,9 @@ impl EnricherRegistry {
             registry.register(Box::new(enricher));
         }
 
+        // Language-agnostic enrichers run after language-specific ones.
+        registry.register(Box::new(BlameEnricher::new()));
+
         registry
     }
 
@@ -430,11 +441,14 @@ impl EnricherRegistry {
         );
 
         for enricher in &self.enrichers {
-            // Check if this enricher supports any language in the graph
-            let supported = enricher
-                .languages()
-                .iter()
-                .any(|lang| languages.iter().any(|l| l == lang));
+            // Check if this enricher supports any language in the graph, or
+            // if it explicitly opts in to running regardless of language
+            // (e.g., the git-blame enricher is language-agnostic).
+            let supported = enricher.runs_regardless_of_language()
+                || enricher
+                    .languages()
+                    .iter()
+                    .any(|lang| languages.iter().any(|l| l == lang));
             if !supported {
                 continue; // silently skip — too many servers to log each one
             }

--- a/src/git/blame.rs
+++ b/src/git/blame.rs
@@ -1,0 +1,294 @@
+//! Git blame enricher: annotates graph nodes with churn and authorship data.
+//!
+//! For each node, finds commits touching its `[line_start..=line_end]` range
+//! and records:
+//! - `churn_count` — number of distinct commits in the node's line range
+//! - `last_author` — author name of the most recent commit touching the range
+//! - `last_commit_sha` — 7-char abbreviated SHA of that commit
+//!
+//! Performance: blame is O(commits × file_lines), so we cache the full
+//! `BlameFile` per file path and map all nodes in that file in one pass.
+//!
+//! Failure modes: if the repository cannot be opened, blame fails for a file,
+//! or a node has no line range, the enricher silently skips that node.
+//! It never returns `Err` — it returns `Ok` with partial results so the
+//! rest of the pipeline continues unaffected.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::extract::{EnrichmentResult, Enricher};
+use crate::graph::{Node};
+use crate::graph::index::GraphIndex;
+
+/// Enricher that annotates nodes with git blame metadata.
+///
+/// Language-agnostic — runs on all nodes regardless of language.
+/// Registered in `EnricherRegistry::with_builtins()`.
+pub struct BlameEnricher;
+
+impl BlameEnricher {
+    pub fn new() -> Self {
+        BlameEnricher
+    }
+}
+
+impl Default for BlameEnricher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Per-line blame entry extracted from `git2::BlameHunk`.
+#[derive(Debug, Clone)]
+struct LineBlame {
+    /// 7-char SHA of the commit that last touched this line.
+    sha7: String,
+    /// Commit timestamp (Unix epoch), used to find the most recent commit.
+    commit_time: i64,
+    /// Author name from the final-commit hunk.
+    author: String,
+}
+
+/// Walk a `git2::Blame` for one file and return a `Vec<LineBlame>` indexed
+/// by 0-based line number (line N → `result[N]`).
+///
+/// Lines with no associated hunk (blank lines at EOF) are filled with a
+/// sentinel entry so the index is always safe to subscript.
+fn blame_to_line_vec(blame: &git2::Blame<'_>) -> Vec<Option<LineBlame>> {
+    // Pre-allocate with a reasonable capacity; we'll grow if needed.
+    let mut lines: Vec<Option<LineBlame>> = Vec::new();
+
+    for hunk in blame.iter() {
+        let start_line = hunk.final_start_line(); // 1-based
+        let line_count = hunk.lines_in_hunk();
+
+        let commit_id = hunk.final_commit_id();
+        let sha7 = format!("{:.7}", commit_id);
+        let commit_time = hunk.final_signature().when().seconds();
+        let author = hunk
+            .final_signature()
+            .name()
+            .unwrap_or("<unknown>")
+            .to_string();
+
+        let entry = LineBlame {
+            sha7,
+            commit_time,
+            author,
+        };
+
+        // Ensure vec is large enough (convert to 0-based)
+        let last_idx = start_line + line_count; // exclusive, 1-based → last 0-based slot +1
+        if lines.len() < last_idx {
+            lines.resize_with(last_idx, || None);
+        }
+
+        for line_idx in (start_line - 1)..(start_line - 1 + line_count) {
+            lines[line_idx] = Some(entry.clone());
+        }
+    }
+
+    lines
+}
+
+/// Given a slice of `LineBlame` entries covering `[line_start..=line_end]`
+/// (1-based, inclusive), compute:
+/// - distinct commit count (churn)
+/// - the most recent commit's SHA and author
+///
+/// Returns `None` if the range is empty or all entries are missing.
+fn summarize_range(
+    line_data: &[Option<LineBlame>],
+    line_start: usize,
+    line_end: usize,
+) -> Option<(usize, String, String)> {
+    if line_start == 0 || line_end == 0 || line_start > line_end {
+        return None;
+    }
+
+    // Convert 1-based inclusive to 0-based slice range
+    let lo = line_start.saturating_sub(1);
+    let hi = line_end.min(line_data.len()); // exclusive
+
+    if lo >= hi {
+        return None;
+    }
+
+    let mut shas: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut newest: Option<&LineBlame> = None;
+
+    for entry in line_data[lo..hi].iter().flatten() {
+        shas.insert(entry.sha7.as_str());
+        match newest {
+            None => newest = Some(entry),
+            Some(prev) if entry.commit_time > prev.commit_time => newest = Some(entry),
+            _ => {}
+        }
+    }
+
+    if shas.is_empty() {
+        return None;
+    }
+
+    let best = newest?;
+    Some((shas.len(), best.sha7.clone(), best.author.clone()))
+}
+
+#[async_trait::async_trait]
+impl Enricher for BlameEnricher {
+    fn name(&self) -> &str {
+        "git-blame"
+    }
+
+    /// Blame is language-agnostic — return the wildcard sentinel.
+    ///
+    /// `enrich_all` checks `runs_regardless_of_language()` and skips the
+    /// language filter for this enricher.
+    fn languages(&self) -> &[&str] {
+        &[]
+    }
+
+    /// Always run — blame is not tied to any specific language.
+    fn runs_regardless_of_language(&self) -> bool {
+        true
+    }
+
+    fn is_ready(&self) -> bool {
+        true
+    }
+
+    async fn enrich(
+        &self,
+        nodes: &[Node],
+        _index: &GraphIndex,
+        repo_root: &Path,
+    ) -> Result<EnrichmentResult> {
+        let repo = match git2::Repository::open(repo_root) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::info!("git-blame enricher: cannot open repo at {}: {}", repo_root.display(), e);
+                return Ok(EnrichmentResult::default());
+            }
+        };
+
+        // Group nodes by their file path to walk blame once per file.
+        let mut file_nodes: HashMap<PathBuf, Vec<usize>> = HashMap::new();
+        for (idx, node) in nodes.iter().enumerate() {
+            let file = PathBuf::from(&node.id.file);
+            file_nodes.entry(file).or_default().push(idx);
+        }
+
+        let mut updated_nodes: Vec<(String, BTreeMap<String, String>)> = Vec::new();
+
+        for (rel_path, node_indices) in &file_nodes {
+            // git2::blame_file requires a path relative to the workdir root.
+            let blame_result = repo.blame_file(rel_path, None);
+            let blame = match blame_result {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::debug!(
+                        "git-blame: skipping {} — blame failed: {}",
+                        rel_path.display(),
+                        e
+                    );
+                    continue;
+                }
+            };
+
+            let line_data = blame_to_line_vec(&blame);
+
+            for &idx in node_indices {
+                let node = &nodes[idx];
+                let line_start = node.line_start;
+                let line_end = node.line_end;
+
+                if let Some((churn, sha7, author)) =
+                    summarize_range(&line_data, line_start, line_end)
+                {
+                    let mut patches = BTreeMap::new();
+                    patches.insert("churn_count".to_string(), churn.to_string());
+                    patches.insert("last_commit_sha".to_string(), sha7);
+                    patches.insert("last_author".to_string(), author);
+                    updated_nodes.push((node.stable_id(), patches));
+                }
+            }
+        }
+
+        tracing::info!(
+            "git-blame enricher: annotated {} / {} nodes",
+            updated_nodes.len(),
+            nodes.len(),
+        );
+
+        Ok(EnrichmentResult {
+            updated_nodes,
+            any_enricher_ran: true,
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_summarize_range_empty() {
+        let data: Vec<Option<LineBlame>> = vec![];
+        assert!(summarize_range(&data, 0, 0).is_none());
+        assert!(summarize_range(&data, 1, 0).is_none()); // start > end
+    }
+
+    #[test]
+    fn test_summarize_range_single_commit() {
+        let entry = LineBlame {
+            sha7: "abc1234".to_string(),
+            commit_time: 1000,
+            author: "Alice".to_string(),
+        };
+        let data = vec![Some(entry.clone()), Some(entry.clone())];
+        // 1-based: lines 1..=2
+        let result = summarize_range(&data, 1, 2).unwrap();
+        assert_eq!(result.0, 1); // 1 distinct commit
+        assert_eq!(result.1, "abc1234");
+        assert_eq!(result.2, "Alice");
+    }
+
+    #[test]
+    fn test_summarize_range_multiple_commits() {
+        let a = LineBlame {
+            sha7: "aaa0001".to_string(),
+            commit_time: 500,
+            author: "Alice".to_string(),
+        };
+        let b = LineBlame {
+            sha7: "bbb0002".to_string(),
+            commit_time: 1500, // more recent
+            author: "Bob".to_string(),
+        };
+        let data = vec![Some(a), Some(b.clone()), Some(b)];
+        // lines 1..=3 — 2 distinct SHAs, Bob is most recent
+        let result = summarize_range(&data, 1, 3).unwrap();
+        assert_eq!(result.0, 2);
+        assert_eq!(result.2, "Bob");
+    }
+
+    #[test]
+    fn test_summarize_range_out_of_bounds() {
+        let entry = LineBlame {
+            sha7: "abc1234".to_string(),
+            commit_time: 1000,
+            author: "Alice".to_string(),
+        };
+        let data = vec![Some(entry)];
+        // Requesting lines 1..=10 but only 1 line of data — should not panic
+        let result = summarize_range(&data, 1, 10);
+        // Should return Some with data from the one available line
+        assert!(result.is_some());
+        let (churn, _, _) = result.unwrap();
+        assert_eq!(churn, 1);
+    }
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,3 +1,4 @@
+pub mod blame;
 pub mod pr_merges;
 
 use std::path::{Path, PathBuf};

--- a/src/service.rs
+++ b/src/service.rs
@@ -129,6 +129,7 @@ pub async fn search(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
 async fn search_flat(params: &SearchParams, query: Option<&str>, ctx: &SearchContext<'_>) -> String {
     let sort_by_complexity = params.sort_by.as_deref() == Some("complexity");
     let sort_by_importance = params.sort_by.as_deref() == Some("importance");
+    let sort_by_churn = params.sort_by.as_deref() == Some("churn");
     let complexity_search = params.min_complexity.is_some() || sort_by_complexity;
     let has_kind_filter = params.kind.is_some();
     let has_file_filter = params.file.is_some();
@@ -137,8 +138,8 @@ async fn search_flat(params: &SearchParams, query: Option<&str>, ctx: &SearchCon
     let has_browse_filter = has_kind_filter || has_file_filter || has_synthetic_filter || has_subsystem_filter;
 
     let query_str = query.unwrap_or("");
-    if query_str.is_empty() && !complexity_search && !sort_by_importance && !has_browse_filter {
-        return "Empty query. Please describe what you're looking for (or use kind, file, synthetic, min_complexity, sort_by=\"complexity\", or sort_by=\"importance\").".to_string();
+    if query_str.is_empty() && !complexity_search && !sort_by_importance && !sort_by_churn && !has_browse_filter {
+        return "Empty query. Please describe what you're looking for (or use kind, file, synthetic, min_complexity, sort_by=\"complexity\", sort_by=\"importance\", or sort_by=\"churn\").".to_string();
     }
 
     let search_mode = parse_search_mode(params.search_mode.as_deref());
@@ -149,7 +150,7 @@ async fn search_flat(params: &SearchParams, query: Option<&str>, ctx: &SearchCon
     // Try embedding-ranked code symbol search first; fall back to name/signature matching.
     let matches: Vec<&Node> = flat_code_symbol_search(
         query_str, search_mode, limit, params, graph_state, ctx,
-        sort_by_complexity, sort_by_importance,
+        sort_by_complexity, sort_by_importance, sort_by_churn,
     ).await;
 
     if !matches.is_empty() {
@@ -216,6 +217,7 @@ async fn flat_code_symbol_search<'a>(
     ctx: &SearchContext<'_>,
     sort_by_complexity: bool,
     sort_by_importance: bool,
+    sort_by_churn: bool,
 ) -> Vec<&'a Node> {
     let query_lower = query_str.to_lowercase();
     let complexity_search = params.min_complexity.is_some() || sort_by_complexity;
@@ -377,6 +379,19 @@ async fn flat_code_symbol_search<'a>(
                 (None, None) => std::cmp::Ordering::Equal,
             }
         });
+    } else if sort_by_churn {
+        // Sort by git churn_count descending (highest-churn symbols first).
+        // Nodes without blame metadata sort last.
+        matches.sort_by(|a, b| {
+            let ca = a.metadata.get("churn_count").and_then(|s| s.parse::<u64>().ok());
+            let cb = b.metadata.get("churn_count").and_then(|s| s.parse::<u64>().ok());
+            match (ca, cb) {
+                (Some(a), Some(b)) => b.cmp(&a),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            }
+        });
     } else if !used_embed {
         // Only apply name-match ranking for fallback results; embed results
         // are already ranked by the embedding index.
@@ -389,8 +404,8 @@ async fn flat_code_symbol_search<'a>(
     // model that attends to (query, document) pairs jointly. This produces more
     // precise relevance scores than bi-encoder similarity alone.
     // Skip reranking when an explicit sort_by mode is active (complexity,
-    // importance) -- the caller's sort request takes precedence.
-    let use_relevance_sort = !sort_by_complexity && !sort_by_importance;
+    // importance, churn) -- the caller's sort request takes precedence.
+    let use_relevance_sort = !sort_by_complexity && !sort_by_importance && !sort_by_churn;
     if params.rerank && use_relevance_sort && !query_str.is_empty() && matches.len() > 1 {
         use crate::rerank::{RerankCandidate, rerank_results};
 
@@ -1166,7 +1181,7 @@ mod tests {
         let params = SearchParams { query: Some("auth".into()), ..Default::default() };
 
         let results = flat_code_symbol_search(
-            "auth", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "auth", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1);
@@ -1184,7 +1199,7 @@ mod tests {
         let params = SearchParams { query: Some("auth_token".into()), ..Default::default() };
 
         let results = flat_code_symbol_search(
-            "auth_token", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "auth_token", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1);
@@ -1208,7 +1223,7 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "config", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "config", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1);
@@ -1231,7 +1246,7 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "handler", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "handler", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1);
@@ -1255,7 +1270,7 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "parse", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "parse", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1);
@@ -1279,7 +1294,7 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "", SearchMode::Hybrid, 10, &params, &gs, &ctx, true, false,
+            "", SearchMode::Hybrid, 10, &params, &gs, &ctx, true, false, false,
         ).await;
 
         assert_eq!(results.len(), 2);
@@ -1305,11 +1320,39 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, true,
+            "", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, true, false,
         ).await;
 
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].id.name, "hub");
+    }
+
+    /// sort_by=churn works: nodes with higher churn_count sort first.
+    #[tokio::test]
+    async fn test_flat_search_sort_by_churn() {
+        let mut stable = make_node("stable_fn", NodeKind::Function, "a.rs");
+        stable.metadata.insert("churn_count".into(), "2".into());
+        let mut churned = make_node("churned_fn", NodeKind::Function, "b.rs");
+        churned.metadata.insert("churn_count".into(), "17".into());
+        let mut no_blame = make_node("no_blame_fn", NodeKind::Function, "c.rs");
+        // no_blame has no churn_count metadata — should sort last
+        let gs = make_graph_state(vec![stable, churned, no_blame.clone()]);
+        let repo_root = PathBuf::from("/tmp/test");
+        let ctx = make_search_context(&gs, &repo_root);
+        let params = SearchParams {
+            kind: Some("function".into()),
+            sort_by: Some("churn".into()),
+            ..Default::default()
+        };
+
+        let results = flat_code_symbol_search(
+            "", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, true,
+        ).await;
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].id.name, "churned_fn");  // highest churn first
+        assert_eq!(results[1].id.name, "stable_fn");   // lower churn second
+        assert_eq!(results[2].id.name, "no_blame_fn"); // no metadata last
     }
 
     /// search_mode is parsed correctly for all variants.
@@ -1373,7 +1416,7 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1);
@@ -1405,7 +1448,7 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "handler", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "handler", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1, "Only one node should pass all three filters");
@@ -1428,7 +1471,7 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "fn", SearchMode::Hybrid, 5, &params, &gs, &ctx, false, false,
+            "fn", SearchMode::Hybrid, 5, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 5, "Should respect limit of 5 even with 20 matches");
@@ -1454,7 +1497,7 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "handler", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "handler", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1, "Should only return nodes from matching root");
@@ -1478,7 +1521,7 @@ mod tests {
             ..Default::default()
         };
         let results = flat_code_symbol_search(
-            "", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id.name, "CONSTANT");
@@ -1490,7 +1533,7 @@ mod tests {
             ..Default::default()
         };
         let results2 = flat_code_symbol_search(
-            "", SearchMode::Hybrid, 10, &params2, &gs, &ctx, false, false,
+            "", SearchMode::Hybrid, 10, &params2, &gs, &ctx, false, false, false,
         ).await;
         assert_eq!(results2.len(), 1);
         assert_eq!(results2[0].id.name, "real_fn");
@@ -1520,7 +1563,7 @@ mod tests {
         // Single match means reranking block is skipped (len() > 1 guard),
         // so no model loading occurs.
         let results = flat_code_symbol_search(
-            "auth", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "auth", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
         assert!(!results.is_empty(), "Rerank=true should not prevent results from appearing");
     }
@@ -1539,7 +1582,7 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "foo", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "foo", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id.name, "foo");
@@ -1830,7 +1873,7 @@ mod tests {
         let params = SearchParams { query: Some("auth/handlers/validate".into()), ..Default::default() };
 
         let results = flat_code_symbol_search(
-            "auth/handlers/validate", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "auth/handlers/validate", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1, "Only auth/handlers validate should match");
@@ -1851,7 +1894,7 @@ mod tests {
         let params = SearchParams { query: Some("validate".into()), ..Default::default() };
 
         let results = flat_code_symbol_search(
-            "validate", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "validate", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 2, "Plain query returns all matches");
@@ -1907,7 +1950,7 @@ mod tests {
         let params = SearchParams::default();
 
         let results = flat_code_symbol_search(
-            "auth/new", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "auth/new", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1, "Path filter should discriminate to only auth node");
@@ -1935,7 +1978,7 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "scan", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "scan", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1, "Only scanner-subsystem node should match");
@@ -1957,7 +2000,7 @@ mod tests {
         };
 
         let results = flat_code_symbol_search(
-            "handler", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false,
+            "handler", SearchMode::Hybrid, 10, &params, &gs, &ctx, false, false, false,
         ).await;
 
         assert_eq!(results.len(), 1, "Case-insensitive subsystem match should work");


### PR DESCRIPTION
## Summary

Adds a `BlameEnricher` that runs after graph extraction and annotates each node with git blame metadata: commit churn, last author, and most recent SHA. Also adds `sort_by="churn"` support so agents can query high-churn symbols.

Closes #394

## Problem

RNA extracts git commits but doesn't attribute them to individual symbols. Agents can't answer "which functions in outcome X have the highest churn?" or "who last changed this function?"

## Solution

**Selected:** File-cached blame enricher via `git2::blame_file()` with `runs_regardless_of_language()` trait extension
**Level:** Local optimum — extends existing enricher pattern without restructuring

Walk blame once per file, map line ranges to nodes in O(N) per file. Avoids the O(nodes × files) cost of calling blame per node.

The `Enricher` trait gains a `runs_regardless_of_language()` method (default `false`) so the language-agnostic blame enricher bypasses the language filter in `enrich_all` without requiring a wildcard sentinel or special-case logic in the registry.

## Changes

- `src/git/blame.rs` — new `BlameEnricher` implementing `Enricher` trait
- `src/git/mod.rs` — `pub mod blame` declaration
- `src/extract/mod.rs` — `runs_regardless_of_language()` default method on `Enricher` trait; updated `enrich_all` filter; registered `BlameEnricher` in `with_builtins()`
- `src/service.rs` — `sort_by="churn"` sort mode; updated `flat_code_symbol_search` signature + all call sites; new `test_flat_search_sort_by_churn` test

## Acceptance Criteria

- [x] `churn_count` — number of commits touching this node's line range
- [x] `last_author` — author of the most recent such commit
- [x] `last_commit_sha` — 7-char SHA of the most recent commit
- [x] Skip gracefully when git isn't available or blame fails
- [x] Cache blame results per file, not per node
- [x] `sort_by="churn"` queryable

## Test Plan

- [x] `git::blame::tests::test_summarize_range_*` (4 tests) — unit tests for line range aggregation
- [x] `service::tests::test_flat_search_sort_by_churn` — sort ordering test
- [ ] CI: smoke tests + cargo test --lib