### PR TITLE
fix: address unresolved Critical/Major CodeRabbit findings from v0.1.14 audit (step 4b)

### DIFF
--- a/src/extract/extractor_config.rs
+++ b/src/extract/extractor_config.rs
@@ -697,7 +697,7 @@ edge_kind = "Consumes"
         let cfg = pubsub_fixture_config();
         assert_eq!(cfg.boundaries.len(), 2);
         assert_eq!(cfg.boundaries[0].function_pattern, "publisher.publish");
-        assert_eq!(cfg.boundaries[0].topic_arg, 0);
+        assert_eq!(cfg.boundaries[0].topic_arg, Some(0));
         assert_eq!(cfg.boundaries[0].edge_kind, "Produces");
         assert_eq!(cfg.boundaries[1].function_pattern, "subscriber.subscribe");
         assert_eq!(cfg.boundaries[1].edge_kind, "Consumes");
@@ -737,7 +737,7 @@ decorator = true
 "#,
         );
         assert_eq!(cfg.boundaries.len(), 2);
-        assert_eq!(cfg.boundaries[0].topic_arg, 0, "arg_position alias must map to topic_arg");
+        assert_eq!(cfg.boundaries[0].topic_arg, Some(0), "arg_position alias must map to topic_arg");
         assert!(!cfg.boundaries[0].decorator);
         assert!(cfg.boundaries[1].decorator);
     }

