### PR TITLE
fix: address review findings from #413

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -500,7 +500,14 @@ async fn search_traversal(params: &SearchParams, query: Option<&str>, node: Opti
         // No node specified: return all rings.
         let rings = gs.index.detect_cycles(edge_filter_slice);
         if rings.is_empty() {
-            return format!("## Circular dependency analysis\n\nNo cycles detected in the coupling graph (Calls + DependsOn edges).{freshness}");
+            let scope = match edge_filter_slice {
+                Some(kinds) if !kinds.is_empty() => {
+                    let labels: Vec<String> = kinds.iter().map(|k| format!("{k}")).collect();
+                    format!("filtered edges: {}", labels.join(", "))
+                }
+                _ => "default coupling graph (Calls + DependsOn)".to_string(),
+            };
+            return format!("## Circular dependency analysis\n\nNo cycles detected in the {scope}.{freshness}");
         }
         let mut out = format!("## Circular dependency analysis\n\n{} ring(s) detected\n\n", rings.len());
         for (i, ring) in rings.iter().enumerate() {


### PR DESCRIPTION
Fixes the one unaddressed CodeRabbit finding from PR #413 that was posted after the final comment sweep step.

## Finding

CodeRabbit (Minor): The "no cycles detected" message in `service.rs` hardcodes `"Calls + DependsOn edges"` even when the caller passed a narrower `edge_types` filter. This misleads users about what was actually analyzed.

## Fix

Replaced the hardcoded string with a dynamic description derived from `edge_filter_slice`:
- If no filter (default): `"default coupling graph (Calls + DependsOn)"`
- If filtered: `"filtered edges: Calls"` (or whatever edge types were passed)

## Test plan

- [x] `cargo test --lib` — 1008 passed, 0 failed
- [x] `cargo check --lib` — clean