### PR TITLE
fix: detect Arrow schema mismatch in incremental persist and auto-recover

### DIFF
--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -404,7 +404,14 @@ fn drop_all_lance_tables(db_path: &Path) {
     if let Ok(entries) = std::fs::read_dir(db_path) {
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.file_name().map(|n| n == "schema_version").unwrap_or(false) {
+            // Preserve both version files: schema_version is rewritten below;
+            // extraction_version must survive so the next extraction-version bump
+            // still triggers its scan-state reset correctly.
+            if path
+                .file_name()
+                .map(|n| n == "schema_version" || n == "extraction_version")
+                .unwrap_or(false)
+            {
                 continue;
             }
             if path.is_dir() {
@@ -1696,7 +1703,9 @@ mod tests {
         assert!(!is_schema_mismatch_error(&not_found));
     }
 
-    /// `drop_all_lance_tables` removes table directories and resets the schema_version file.
+    /// `drop_all_lance_tables` removes table directories, resets the schema_version file,
+    /// and preserves the extraction_version file so the next version bump still triggers
+    /// its scan-state reset correctly.
     #[test]
     fn test_drop_all_lance_tables_clears_dirs_and_resets_version() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1707,6 +1716,8 @@ mod tests {
         std::fs::create_dir_all(db_path.join("symbols.lance")).unwrap();
         std::fs::create_dir_all(db_path.join("edges.lance")).unwrap();
         std::fs::write(db_path.join("schema_version"), "9").unwrap();
+        // extraction_version must survive the cleanup.
+        std::fs::write(db_path.join("extraction_version"), "42").unwrap();
 
         drop_all_lance_tables(&db_path);
 
@@ -1717,6 +1728,11 @@ mod tests {
         // schema_version should be reset to SCHEMA_VERSION.
         let written = std::fs::read_to_string(db_path.join("schema_version")).unwrap();
         assert_eq!(written, SCHEMA_VERSION.to_string());
+
+        // extraction_version must be preserved so subsequent extraction-version bumps
+        // still trigger their scan-state reset correctly.
+        let ev = std::fs::read_to_string(db_path.join("extraction_version")).unwrap();
+        assert_eq!(ev, "42", "extraction_version must survive drop_all_lance_tables");
     }
 
     /// After a schema mismatch during incremental persist, `persist_graph_incremental`


### PR DESCRIPTION
## Summary

Fixes #356.

The pre-flight `check_and_migrate_schema` guard uses a `schema_version` file to detect version bumps. If that file is in sync while the LanceDB tables themselves are stale (partial cache clear, file copied without tables, etc.), the file-level check passes and `merge_insert` fails with an Arrow schema error that surfaces as a generic failure.

This PR adds a second line of defence directly in the `merge_insert` error paths:

- **`is_schema_mismatch_error`** — matches Arrow/LanceDB schema error message substrings (`schema`, `column not found`, `field not found`, `type mismatch`, `invalid recordbatch`)
- **`drop_all_lance_tables`** — drops all table directories in the LanceDB path and resets `schema_version`, mirroring what `check_and_migrate_schema` does
- Both the **symbols** and **edges** `merge_insert` loops now check for schema mismatch before the conflict-retry path, drop stale tables, and return `Ok(true)` so `graph.rs` triggers `persist_graph_to_lance` (full rebuild)

The caller path in `graph.rs` already handles `Ok(true)` by calling `persist_graph_to_lance` — no changes needed there.

## Changes

- `src/server/store.rs` only

## Tests

3 new unit tests, all passing alongside the existing 12 store tests (15 total):

- `test_is_schema_mismatch_error_detection` — verifies the helper matches expected phrases and rejects unrelated errors
- `test_drop_all_lance_tables_clears_dirs_and_resets_version` — verifies table dirs are removed and `schema_version` is reset
- `test_incremental_persist_recovers_from_schema_mismatch` — verifies that after dropping tables, a subsequent `persist_graph_incremental` succeeds without panic

## Test plan

- [x] `cargo check --lib` passes (no new errors or warnings)
- [x] `cargo test --lib -- store::tests` — 15/15 pass
- [x] Manual: simulate a mismatch by upgrading RNA with a stale LanceDB cache — first incremental scan should log "LanceDB schema mismatch detected" and automatically recover to a full rebuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database error recovery: automatic detection of schema mismatches now clears corrupted state and resets schema to enable seamless recovery without manual intervention.
* **Tests**
  * Added tests covering schema-mismatch detection and the recovery path to improve reliability and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->