### PR TITLE
feat: persist doc_comment in symbols table for LSP reindex round-trip

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -14,7 +14,7 @@ use arrow_schema::{DataType, Field, Schema};
 /// The server auto-drops and rebuilds all LanceDB tables when this mismatches
 /// the stored version. No manual cache deletion needed.
 /// Also surfaced in the index freshness footer on `search`.
-pub const SCHEMA_VERSION: u32 = 14;
+pub const SCHEMA_VERSION: u32 = 15;
 
 /// Extraction version for source-level extraction logic.
 ///
@@ -47,6 +47,7 @@ pub const EXTRACTION_VERSION: u32 = 2;
 /// - `diagnostic_timestamp` — unix timestamp (seconds) when diagnostic was captured
 /// - `http_method`  — HTTP verb for ApiEndpoint nodes ("GET", "POST", etc.)
 /// - `http_path`    — HTTP path for ApiEndpoint nodes ("/users", "/items/{id}", etc.)
+/// - `doc_comment`  — documentation comment extracted by tree-sitter (#416)
 ///
 /// bump SCHEMA_VERSION in store.rs when changing this
 pub fn symbols_schema() -> Schema {
@@ -87,6 +88,8 @@ pub fn symbols_schema() -> Schema {
         // ApiEndpoint columns — populated for NodeKind::ApiEndpoint nodes
         Field::new("http_method", DataType::Utf8, true),    // "GET" | "POST" | "PUT" | etc.
         Field::new("http_path", DataType::Utf8, true),      // "/users" | "/items/{id}" | etc.
+        // Doc comment column — survives LSP reindex round-trip (#416)
+        Field::new("doc_comment", DataType::Utf8, true),    // metadata["doc_comment"] — documentation comment
         // Vector column is added dynamically when embeddings are computed,
         // since the dimension depends on the model. See `symbols_schema_with_vector`.
         Field::new("updated_at", DataType::Int64, false),
@@ -134,6 +137,8 @@ pub fn symbols_schema_with_vector(dim: i32) -> Schema {
         // ApiEndpoint columns — populated for NodeKind::ApiEndpoint nodes
         Field::new("http_method", DataType::Utf8, true),
         Field::new("http_path", DataType::Utf8, true),
+        // Doc comment column — survives LSP reindex round-trip (#416)
+        Field::new("doc_comment", DataType::Utf8, true),
         Field::new(
             "vector",
             DataType::FixedSizeList(
@@ -214,8 +219,8 @@ mod tests {
 
     #[test]
     fn test_schema_version_constant() {
-        // SCHEMA_VERSION must be at least 13 (bumped for ApiEndpoint http_method/http_path columns)
-        assert!(SCHEMA_VERSION >= 13, "SCHEMA_VERSION should be >= 13");
+        // SCHEMA_VERSION must be at least 15 (bumped for doc_comment column #416)
+        assert!(SCHEMA_VERSION >= 15, "SCHEMA_VERSION should be >= 15");
     }
 
     #[test]
@@ -256,6 +261,8 @@ mod tests {
         // ApiEndpoint columns (added for NodeKind::ApiEndpoint nodes)
         assert!(schema.field_with_name("http_method").is_ok());
         assert!(schema.field_with_name("http_path").is_ok());
+        // doc_comment column — survives LSP reindex round-trip (#416)
+        assert!(schema.field_with_name("doc_comment").is_ok());
         assert!(schema.field_with_name("updated_at").is_ok());
         // no vector column in base schema
         assert!(schema.field_with_name("vector").is_err());

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -540,6 +540,10 @@ pub(crate) async fn persist_graph_to_lance(
         let http_paths: Vec<Option<String>> = nodes.iter()
             .map(|n| n.metadata.get("http_path").cloned())
             .collect();
+        // doc_comment column — persisted for LSP reindex round-trip (#416)
+        let doc_comments: Vec<Option<String>> = nodes.iter()
+            .map(|n| n.metadata.get("doc_comment").cloned())
+            .collect();
         let updated_ats: Vec<i64> = vec![now; nodes.len()];
 
         let batch = RecordBatch::try_new(
@@ -578,6 +582,7 @@ pub(crate) async fn persist_graph_to_lance(
                 Arc::new(StringArray::from(diag_timestamps)),
                 Arc::new(StringArray::from(http_methods)),
                 Arc::new(StringArray::from(http_paths)),
+                Arc::new(StringArray::from(doc_comments)),
                 Arc::new(Int64Array::from(updated_ats)),
             ],
         )?;
@@ -854,6 +859,10 @@ pub(crate) async fn persist_graph_incremental(
             let http_paths: Vec<Option<String>> = upsert_nodes.iter()
                 .map(|n| n.metadata.get("http_path").cloned())
                 .collect();
+            // doc_comment column — persisted for LSP reindex round-trip (#416)
+            let doc_comments: Vec<Option<String>> = upsert_nodes.iter()
+                .map(|n| n.metadata.get("doc_comment").cloned())
+                .collect();
             let updated_ats: Vec<i64> = vec![now; upsert_nodes.len()];
 
             let batch = RecordBatch::try_new(
@@ -892,6 +901,7 @@ pub(crate) async fn persist_graph_incremental(
                     Arc::new(StringArray::from(diag_timestamps)),
                     Arc::new(StringArray::from(http_methods)),
                     Arc::new(StringArray::from(http_paths)),
+                    Arc::new(StringArray::from(doc_comments)),
                     Arc::new(Int64Array::from(updated_ats)),
                 ],
             )?;
@@ -1129,6 +1139,9 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>());
             let http_path_col = batch.column_by_name("http_path")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+            // doc_comment column — survives LSP reindex round-trip (#416)
+            let doc_comment_col = batch.column_by_name("doc_comment")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
 
             for i in 0..batch.num_rows() {
                 let file_path = PathBuf::from(file_paths.value(i));
@@ -1284,6 +1297,14 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                         let val = col.value(i);
                         if !val.is_empty() {
                             metadata.insert("http_path".to_string(), val.to_string());
+                        }
+                    }
+                }
+                if let Some(col) = doc_comment_col {
+                    if !col.is_null(i) {
+                        let val = col.value(i);
+                        if !val.is_empty() {
+                            metadata.insert("doc_comment".to_string(), val.to_string());
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- Adds `doc_comment` as a nullable `Utf8` Arrow column to `symbols_schema()` and `symbols_schema_with_vector()` in `src/graph/store.rs`
- Wires `doc_comment` through both write paths (initial batch + upsert/merge batch) in `src/server/store.rs`
- Adds `doc_comment` to the read path (Arrow → `Node.metadata`) in `src/server/store.rs`
- Bumps `SCHEMA_VERSION` 14 → 15 to trigger auto-rebuild of LanceDB tables

## Problem

PR #415 added doc comment extraction to `Node.metadata["doc_comment"]` and used it in `build_code_embedding_text()`. However the `symbols` table had no `doc_comment` column, so LSP reindex calls (`reindex_nodes()`) loaded nodes from the table without doc comments, losing them from embedding text on subsequent reindex passes.

## Test plan

- [x] `cargo check --lib` passes
- [x] All 8 `graph::store` unit tests pass (schema field assertions, version constant assertions)
- [x] `test_symbols_schema_fields` now asserts `doc_comment` field is present
- [x] `test_schema_version_constant` updated to assert `SCHEMA_VERSION >= 15`

Closes #416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Symbol metadata now includes documentation comments that are automatically persisted and retrieved during sync and load operations.

* **Updates**
  * Database schema updated to version 15 to support the new documentation comment field for symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->