### PR TITLE
fix: guard strip_quotes against 1-char captures to avoid panic

### DIFF
--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -1152,9 +1152,12 @@ fn parse_import_target(import_text: &str) -> String {
 /// metadata stores the bare path.
 fn strip_quotes(s: &str) -> String {
     let s = s.trim();
-    if (s.starts_with('"') && s.ends_with('"'))
-        || (s.starts_with('\'') && s.ends_with('\''))
-        || (s.starts_with('`') && s.ends_with('`'))
+    // Guard: must be at least 2 chars so slicing `s[1..s.len()-1]` is safe.
+    // A single quote/backtick character would panic without this guard.
+    if s.len() >= 2
+        && ((s.starts_with('"') && s.ends_with('"'))
+            || (s.starts_with('\'') && s.ends_with('\''))
+            || (s.starts_with('`') && s.ends_with('`')))
     {
         s[1..s.len() - 1].to_string()
     } else {


### PR DESCRIPTION
## Summary

Fixes a Minor CodeRabbit finding from #412 that wasn't addressed before merge.

Closes the unaddressed comment from https://github.com/open-horizon-labs/repo-native-alignment/pull/412#discussion_r2079427547

## Problem

In `strip_quotes()` in `src/extract/generic.rs`, if a tree-sitter query produces a single-character capture (e.g. just a `"` or `'` or `` ` `` character), the slice `s[1..s.len()-1]` would panic because `s.len()-1 = 0 < 1`.

This is the CodeRabbit suggestion verbatim: add a `s.len() >= 2` guard before the slice.

## Fix

Add length guard: only strip quotes if the string is at least 2 characters long. For a 1-char string, the original string is returned unchanged (no stripping).

This is safe for all normal string literal captures (they will always be at least 2 chars: open + close quote), and prevents any theoretical panic path if a malformed capture reaches the function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes when processing quoted strings, improving application stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->