### PR TITLE
fix: deduplicate graph.nodes to prevent manifest node accumulation

### DIFF
--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -954,8 +954,8 @@ impl RnaHandler {
 
         // Re-run manifest pass with the primary root so that changes to
         // package.json, pyproject.toml, requirements.txt, or go.mod are
-        // reflected in the incremental graph. Package nodes from previous
-        // passes are harmlessly overwritten (same stable_id, same data).
+        // reflected in the incremental graph. Duplicate package nodes from
+        // repeated runs are deduplicated below before the petgraph rebuild.
         {
             let root_pairs = vec![(primary_slug.clone(), self.repo_root.clone())];
             let manifest_result = crate::extract::manifest::manifest_pass(&root_pairs);
@@ -1011,16 +1011,27 @@ impl RnaHandler {
             }
         }
 
-        // Deduplicate graph.edges in-place before rebuilding the petgraph index.
-        // Post-extraction passes (api_link, manifest, tested_by, directory_module) re-run
-        // over the full node set on every incremental scan, which causes the same edges to
-        // be appended to graph.edges repeatedly.  After N scans each edge appears
-        // N times, inflating PageRank weights for the connected nodes.
+        // Deduplicate graph.nodes and graph.edges in-place before rebuilding the
+        // petgraph index.  Post-extraction passes (api_link, manifest, tested_by,
+        // directory_module) re-run over the full node/edge set on every incremental
+        // scan, which causes the same entries to be appended repeatedly.  After N
+        // scans each entry appears N times, causing:
+        //   - graph.nodes: duplicate package nodes from manifest_pass (memory growth,
+        //     stale data exposed to search/query tools)
+        //   - graph.edges: N-multiplied edges → inflated PageRank weights
         //
-        // We use Edge::stable_id() (encodes from→kind→to) as the dedup key.
+        // Node dedup: keep the LAST occurrence (newest data). Reverse, retain first
+        // seen (which is now the newest), then reverse back to restore order.
+        // Edge dedup: keep the FIRST occurrence (stable_id is topology-only; all
+        // duplicates are structurally identical).
         {
-            let mut seen = std::collections::HashSet::new();
-            graph.edges.retain(|e| seen.insert(e.stable_id()));
+            let mut seen_nodes = std::collections::HashSet::new();
+            graph.nodes.reverse();
+            graph.nodes.retain(|n| seen_nodes.insert(n.stable_id()));
+            graph.nodes.reverse();
+
+            let mut seen_edges = std::collections::HashSet::new();
+            graph.edges.retain(|e| seen_edges.insert(e.stable_id()));
         }
 
         // Rebuild petgraph index


### PR DESCRIPTION
## Summary

Addresses CodeRabbit Major finding from PR #447: `manifest_pass()` (and `directory_module_pass()`) were appending nodes to `graph.nodes` on every incremental scan without deduplication, causing unbounded growth.

## Problem

PR #447 fixed `graph.edges` accumulation (PageRank skew) but left `graph.nodes` undeduped. CodeRabbit flagged this as a Major finding (severity: 🟠) on the merged PR:

> Deduping only `graph.edges` still leaves manifest package nodes unbounded. `manifest_pass()` above also appends package nodes on every incremental scan, so this fixes the PageRank skew but not the memory/query duplication from repeated manifest nodes.

After N incremental scans, each logical package node appeared N times in `graph.nodes`, causing:
- Memory growth proportional to scan count
- Duplicate entries surfaced in search results (same package returned N times)
- The stale comment claiming nodes were "harmlessly overwritten" was incorrect (`extend()` appends, it doesn't overwrite)

## Fix

Add node dedup to the existing dedup block in `update_graph_with_scan`. Use `Node::stable_id()` as the key, keeping the **newest** occurrence (last appended = most recent data) by reversing before retain, then reversing back to restore order.

Also fixes the stale comment at the manifest_pass call site.

## Test Plan

- [x] `cargo check --lib` — no new errors
- [x] `test_rebuild_from_edges_deduplicates` — still passes
- [x] `test_rebuild_dedup_stable_across_simulated_scans` — still passes
- The `reverse/retain/reverse` pattern is a standard Rust idiom for "keep last" dedup

Follows up on: #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph deduplication to prevent duplicate node and edge entries during incremental updates, enhancing search accuracy and performance calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->