### PR TITLE
fix: address review findings from #515

### DIFF
--- a/.claude/agents/dev-pipeline-oversight.md
+++ b/.claude/agents/dev-pipeline-oversight.md
@@ -22,8 +22,10 @@ mcpServers:
 > ```bash
 > COUNT=$(repo-native-alignment search "" --repo . --limit 1 2>/dev/null | grep -o "[0-9]* symbols" | head -1)
 > echo "RNA ready: $COUNT indexed"
-> # If 0 or failed:
-> repo-native-alignment scan --repo . --full 2>&1 | tail -2
+> # If 0 or failed, rebuild:
+> if [ -z "$COUNT" ] || [ "$COUNT" = "0" ]; then
+>   repo-native-alignment scan --repo . --full 2>&1 | tail -2
+> fi
 > ```
 >
 > **Friction consequence:** Any Grep/Read used for code navigation after the scan has run is a `skipped` friction event. Log it to `.oh/friction-logs/<original-pr>-oversight.md`. An oversight run that uses Grep 10 times and logs 0 friction events has failed at self-monitoring, not succeeded at code review.

--- a/.claude/agents/ship.md
+++ b/.claude/agents/ship.md
@@ -49,8 +49,10 @@ Before starting:
    COUNT=$(repo-native-alignment search "" --repo . --limit 1 2>/dev/null | grep -o "[0-9]* symbols" | head -1)
    echo "RNA ready: $COUNT indexed"
 
-   # If count is 0 or command failed, scan now
-   repo-native-alignment scan --repo . --full 2>&1 | tail -2
+   # Only run full scan if index is empty or unavailable
+   if [ -z "$COUNT" ] || [ "$COUNT" = "0" ]; then
+     repo-native-alignment scan --repo . --full 2>&1 | tail -2
+   fi
    ```
    You CANNOT do code review, dissent analysis, or adversarial testing without an indexed worktree. Any Grep/Read for code navigation after this point is a friction event and must be logged to `.oh/friction-logs/<pr-number>-ship.md`.
 

--- a/.claude/skills/release.md
+++ b/.claude/skills/release.md
@@ -2,6 +2,8 @@
 
 Prepare and present a release decision package. Does NOT release automatically — presents findings to the human to decide.
 
+> **You are an RNA power user.** Use RNA MCP tools (`search`, `repo_map`, `outcome_progress`, `search_symbols`, `graph_query`) for all repo exploration — checking outcomes, finding issues, inspecting merged PRs, scanning guardrails. Use the CLI (`repo-native-alignment search --repo . "query"`) for worktree-specific queries. Every Grep/Read instead of an RNA tool is a friction event.
+
 **This skill is hardass. A SKIP is not "safe to ship with." A SKIP means the feature is not done. Not done = blocking.**
 
 ## Hard rules

--- a/.oh/sessions/release-v0.1.15.md
+++ b/.oh/sessions/release-v0.1.15.md
@@ -1,6 +1,12 @@
+---
+title: Release v0.1.15 Decision Package
+version: 0.1.15
+status: pending-human-decision
+started: 2026-03-22
+binary: repo-native-alignment
+---
+
 # Release v0.1.15 Decision Package
-**Started:** 2026-03-22
-**Binary:** repo-native-alignment 0.1.15
 
 ---
 
@@ -125,11 +131,15 @@ Rationale: These 5 cover the four major v0.1.14→v0.1.15 architectural addition
 ### Block release
 None identified.
 
-### Safe to ship with
-- #465 (OpenAPI bidirectional) — not yet merged, skip list in test suite
-- #466 (gRPC service edges) — not yet merged, skip list in test suite
-- #492 (module split) — not yet merged, skip list in test suite
-- #502 (pipeline wired to EventBus) — Phase 3 work, not blocking Phase 2 release
+### Deferred (explicitly out-of-scope for v0.1.15)
+
+These items were deferred when the decision package was assembled. They have since landed:
+- #465 (OpenAPI bidirectional) — **merged as #509** after this package was written
+- #466 (gRPC service edges) — **merged as #508** after this package was written
+- #492 (module split) — **merged as #503** after this package was written
+- #502 (pipeline wired to EventBus) — **merged as #515** after this package was written
+
+### Known issue (not blocking)
 - Lance panic during rapid successive incremental scans — transient, no data loss, self-resolving. Manifests as "JoinError::Cancelled" in stderr. All scan data is persisted before the panic.
 
 ---

--- a/scripts/prep-worktree.sh
+++ b/scripts/prep-worktree.sh
@@ -67,8 +67,12 @@ if [ -d "$MAIN_CACHE/lance" ]; then
     # Clear scan-state so incremental scan re-checks changed files
     rm -f "$WORKTREE_CACHE/scan-state.json"
     echo "RNA scan cache copied. Running incremental scan now (fast, picks up any changed files)..."
-    (cd "$WORKTREE_PATH" && repo-native-alignment scan --repo . 2>&1 | tail -2) || echo "Scan failed — run manually: repo-native-alignment scan --repo . --full"
-    echo "RNA scan complete. Agents can immediately use: repo-native-alignment search --repo . 'query'"
+    if (cd "$WORKTREE_PATH" && repo-native-alignment scan --repo . 2>&1 | tail -2); then
+        echo "RNA scan complete. Agents can immediately use: repo-native-alignment search --repo . 'query'"
+    else
+        echo "Scan failed — run manually: repo-native-alignment scan --repo . --full"
+        echo "WARNING: Search index may be stale until a full scan completes."
+    fi
 else
     echo "No RNA scan cache found — agents will need to run: repo-native-alignment scan --repo . --full"
 fi


### PR DESCRIPTION
## Summary

Post-merge comment audit for PR #515. Addresses 5 CodeRabbit findings that were not fixed in the original PR.

**All 5 findings addressed:**

- **scripts/prep-worktree.sh** (Minor): Success banner no longer prints when the scan falls back to the manual-run message. `if/else` structure now correct.
- **ship.md** (Minor): RNA scan gate only runs `--full` when COUNT is empty/0. Avoids forced full rescan on every `/ship` run.
- **dev-pipeline-oversight.md** (Minor): Same scan gate fix.
- **release.md** (Major): Add standard RNA-navigation contract so `/release` agents use RNA MCP tools for repo exploration.
- **release-v0.1.15.md** (Minor + Major): Add YAML frontmatter; rename "Safe to ship with" to "Deferred (explicitly out-of-scope)" with notes that all 4 deferred items have since landed.

## Test plan
- [ ] Scripts and agent docs verified for correctness
- [ ] No code changes (docs-only PR)