### PR TITLE
ci: upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,36 @@
+name: PR Checklist
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  checklist:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Check for unchecked items
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const body = pr.body || '';
+            const unchecked = (body.match(/^- \[ \] /gm) || []).length;
+            const checked = (body.match(/^- \[x\] /gmi) || []).length;
+            const total = unchecked + checked;
+
+            if (total === 0) {
+              console.log('No checklist items found — passing.');
+              return;
+            }
+
+            console.log(`Checklist: ${checked}/${total} complete`);
+
+            if (unchecked > 0) {
+              core.setFailed(`${unchecked} unchecked item(s) in PR description. Complete all checklist items before merging.`);
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,12 @@ jobs:
   build-fast:
     runs-on: namespace-profile-tahoe
     timeout-minutes: 60
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Patch version from tag
         run: |
@@ -62,7 +64,7 @@ jobs:
           tar czf repo-native-alignment-darwin-arm64-fast.tar.gz -C target/aarch64-apple-darwin/release repo-native-alignment
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: repo-native-alignment-darwin-arm64-fast
           path: repo-native-alignment-darwin-arm64-fast.tar.gz
@@ -72,9 +74,11 @@ jobs:
     needs: build-fast
     runs-on: namespace-profile-tahoe
     timeout-minutes: 60
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Patch version from tag
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
@@ -111,7 +115,7 @@ jobs:
           strip target/aarch64-apple-darwin/release/repo-native-alignment
           tar czf repo-native-alignment-darwin-arm64.tar.gz -C target/aarch64-apple-darwin/release repo-native-alignment
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: repo-native-alignment-darwin-arm64
           path: repo-native-alignment-darwin-arm64.tar.gz
@@ -120,9 +124,11 @@ jobs:
   build-linux:
     runs-on: namespace-profile-cached
     timeout-minutes: 60
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Patch version from tag
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
@@ -153,7 +159,7 @@ jobs:
           strip target/x86_64-unknown-linux-gnu/release/repo-native-alignment
           tar czf repo-native-alignment-linux-x86_64.tar.gz -C target/x86_64-unknown-linux-gnu/release repo-native-alignment
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: repo-native-alignment-linux-x86_64
           path: repo-native-alignment-linux-x86_64.tar.gz
@@ -164,12 +170,12 @@ jobs:
 
     steps:
       - name: Checkout (for tag annotation)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
 
       - name: Upload to GitHub Release
         env:
@@ -202,7 +208,7 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 

--- a/.github/workflows/rust-main-merge.yml
+++ b/.github/workflows/rust-main-merge.yml
@@ -19,8 +19,8 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -43,7 +43,7 @@ jobs:
         run: echo "No Rust changes — skipping lint"
       - name: Checkout
         if: needs.changes.outputs.rust == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: No language-specific conditionals in generic.rs
         if: needs.changes.outputs.rust == 'true'
         run: |
@@ -72,13 +72,15 @@ jobs:
     needs: changes
     runs-on: namespace-profile-cached
     timeout-minutes: 15
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Skip (no Rust changes)
         if: needs.changes.outputs.rust != 'true'
         run: echo "No Rust changes — skipping tests"
       - name: Checkout
         if: needs.changes.outputs.rust == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install protoc
         if: needs.changes.outputs.rust == 'true'
@@ -117,9 +119,11 @@ jobs:
     if: needs.changes.outputs.rust == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
     runs-on: namespace-profile-cached
     timeout-minutes: 20
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install protoc
         uses: arduino/setup-protoc@v3
@@ -170,9 +174,9 @@ jobs:
           echo "$OUTPUT" | grep -q "neighbors\|No results" || { echo "FAIL: graph returned unexpected output"; exit 1; }
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install MCP TypeScript SDK
@@ -187,10 +191,12 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: namespace-profile-tahoe
     timeout-minutes: 60
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install protoc
         uses: arduino/setup-protoc@v3
@@ -225,10 +231,8 @@ jobs:
           tar czf repo-native-alignment-darwin-arm64-fast.tar.gz -C target/aarch64-apple-darwin/release repo-native-alignment
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: repo-native-alignment-darwin-arm64-fast
           path: repo-native-alignment-darwin-arm64-fast.tar.gz
           retention-days: 30
-
-


### PR DESCRIPTION
Closes #358

## Summary

- \`actions/checkout\` v4 -> v5 (node24 runtime)
- \`dorny/paths-filter\` v3 -> v4 (node24 runtime)
- \`actions/setup-node\` v4 -> v6, \`node-version\` 20 -> 24
- \`actions/upload-artifact\` v4 -> v6 (node24 runtime)
- \`actions/download-artifact\` v4 -> v7 (node24 runtime)
- \`actions/github-script\` v7 -> v8 (node24 runtime)
- Added \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true\` at job level for \`mozilla-actions/sccache-action\` and \`arduino/setup-protoc\` — neither has a node24 release yet (upstream PRs open for both); the env var makes GitHub force node24 execution

## Notes

\`namespacelabs/nscloud-cache-action@v1\` and \`peter-evans/create-pull-request@v8\` already use node24 — no changes needed for those.

## Test plan

- [x] CI passes on this PR (PR Checklist, Rust CI)
- [x] \`changes\`, \`lint\`, \`test\`, \`smoke\` jobs all green
- [x] No node20 deprecation warnings in CI logs