### PR TITLE
fix: address review findings from #473 (subsystem node index + edge persist)

### DIFF
--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -841,6 +841,28 @@ impl RnaHandler {
                 );
                 all_edges.extend(subsystem_fw_edges);
             }
+
+            // 6e. Extend petgraph index to include newly emitted virtual nodes
+            // (subsystem, framework, channel, event) and their edges. Step 5 built
+            // the index BEFORE these nodes existed, so agents traversing the graph
+            // would miss them. Use targeted incremental updates (not full rebuild)
+            // to keep this O(new nodes + new edges) instead of O(all nodes).
+            for node in &all_nodes {
+                if matches!(&node.id.kind, NodeKind::Other(s) if matches!(s.as_str(), "subsystem" | "framework" | "channel" | "event")) {
+                    index.ensure_node(&node.stable_id(), &node.id.kind.to_string());
+                }
+            }
+            for edge in &all_edges {
+                if matches!(&edge.to.kind, NodeKind::Other(s) if matches!(s.as_str(), "subsystem" | "framework" | "channel" | "event")) {
+                    index.add_edge(
+                        &edge.from.to_stable_id(),
+                        &edge.from.kind.to_string(),
+                        &edge.to.to_stable_id(),
+                        &edge.to.kind.to_string(),
+                        edge.kind.clone(),
+                    );
+                }
+            }
         }
 
         // 7. Persist graph to LanceDB
@@ -1320,6 +1342,10 @@ impl RnaHandler {
                 for node in &sub_result.nodes {
                     upsert_node_ids.insert(node.stable_id());
                 }
+                // BelongsTo edges must be persisted too — include in upsert_edges
+                // so LanceDB gets the full delta (nodes without edges are queryable
+                // as nodes but not traversable as graph endpoints).
+                upsert_edges.extend(sub_result.edges.iter().cloned());
                 graph.nodes.extend(sub_result.nodes);
                 graph.edges.extend(sub_result.edges);
             }


### PR DESCRIPTION
## Summary

Follow-up to #473 (feat: subsystem detection emits first-class nodes). Addresses two unaddressed Critical/Major CodeRabbit findings from that PR's review.

**Critical: rebuild petgraph index after virtual node emission (step 6e)**

`graph --node "subsystem:embed" --mode neighbors` returned zero results because steps 6c-6d (subsystem_node_pass, framework aggregation, etc.) emitted new virtual nodes **after** the petgraph index was built at step 5. The GraphState.index was unaware of subsystem nodes.

Fix: added step 6e that incrementally extends the index with newly-emitted virtual nodes using `add_edge`/`ensure_node` calls — O(new nodes + new edges), not a full rebuild.

**Major: BelongsTo edges from subsystem nodes not persisted (incremental path)**

In `update_graph_with_scan`, `sub_result.edges` (BelongsTo edges from member symbols → subsystem nodes) were added to `graph.edges` but NOT to `upsert_edges`. LanceDB never received them, so they vanished on server restart — leaving subsystem nodes traversable in memory but orphaned in the database.

Fix: added `upsert_edges.extend(sub_result.edges.iter().cloned())`.

## Test plan

- [x] `cargo check --lib` — no errors, 3 pre-existing warnings
- [x] `cargo test` — 1346 tests pass

[outcome:subsystem-detection]
[outcome:context-assembly]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph construction to properly handle all node types during system initialization.
  * Enhanced incremental updates to ensure complete data persistence tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->