### PR TITLE
fix: increase LSP readiness wait to 30s for servers without serverStatus

### DIFF
--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -508,7 +508,10 @@ impl LspEnricher {
                 let remaining = deadline.duration_since(tokio::time::Instant::now());
                 remaining.min(tokio::time::Duration::from_secs(60))
             } else {
-                tokio::time::Duration::from_secs(5)
+                // Servers that don't send serverStatus (e.g. typescript-language-server)
+                // may still be indexing the project. Wait up to 30s of silence before
+                // assuming ready — tsserver needs time to load a large project.
+                tokio::time::Duration::from_secs(30)
             };
 
             match tokio::time::timeout(
@@ -587,7 +590,7 @@ impl LspEnricher {
                         );
                     } else {
                         // No serverStatus received — server may not support it
-                        tracing::info!("{} no serverStatus after 5s, assuming ready", self.server_command);
+                        tracing::info!("{} no serverStatus after 30s, assuming ready", self.server_command);
                     }
                     break;
                 }


### PR DESCRIPTION
typescript-language-server doesn't send `experimental/serverStatus`, so RNA assumed ready after just 5s of silence post-init. For large projects (26k+ TypeScript files), tsserver needs more time to finish indexing before reference queries return results.

With 5s wait: 0 TypeScript reference edges produced.
With 30s wait: tsserver finishes indexing, reference queries work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced initialization stability by adjusting server readiness detection timing to allow additional time for server startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->