### PR TITLE
fix: address review findings from #432

### DIFF
--- a/src/extract/graphql.rs
+++ b/src/extract/graphql.rs
@@ -573,17 +573,21 @@ fn extract_type_text(node: tree_sitter::Node<'_>, source: &[u8]) -> String {
 }
 
 /// Strip GraphQL type modifiers (!, []) to get the bare type name.
+///
+/// Handles arbitrary nesting: `[[User!]!]!` → `User`.
 fn strip_type_modifiers(type_str: &str) -> &str {
-    let s = type_str.trim();
-    // Strip outer non-null
-    let s = s.trim_end_matches('!');
-    let s = s.trim();
-    // Strip list wrapper
-    if s.starts_with('[') && s.ends_with(']') {
-        s[1..s.len() - 1].trim_end_matches('!').trim()
-    } else {
-        s.trim_end_matches('!')
+    let mut s = type_str.trim();
+    loop {
+        let prev = s;
+        s = s.trim_end_matches('!').trim();
+        if s.starts_with('[') && s.ends_with(']') {
+            s = s[1..s.len() - 1].trim();
+        }
+        if s == prev {
+            break;
+        }
     }
+    s
 }
 
 /// Returns true if the name is a built-in GraphQL scalar type.
@@ -921,6 +925,9 @@ type Tag {
         assert_eq!(strip_type_modifiers("[User!]!"), "User");
         assert_eq!(strip_type_modifiers("[User]"), "User");
         assert_eq!(strip_type_modifiers("User"), "User");
+        // Nested list types (rare but valid GraphQL)
+        assert_eq!(strip_type_modifiers("[[User!]!]!"), "User");
+        assert_eq!(strip_type_modifiers("[[String]]"), "String");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a minor finding from CodeRabbit review on #432 (GraphQL schema extractor).

- `strip_type_modifiers` only handled single-level list wrappers. `[[User!]!]!` would return `[User!]` instead of `User`.
- Updated to use an iterative loop that strips all nesting levels.
- Added test cases for `[[User!]!]!` and `[[String]]`.

## Impact

Low: nested list types are valid GraphQL but rare in practice. The only effect of the bug was that `DependsOn` edges from fields with nested list types to their base type would not be emitted. No incorrect data was produced — the fallback was safe (non-matching type names produce no edge).

## Test plan

- [x] `cargo test --lib extract::graphql` — 12 tests pass (including 2 new nested list cases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GraphQL schema parsing to correctly handle complex nested type definitions with multiple modifiers.

* **Tests**
  * Extended test coverage to verify correct behavior with nested type scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->