--- a/src/extract/framework_detection.rs
+++ b/src/extract/framework_detection.rs
@@ -86,7 +86,12 @@ static FRAMEWORK_RULES: &[FrameworkRule] = &[
     // Next.js — must check 'next/server', 'next/router', etc. before generic 'react'
     FrameworkRule { import_pattern: "next/", language: "typescript", framework_id: "nextjs-app-router", display_name: "Next.js" },
     FrameworkRule { import_pattern: "next/", language: "javascript", framework_id: "nextjs-app-router", display_name: "Next.js" },
+    // Bare `import "next"` / `import 'next'` — support both quote styles in both
+    // languages because TypeScript and JavaScript projects freely mix single/double
+    // quotes depending on their formatter config.
     FrameworkRule { import_pattern: "\"next\"", language: "typescript", framework_id: "nextjs-app-router", display_name: "Next.js" },
+    FrameworkRule { import_pattern: "'next'", language: "typescript", framework_id: "nextjs-app-router", display_name: "Next.js" },
+    FrameworkRule { import_pattern: "\"next\"", language: "javascript", framework_id: "nextjs-app-router", display_name: "Next.js" },
     FrameworkRule { import_pattern: "'next'", language: "javascript", framework_id: "nextjs-app-router", display_name: "Next.js" },
     // React (after Next.js to avoid clobbering)
     FrameworkRule { import_pattern: "react", language: "typescript", framework_id: "react", display_name: "React" },
@@ -333,8 +338,10 @@ pub fn subsystem_framework_aggregation_pass(all_nodes: &[Node]) -> Vec<crate::gr
     // 2. Collect (member stable_id → file) from all non-subsystem nodes.
     // 3. For each subsystem, count members' files → frameworks.
 
-    // Step 1: file → set of frameworks detected in that file.
-    let mut file_frameworks: HashMap<String, HashSet<String>> = HashMap::new();
+    // Step 1: (root, file) → set of frameworks detected in that file.
+    // The key includes root so that two workspace roots with the same relative
+    // file path (e.g. both have `src/main.ts`) don't merge their import data.
+    let mut file_frameworks: HashMap<(String, String), HashSet<String>> = HashMap::new();
     for node in all_nodes {
         if node.id.kind != NodeKind::Import {
             continue;
@@ -351,7 +358,7 @@ pub fn subsystem_framework_aggregation_pass(all_nodes: &[Node]) -> Vec<crate::gr
             let pattern = rule.import_pattern.to_lowercase();
             if import_text.contains(pattern.as_str()) {
                 file_frameworks
-                    .entry(node.id.file.display().to_string())
+                    .entry((node.id.root.clone(), node.id.file.display().to_string()))
                     .or_default()
                     .insert(rule.framework_id.to_string());
             }
@@ -395,7 +402,7 @@ pub fn subsystem_framework_aggregation_pass(all_nodes: &[Node]) -> Vec<crate::gr
         let sid = node.stable_id();
         if let Some(sub_name) = member_to_subsystem.get(&sid) {
             *subsystem_member_counts.entry(sub_name.clone()).or_default() += 1;
-            let file_key = node.id.file.display().to_string();
+            let file_key = (node.id.root.clone(), node.id.file.display().to_string());
             if let Some(frameworks) = file_frameworks.get(&file_key) {
                 let sub_entry = subsystem_framework_counts
                     .entry(sub_name.clone())

--- a/src/extract/websocket.rs
+++ b/src/extract/websocket.rs
@@ -194,68 +194,67 @@ pub fn websocket_pass(
                 continue;
             }
 
-            let event_name = match &rule.extraction {
-                WsExtraction::QuotedAfter(prefix) => extract_quoted_after(&node.body, prefix),
+            // Collect ALL quoted event names for this rule — a handler body may
+            // contain multiple socket.on("a", ...) / socket.emit("b", ...) calls.
+            let event_names: Vec<String> = match &rule.extraction {
+                WsExtraction::QuotedAfter(prefix) => extract_all_quoted_after(&node.body, prefix),
             };
-
-            let event_name = match event_name {
-                Some(n) if !n.is_empty() => n,
-                _ => continue,
-            };
-
-            // Skip lifecycle events — they're not application-level topology.
-            if is_lifecycle_event(&event_name) {
-                continue;
-            }
-
-            let event_key = format!("{}:{}", root_id, event_name);
-            let event_id = event_nodes
-                .entry(event_key)
-                .or_insert_with(|| {
-                    let mut metadata = BTreeMap::new();
-                    metadata.insert("channel_type".to_string(), "socketio".to_string());
-                    Node {
-                        id: NodeId {
-                            root: root_id.to_string(),
-                            file: PathBuf::from(format!("events/{}", event_name)),
-                            name: event_name.clone(),
-                            kind: NodeKind::Other("event".to_string()),
-                        },
-                        language: String::new(),
-                        line_start: 0,
-                        line_end: 0,
-                        signature: format!("event {}", event_name),
-                        body: String::new(),
-                        metadata,
-                        source: ExtractionSource::TreeSitter,
-                    }
-                })
-                .id
-                .clone();
 
             let edge_kind = match rule.direction {
                 Direction::Produces => EdgeKind::Produces,
                 Direction::Consumes => EdgeKind::Consumes,
             };
 
-            // Deduplicate: skip if we already emitted an edge for this
-            // (from_node, event_name, direction) combination.
-            let dedup_key = (
-                node.stable_id(),
-                event_name.clone(),
-                edge_kind.to_string(),
-            );
-            if !seen_edges.insert(dedup_key) {
-                continue;
-            }
+            for event_name in event_names {
+                // Skip lifecycle events — they're not application-level topology.
+                if is_lifecycle_event(&event_name) {
+                    continue;
+                }
 
-            result_edges.push(Edge {
-                from: node.id.clone(),
-                to: event_id,
-                kind: edge_kind,
-                source: ExtractionSource::TreeSitter,
-                confidence: Confidence::Detected,
-            });
+                let event_key = format!("{}:{}", root_id, event_name);
+                let event_id = event_nodes
+                    .entry(event_key)
+                    .or_insert_with(|| {
+                        let mut metadata = BTreeMap::new();
+                        metadata.insert("channel_type".to_string(), "socketio".to_string());
+                        Node {
+                            id: NodeId {
+                                root: root_id.to_string(),
+                                file: PathBuf::from(format!("events/{}", event_name)),
+                                name: event_name.clone(),
+                                kind: NodeKind::Other("event".to_string()),
+                            },
+                            language: String::new(),
+                            line_start: 0,
+                            line_end: 0,
+                            signature: format!("event {}", event_name),
+                            body: String::new(),
+                            metadata,
+                            source: ExtractionSource::TreeSitter,
+                        }
+                    })
+                    .id
+                    .clone();
+
+                // Deduplicate: skip if we already emitted an edge for this
+                // (from_node, event_name, direction) combination.
+                let dedup_key = (
+                    node.stable_id(),
+                    event_name.clone(),
+                    edge_kind.to_string(),
+                );
+                if !seen_edges.insert(dedup_key) {
+                    continue;
+                }
+
+                result_edges.push(Edge {
+                    from: node.id.clone(),
+                    to: event_id,
+                    kind: edge_kind.clone(),
+                    source: ExtractionSource::TreeSitter,
+                    confidence: Confidence::Detected,
+                });
+            }
         }
     }
 
@@ -280,29 +279,56 @@ pub fn websocket_pass(
 // ---------------------------------------------------------------------------
 
 fn extract_quoted_after(body: &str, prefix: &str) -> Option<String> {
+    extract_all_quoted_after(body, prefix).into_iter().next()
+}
+
+/// Extract ALL quoted string arguments that immediately follow each occurrence of
+/// `prefix` in `body`. A handler with multiple `socket.on("a", ...) socket.on("b", ...)`
+/// calls will return `["a", "b"]` instead of just `["a"]`.
+fn extract_all_quoted_after(body: &str, prefix: &str) -> Vec<String> {
     let prefix_lower = prefix.to_lowercase();
     let body_lower = body.to_lowercase();
+    let prefix_len = prefix.len();
 
-    let start_pos = body_lower.find(prefix_lower.as_str())?;
-    let after = &body[start_pos + prefix.len()..];
-    let after = after.trim_start_matches([' ', '\t', '\n', '\r']);
+    let mut results = Vec::new();
+    let mut search_start = 0usize;
 
-    let quote_char = match after.chars().next()? {
-        '"' => '"',
-        '\'' => '\'',
-        '`' => '`',
-        _ => return None,
-    };
+    while let Some(rel_pos) = body_lower[search_start..].find(prefix_lower.as_str()) {
+        let abs_pos = search_start + rel_pos;
+        let after_start = abs_pos + prefix_len;
+        search_start = after_start;
 
-    let content = &after[1..];
-    let end = content.find(quote_char)?;
-    let name = content[..end].trim().to_string();
+        // Guard: prefix_len must advance at least one byte to prevent infinite loop.
+        if prefix_len == 0 {
+            break;
+        }
 
-    if name.is_empty() || name.contains('\n') {
-        return None;
+        let after = match body.get(after_start..) {
+            Some(s) => s,
+            None => break,
+        };
+        let after = after.trim_start_matches([' ', '\t', '\n', '\r']);
+
+        let quote_char = match after.chars().next() {
+            Some('"') => '"',
+            Some('\'') => '\'',
+            Some('`') => '`',
+            _ => continue,
+        };
+
+        let content = &after[1..];
+        let end = match content.find(quote_char) {
+            Some(e) => e,
+            None => continue,
+        };
+        let name = content[..end].trim().to_string();
+        if name.is_empty() || name.contains('\n') {
+            continue;
+        }
+        results.push(name);
     }
 
-    Some(name)
+    results
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -1056,6 +1056,9 @@ impl RnaHandler {
 
         // Re-run all post-extraction passes via EventBus (ADR Phase 2b, issue #502).
         // Include all roots for passes that need filesystem access (manifest, nextjs_routing).
+        // lsp_only roots are intentionally included: nextjs_routing_pass emits ApiEndpoint
+        // nodes for lsp_only subdirectory roots so agents can see what routes exist even
+        // when tree-sitter extraction was skipped for those roots.
         let root_pairs_incremental: Vec<(String, std::path::PathBuf)> = WorkspaceConfig::load()
             .with_primary_root(self.repo_root.clone())
             .with_worktrees(&self.repo_root)


### PR DESCRIPTION
## Summary

Release step 4b: CodeRabbit sweep of all 65 PRs merged since v0.1.14. After auditing every CodeRabbit inline comment, three genuine unaddressed Major findings were found and fixed.

- **PR #480 MAJOR** (`framework_detection.rs`): `subsystem_framework_aggregation_pass` keyed `file_frameworks` by file path only. In multi-root workspaces, two roots with `src/lib.ts` would merge import data, miscounting framework usage per subsystem. Fixed by keying on `(root, file)` tuple.

- **PR #480 MAJOR** (`framework_detection.rs`): Bare `import 'next'` / `import "next"` detection was asymmetric — double quotes only for TypeScript, single quotes only for JavaScript. TypeScript repos using Prettier's single-quote default would miss Next.js detection. Fixed by adding both quote styles for both languages.

- **PR #481 MAJOR** (`websocket.rs`): `extract_quoted_after` returned only the first Socket.IO event per body pattern. A handler with `socket.on("login", ...) socket.on("logout", ...)` would only contribute `"login"`. Fixed by adding `extract_all_quoted_after` that iterates all occurrences; the per-rule loop now processes all returned event names.

Also fixed a pre-existing test compilation error in `extractor_config.rs` where `topic_arg` (changed to `Option<usize>` in commit 74e5145) was compared against bare `0` instead of `Some(0)`.

## Audit findings: complete status

Of the ~200 CodeRabbit inline comments across 65 PRs:
- Most Critical/Major findings were addressed in subsequent fix PRs during the merge pipeline
- The three findings above slipped through
- No new Critical findings remain open
- Key already-fixed: #472 Critical (Unicode panic), #473 Critical (subsystem index), #487 Critical (post-pass persistence), #490 Critical (Louvain complexity), #439 Critical (C/C++ header routing), #444 Critical (symlink recursion), #445 Critical (serde bool), #459 Critical (reference index loop), #495 Critical (sentinel write ordering), #508 Critical (gRPC Java naming), #509 Critical (EXTRACTION_VERSION bump)

## Test plan

- [x] `cargo check --lib` passes
- [x] `cargo test --lib` — 1547 passed, 0 failed
- [x] Targeted tests: websocket module, framework_detection module all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended Next.js framework detection to recognize bare `import "next"` statements in addition to prefixed imports.

* **Bug Fixes**
  * WebSocket event extraction now extracts all quoted event names per rule instead of just the first match.
  * Improved framework detection handling for multi-root workspaces to prevent data merging across different roots.

* **Tests**
  * Updated configuration parsing unit tests.

* **Documentation**
  * Added clarification on LSP-only root behavior in post-extraction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->