### PR TITLE
feat: add ScanStatsConsumer singleton; list_roots reads live scan state

### DIFF
--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -22,9 +22,11 @@
 
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
 
 use crate::extract::ExtractorRegistry;
 use crate::extract::event_bus::{ExtractionConsumer, ExtractionEvent, ExtractionEventKind};
+use crate::extract::scan_stats::{ScanStats, ScanStatsConsumer};
 use crate::graph::Node;
 
 // ---------------------------------------------------------------------------
@@ -786,6 +788,8 @@ impl ExtractionConsumer for SubsystemConsumer {
 /// path; Phase 3+ promotes these stubs to full async consumers.
 ///
 /// Registered consumers:
+/// - `ScanStatsConsumer` — `RootDiscovered`, `RootExtracted`, `LanguageDetected`,
+///   `EnrichmentComplete`, `PassesComplete` (singleton; writes into `scan_stats`)
 /// - `ManifestConsumer`, `TreeSitterConsumer` — `RootDiscovered`
 /// - `LanguageAccumulatorConsumer`, `PostExtractionConsumer`,
 ///   `OpenApiConsumer`, `GrpcConsumer`, `EmbeddingIndexerConsumer` — `RootExtracted`
@@ -801,13 +805,24 @@ impl ExtractionConsumer for SubsystemConsumer {
 ///
 /// `root_pairs` must be the full `(slug, path)` list for the workspace.
 /// `primary_slug` is the slug of the primary code root.
+/// `scan_stats` is the shared stats handle owned by `RnaHandler`. When `None`,
+/// a fresh throwaway `Arc` is created (used by `run_post_passes_via_bus` and tests).
+///
+/// Returns `(bus, scan_stats_arc)` where `scan_stats_arc` is either the passed-in
+/// `Arc` or the freshly created one.
 pub fn build_builtin_bus(
     root_pairs: Vec<(String, PathBuf)>,
     primary_slug: String,
-) -> crate::extract::event_bus::EventBus {
+    scan_stats: Option<Arc<RwLock<ScanStats>>>,
+) -> (crate::extract::event_bus::EventBus, Arc<RwLock<ScanStats>>) {
     use crate::extract::event_bus::EventBus;
 
     let mut bus = EventBus::new();
+
+    // --- ScanStatsConsumer (singleton — registered first so it sees every event) ---
+    let stats_arc = scan_stats.unwrap_or_else(|| Arc::new(RwLock::new(ScanStats::default())));
+    let scan_stats_consumer = ScanStatsConsumer { stats: Arc::clone(&stats_arc) };
+    bus.register(Box::new(scan_stats_consumer));
 
     // --- RootDiscovered consumers ---
     bus.register(Box::new(ManifestConsumer));
@@ -846,7 +861,7 @@ pub fn build_builtin_bus(
     bus.register(Box::new(SubsystemConsumer));
     bus.register(Box::new(LanceDBConsumer));
 
-    bus
+    (bus, stats_arc)
 }
 
 // ---------------------------------------------------------------------------
@@ -875,6 +890,8 @@ pub fn build_builtin_bus(
 /// * `root_pairs` - `(slug, path)` pairs for all workspace roots
 /// * `primary_slug` - slug of the primary code root
 /// * `repo_root` - path to the primary repository root (for the bus event)
+/// * `scan_stats` - optional shared stats handle from `RnaHandler`. When provided,
+///   the `ScanStatsConsumer` writes into this `Arc`; when `None`, a throwaway is used.
 ///
 /// # Returns
 /// `Ok((nodes, edges, detected_frameworks))` — the enriched graph and framework set.
@@ -891,6 +908,7 @@ pub fn run_post_passes_via_bus(
     root_pairs: Vec<(String, PathBuf)>,
     primary_slug: String,
     repo_root: PathBuf,
+    scan_stats: Option<Arc<RwLock<ScanStats>>>,
 ) -> anyhow::Result<(Vec<crate::graph::Node>, Vec<crate::graph::Edge>, std::collections::HashSet<String>)> {
     use crate::extract::event_bus::ExtractionEvent;
     use std::sync::Arc;
@@ -899,7 +917,7 @@ pub fn run_post_passes_via_bus(
     let nodes_arc: Arc<[crate::graph::Node]> = Arc::from(nodes.into_boxed_slice());
     let edges_arc: Arc<[crate::graph::Edge]> = Arc::from(edges.into_boxed_slice());
 
-    let bus = build_builtin_bus(root_pairs, primary_slug.clone());
+    let (bus, _stats) = build_builtin_bus(root_pairs, primary_slug.clone(), scan_stats);
     let events = bus.emit(ExtractionEvent::RootExtracted {
         slug: primary_slug,
         path: repo_root,
@@ -1119,12 +1137,13 @@ mod tests {
     /// Verify build_builtin_bus registers consumers for all expected event kinds.
     #[test]
     fn test_builtin_bus_has_consumers_for_all_event_kinds() {
-        let bus = build_builtin_bus(vec![], "test".into());
+        let (bus, _stats) = build_builtin_bus(vec![], "test".into(), None);
         // Derive the exact expected count to catch regressions when languages are added/removed.
         let lsp_count = crate::extract::EnricherRegistry::with_builtins()
             .supported_languages()
             .len();
         let expected_total =
+            1 +        // ScanStatsConsumer (singleton, registered first)
             2 +        // RootDiscovered: ManifestConsumer, TreeSitterConsumer
             5 +        // RootExtracted: LanguageAccumulatorConsumer, PostExtractionConsumer,
                        //   OpenApiConsumer, GrpcConsumer, EmbeddingIndexerConsumer
@@ -1136,6 +1155,25 @@ mod tests {
             bus.len(), expected_total,
             "Unexpected built-in consumer count: got {}, expected {} (lsp_count={})",
             bus.len(), expected_total, lsp_count
+        );
+    }
+
+    /// Verify build_builtin_bus returns a stats handle that shares state with the bus.
+    #[test]
+    fn test_builtin_bus_returns_scan_stats_handle() {
+        let (bus, stats) = build_builtin_bus(vec![], "test".into(), None);
+        // No activity yet
+        assert!(!stats.read().unwrap().has_activity());
+
+        // Emit RootDiscovered — the ScanStatsConsumer inside the bus should update stats.
+        bus.emit(crate::extract::event_bus::ExtractionEvent::RootDiscovered {
+            slug: "test".into(),
+            path: PathBuf::from("."),
+            lsp_only: false,
+        });
+        assert!(
+            stats.read().unwrap().has_activity(),
+            "stats handle must reflect events fired through the bus"
         );
     }
 
@@ -1195,9 +1233,10 @@ mod tests {
         // Need scan state dir
         std::fs::create_dir_all(tmp.path().join(".oh").join(".cache")).unwrap();
 
-        let bus = build_builtin_bus(
+        let (bus, _stats) = build_builtin_bus(
             vec![("test".to_string(), tmp.path().to_path_buf())],
             "test".to_string(),
+            None,
         );
         let events = bus.emit(ExtractionEvent::RootDiscovered {
             slug: "test".to_string(),
@@ -1303,6 +1342,7 @@ mod tests {
             vec![],
             "test".to_string(),
             PathBuf::from("."),
+            None,
         ).expect("run_post_passes_via_bus must not fail on empty input");
         assert!(nodes.is_empty(), "empty input → empty nodes");
         assert!(edges.is_empty(), "empty input → empty edges");
@@ -1343,6 +1383,7 @@ mod tests {
             vec![],
             "test".to_string(),
             PathBuf::from("."),
+            None,
         ).expect("run_post_passes_via_bus must not fail with valid input");
 
         // Output must contain the input node (passes should not drop it)

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -2666,6 +2666,7 @@ impl Enricher for LspEnricher {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::str::FromStr;
 
     use super::*;
 

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -12,6 +12,7 @@ pub mod fastapi_router_prefix;
 pub mod consumers;
 pub mod directory_module;
 pub mod event_bus;
+pub mod scan_stats;
 pub mod openapi_sdk_link;
 pub mod extractor_config;
 pub mod framework_detection;

--- a/src/extract/scan_stats.rs
+++ b/src/extract/scan_stats.rs
@@ -1,0 +1,512 @@
+//! `ScanStatsConsumer` — live scan state maintained by the event bus.
+//!
+//! # Purpose
+//!
+//! `list_roots` previously read `extract_completed.json` WAL sentinels to
+//! determine scan status. Sentinels are written only after a phase fully
+//! completes and persists — they cannot distinguish "scan in progress" from
+//! "scan never ran" and have no visibility into per-language LSP state
+//! during enrichment.
+//!
+//! `ScanStatsConsumer` subscribes to extraction events and maintains live
+//! state in an `Arc<RwLock<ScanStats>>`. `list_roots` reads from this
+//! singleton for in-progress and complete status. Sentinel files remain as
+//! a cold-start fallback (no bus events yet — sentinel exists from a
+//! previous run).
+//!
+//! # Architecture
+//!
+//! ```text
+//! ExtractionEvent            ScanStats mutation
+//! ─────────────────────────  ─────────────────────────────────────
+//! RootDiscovered             roots_queued += 1
+//! RootExtracted              roots_extracted[slug] = RootStats
+//! LanguageDetected           languages_in_flight[slug] += [lang]
+//! EnrichmentComplete         languages_done[slug] += [lang],
+//!                            lsp_edge_counts[slug][lang] = count
+//! PassesComplete             roots_complete[slug] = full stats
+//! ```
+//!
+//! All mutations take an exclusive write lock; reads take a shared lock.
+//! The lock is uncontested in the common case (only the extraction thread
+//! writes; `list_roots` reads from a different task).
+//!
+//! # Cold-start fallback
+//!
+//! On cold start (server restarts after a prior scan), no bus events fire.
+//! `list_roots` falls back to the sentinel files in `.oh/.cache/` exactly
+//! as it did before this change. The `ScanStats` will be empty/default in
+//! that case, and the caller must check `roots_complete` being empty as the
+//! signal to fall back.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::Instant;
+
+use crate::extract::event_bus::{ExtractionConsumer, ExtractionEvent, ExtractionEventKind};
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+/// Per-root stats populated after `RootExtracted`.
+#[derive(Debug, Clone)]
+pub struct RootExtractedStats {
+    /// Number of symbols (nodes) extracted by tree-sitter.
+    pub symbol_count: usize,
+    /// Number of edges extracted by tree-sitter.
+    pub edge_count: usize,
+    /// Wall-clock time when extraction completed.
+    pub completed_at: Instant,
+}
+
+/// Full per-root stats populated after `PassesComplete` (all passes + LSP done).
+#[derive(Debug, Clone)]
+pub struct RootCompleteStats {
+    /// Total symbols after all passes ran.
+    pub symbol_count: usize,
+    /// Total edges after all passes ran.
+    pub edge_count: usize,
+    /// Detected framework IDs (e.g. "fastapi", "kafkajs").
+    pub detected_frameworks: std::collections::HashSet<String>,
+    /// Wall-clock time when all passes completed.
+    pub completed_at: Instant,
+}
+
+/// Live scan state maintained by [`ScanStatsConsumer`].
+///
+/// All fields are keyed by root slug. The struct is read-locked by
+/// `list_roots` and write-locked by the consumer callbacks.
+#[derive(Debug, Default)]
+pub struct ScanStats {
+    /// How many roots have been queued (received `RootDiscovered`).
+    pub roots_queued: usize,
+
+    /// Roots that have completed tree-sitter extraction (`RootExtracted`).
+    /// Present between extraction and `PassesComplete`.
+    pub roots_extracted: HashMap<String, RootExtractedStats>,
+
+    /// Languages currently in flight (detected but enrichment not yet done).
+    /// `LanguageDetected` adds a language; `EnrichmentComplete` removes it.
+    pub languages_in_flight: HashMap<String, Vec<String>>,
+
+    /// Languages for which enrichment has completed, per root.
+    pub languages_done: HashMap<String, Vec<String>>,
+
+    /// LSP edge counts per root per language, populated on `EnrichmentComplete`.
+    pub lsp_edge_counts: HashMap<String, HashMap<String, usize>>,
+
+    /// Roots that have completed all passes (`PassesComplete`).
+    pub roots_complete: HashMap<String, RootCompleteStats>,
+}
+
+impl ScanStats {
+    /// Returns true if any scan activity has been observed (at least one root
+    /// discovered). When false, `list_roots` should fall back to sentinel files.
+    pub fn has_activity(&self) -> bool {
+        self.roots_queued > 0
+    }
+
+    /// Returns `true` if the given root has finished all post-extraction passes.
+    pub fn is_root_complete(&self, slug: &str) -> bool {
+        self.roots_complete.contains_key(slug)
+    }
+
+    /// Returns `true` if the given root is currently being extracted or enriched
+    /// (seen via `RootDiscovered` but `PassesComplete` not yet received).
+    pub fn is_root_in_progress(&self, slug: &str) -> bool {
+        self.roots_queued > 0
+            && !self.roots_complete.contains_key(slug)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ScanStatsConsumer
+// ---------------------------------------------------------------------------
+
+/// Singleton consumer that maintains live scan state.
+///
+/// Register via [`build_builtin_bus`] before emitting any events.
+/// Obtain the shared state via [`ScanStatsConsumer::stats`].
+///
+/// [`build_builtin_bus`]: crate::extract::consumers::build_builtin_bus
+pub struct ScanStatsConsumer {
+    /// Shared mutable scan state. The bus and any reader share this Arc.
+    pub stats: Arc<RwLock<ScanStats>>,
+}
+
+impl ScanStatsConsumer {
+    /// Create a new consumer backed by a fresh, empty [`ScanStats`].
+    pub fn new() -> Self {
+        Self {
+            stats: Arc::new(RwLock::new(ScanStats::default())),
+        }
+    }
+
+    /// Return a clone of the `Arc` so callers can hold a handle to the stats
+    /// without owning the consumer.
+    pub fn stats_handle(&self) -> Arc<RwLock<ScanStats>> {
+        Arc::clone(&self.stats)
+    }
+}
+
+impl Default for ScanStatsConsumer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExtractionConsumer for ScanStatsConsumer {
+    fn name(&self) -> &str {
+        "scan_stats"
+    }
+
+    fn subscribes_to(&self) -> &[ExtractionEventKind] {
+        &[
+            ExtractionEventKind::RootDiscovered,
+            ExtractionEventKind::RootExtracted,
+            ExtractionEventKind::LanguageDetected,
+            ExtractionEventKind::EnrichmentComplete,
+            ExtractionEventKind::PassesComplete,
+        ]
+    }
+
+    fn on_event(&self, event: &ExtractionEvent) -> anyhow::Result<Vec<ExtractionEvent>> {
+        // Acquire an exclusive write lock. The lock is short-lived (a few HashMap ops)
+        // and uncontested in normal operation — the extraction thread is the only writer.
+        let mut stats = self.stats.write().map_err(|e| anyhow::anyhow!("ScanStatsConsumer lock poisoned: {}", e))?;
+
+        match event {
+            ExtractionEvent::RootDiscovered { slug, .. } => {
+                stats.roots_queued += 1;
+                tracing::debug!(
+                    "ScanStatsConsumer: RootDiscovered '{}' (total queued: {})",
+                    slug,
+                    stats.roots_queued,
+                );
+            }
+
+            ExtractionEvent::RootExtracted { slug, nodes, edges, .. } => {
+                stats.roots_extracted.insert(slug.clone(), RootExtractedStats {
+                    symbol_count: nodes.len(),
+                    edge_count: edges.len(),
+                    completed_at: Instant::now(),
+                });
+                tracing::debug!(
+                    "ScanStatsConsumer: RootExtracted '{}': {} symbols, {} edges",
+                    slug,
+                    nodes.len(),
+                    edges.len(),
+                );
+            }
+
+            ExtractionEvent::LanguageDetected { slug, language, .. } => {
+                stats.languages_in_flight
+                    .entry(slug.clone())
+                    .or_default()
+                    .push(language.clone());
+                tracing::debug!(
+                    "ScanStatsConsumer: LanguageDetected '{}' in '{}'",
+                    language,
+                    slug,
+                );
+            }
+
+            ExtractionEvent::EnrichmentComplete { slug, language, added_edges, .. } => {
+                // Remove from in-flight.
+                if let Some(in_flight) = stats.languages_in_flight.get_mut(slug) {
+                    in_flight.retain(|l| l != language);
+                }
+                // Add to done.
+                stats.languages_done
+                    .entry(slug.clone())
+                    .or_default()
+                    .push(language.clone());
+                // Record LSP edge count.
+                stats.lsp_edge_counts
+                    .entry(slug.clone())
+                    .or_default()
+                    .insert(language.clone(), added_edges.len());
+                tracing::debug!(
+                    "ScanStatsConsumer: EnrichmentComplete '{}' for '{}': {} LSP edges",
+                    language,
+                    slug,
+                    added_edges.len(),
+                );
+            }
+
+            ExtractionEvent::PassesComplete { slug, nodes, edges, detected_frameworks, .. } => {
+                stats.roots_complete.insert(slug.clone(), RootCompleteStats {
+                    symbol_count: nodes.len(),
+                    edge_count: edges.len(),
+                    detected_frameworks: detected_frameworks.clone(),
+                    completed_at: Instant::now(),
+                });
+                // Clean up intermediate state now that this root is complete.
+                stats.roots_extracted.remove(slug);
+                stats.languages_in_flight.remove(slug);
+                tracing::info!(
+                    "ScanStatsConsumer: PassesComplete '{}': {} symbols, {} edges, {} framework(s)",
+                    slug,
+                    nodes.len(),
+                    edges.len(),
+                    detected_frameworks.len(),
+                );
+            }
+
+            // Other events not subscribed to — guard clause in bus ensures we never
+            // receive them, but keep exhaustive for correctness.
+            _ => {}
+        }
+
+        Ok(vec![])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extract::event_bus::ExtractionEvent;
+    use std::path::PathBuf;
+
+    fn make_consumer() -> ScanStatsConsumer {
+        ScanStatsConsumer::new()
+    }
+
+    fn slug(s: &str) -> String {
+        s.to_string()
+    }
+
+    fn empty_arc_nodes() -> std::sync::Arc<[crate::graph::Node]> {
+        std::sync::Arc::from([])
+    }
+
+    fn empty_arc_edges() -> std::sync::Arc<[crate::graph::Edge]> {
+        std::sync::Arc::from([])
+    }
+
+    #[test]
+    fn test_root_discovered_increments_queued() {
+        let c = make_consumer();
+        let event = ExtractionEvent::RootDiscovered {
+            slug: slug("api"),
+            path: PathBuf::from("."),
+            lsp_only: false,
+        };
+        c.on_event(&event).unwrap();
+
+        let stats = c.stats.read().unwrap();
+        assert_eq!(stats.roots_queued, 1);
+        assert!(stats.has_activity());
+    }
+
+    #[test]
+    fn test_multiple_roots_discovered() {
+        let c = make_consumer();
+        for name in ["api", "frontend", "infra"] {
+            c.on_event(&ExtractionEvent::RootDiscovered {
+                slug: slug(name),
+                path: PathBuf::from("."),
+                lsp_only: false,
+            }).unwrap();
+        }
+        let stats = c.stats.read().unwrap();
+        assert_eq!(stats.roots_queued, 3);
+    }
+
+    #[test]
+    fn test_root_extracted_records_stats() {
+        let c = make_consumer();
+        // RootDiscovered first
+        c.on_event(&ExtractionEvent::RootDiscovered {
+            slug: slug("api"),
+            path: PathBuf::from("."),
+            lsp_only: false,
+        }).unwrap();
+        // Then RootExtracted
+        c.on_event(&ExtractionEvent::RootExtracted {
+            slug: slug("api"),
+            path: PathBuf::from("."),
+            nodes: std::sync::Arc::from(vec![].into_boxed_slice()),
+            edges: std::sync::Arc::from(vec![].into_boxed_slice()),
+        }).unwrap();
+        let stats = c.stats.read().unwrap();
+        let extracted = stats.roots_extracted.get("api").expect("api should be in roots_extracted");
+        assert_eq!(extracted.symbol_count, 0);
+        assert_eq!(extracted.edge_count, 0);
+        assert!(stats.is_root_in_progress("api"), "root should be in-progress after RootExtracted");
+    }
+
+    #[test]
+    fn test_language_detected_adds_to_in_flight() {
+        let c = make_consumer();
+        c.on_event(&ExtractionEvent::LanguageDetected {
+            slug: slug("api"),
+            language: "rust".into(),
+            nodes: empty_arc_nodes(),
+        }).unwrap();
+        c.on_event(&ExtractionEvent::LanguageDetected {
+            slug: slug("api"),
+            language: "python".into(),
+            nodes: empty_arc_nodes(),
+        }).unwrap();
+        let stats = c.stats.read().unwrap();
+        let in_flight = stats.languages_in_flight.get("api").expect("api should have in-flight langs");
+        assert!(in_flight.contains(&"rust".to_string()));
+        assert!(in_flight.contains(&"python".to_string()));
+    }
+
+    #[test]
+    fn test_enrichment_complete_moves_lang_from_in_flight_to_done() {
+        let c = make_consumer();
+        // Add rust to in-flight
+        c.on_event(&ExtractionEvent::LanguageDetected {
+            slug: slug("api"),
+            language: "rust".into(),
+            nodes: empty_arc_nodes(),
+        }).unwrap();
+        // Complete enrichment for rust
+        c.on_event(&ExtractionEvent::EnrichmentComplete {
+            slug: slug("api"),
+            language: "rust".into(),
+            added_edges: empty_arc_edges(),
+            new_nodes: empty_arc_nodes(),
+        }).unwrap();
+        let stats = c.stats.read().unwrap();
+        let in_flight = stats.languages_in_flight.get("api").map(|v| v.as_slice()).unwrap_or(&[]);
+        assert!(!in_flight.contains(&"rust".to_string()), "rust should no longer be in-flight");
+        let done = stats.languages_done.get("api").expect("api should have done langs");
+        assert!(done.contains(&"rust".to_string()), "rust should be in done langs");
+    }
+
+    #[test]
+    fn test_enrichment_complete_records_lsp_edge_count() {
+        use crate::graph::{Edge, EdgeKind, ExtractionSource, Confidence, NodeId, NodeKind};
+        use std::path::PathBuf as Pb;
+        let c = make_consumer();
+
+        // Build 3 fake edges
+        let make_edge = |n: &str| Edge {
+            from: NodeId { root: "api".into(), file: Pb::from("a.rs"), name: n.into(), kind: NodeKind::Function },
+            to: NodeId { root: "api".into(), file: Pb::from("b.rs"), name: "b".into(), kind: NodeKind::Function },
+            kind: EdgeKind::Calls,
+            source: ExtractionSource::TreeSitter,
+            confidence: Confidence::Confirmed,
+        };
+        let edges: Vec<Edge> = (0..3).map(|i| make_edge(&format!("fn{}", i))).collect();
+
+        c.on_event(&ExtractionEvent::LanguageDetected {
+            slug: slug("api"),
+            language: "rust".into(),
+            nodes: empty_arc_nodes(),
+        }).unwrap();
+        c.on_event(&ExtractionEvent::EnrichmentComplete {
+            slug: slug("api"),
+            language: "rust".into(),
+            added_edges: std::sync::Arc::from(edges.into_boxed_slice()),
+            new_nodes: empty_arc_nodes(),
+        }).unwrap();
+
+        let stats = c.stats.read().unwrap();
+        let count = stats.lsp_edge_counts
+            .get("api").expect("api")
+            .get("rust").copied().unwrap_or(0);
+        assert_eq!(count, 3, "lsp_edge_count should reflect added_edges length");
+    }
+
+    #[test]
+    fn test_passes_complete_marks_root_complete_and_clears_intermediate() {
+        let c = make_consumer();
+        // Simulate full pipeline for "api"
+        c.on_event(&ExtractionEvent::RootDiscovered {
+            slug: slug("api"), path: PathBuf::from("."), lsp_only: false,
+        }).unwrap();
+        c.on_event(&ExtractionEvent::RootExtracted {
+            slug: slug("api"), path: PathBuf::from("."),
+            nodes: std::sync::Arc::from(vec![].into_boxed_slice()),
+            edges: std::sync::Arc::from(vec![].into_boxed_slice()),
+        }).unwrap();
+        c.on_event(&ExtractionEvent::LanguageDetected {
+            slug: slug("api"), language: "rust".into(), nodes: empty_arc_nodes(),
+        }).unwrap();
+        c.on_event(&ExtractionEvent::EnrichmentComplete {
+            slug: slug("api"), language: "rust".into(),
+            added_edges: empty_arc_edges(), new_nodes: empty_arc_nodes(),
+        }).unwrap();
+        c.on_event(&ExtractionEvent::PassesComplete {
+            slug: slug("api"),
+            nodes: std::sync::Arc::from(vec![].into_boxed_slice()),
+            edges: std::sync::Arc::from(vec![].into_boxed_slice()),
+            detected_frameworks: std::collections::HashSet::new(),
+        }).unwrap();
+
+        let stats = c.stats.read().unwrap();
+        assert!(stats.is_root_complete("api"), "root should be complete after PassesComplete");
+        assert!(!stats.is_root_in_progress("api"), "root should not be in-progress after PassesComplete");
+        assert!(!stats.roots_extracted.contains_key("api"), "intermediate extracted state should be removed");
+        assert!(!stats.languages_in_flight.contains_key("api"), "in-flight languages should be cleared");
+    }
+
+    #[test]
+    fn test_no_activity_when_empty() {
+        let c = make_consumer();
+        let stats = c.stats.read().unwrap();
+        assert!(!stats.has_activity(), "fresh consumer has no activity");
+        assert!(!stats.is_root_complete("anything"));
+        assert!(!stats.is_root_in_progress("anything"));
+    }
+
+    /// Verify that stats_handle() and the consumer share the same allocation.
+    #[test]
+    fn test_stats_handle_shares_same_arc() {
+        let c = make_consumer();
+        let handle = c.stats_handle();
+        // Mutate through the consumer's internal Arc
+        c.on_event(&ExtractionEvent::RootDiscovered {
+            slug: slug("test"), path: PathBuf::from("."), lsp_only: false,
+        }).unwrap();
+        // Read through the handle — must see the mutation
+        let stats = handle.read().unwrap();
+        assert_eq!(stats.roots_queued, 1, "stats_handle must share the same Arc as the consumer");
+    }
+
+    /// Adversarial: EnrichmentComplete for a language that was never in-flight
+    /// must not panic and must still add the language to done.
+    #[test]
+    fn test_enrichment_complete_without_prior_language_detected() {
+        let c = make_consumer();
+        // No LanguageDetected fired before this
+        let result = c.on_event(&ExtractionEvent::EnrichmentComplete {
+            slug: slug("api"),
+            language: "go".into(),
+            added_edges: empty_arc_edges(),
+            new_nodes: empty_arc_nodes(),
+        });
+        assert!(result.is_ok(), "should not fail even without prior LanguageDetected");
+        let stats = c.stats.read().unwrap();
+        let done = stats.languages_done.get("api").expect("api should be in done");
+        assert!(done.contains(&"go".to_string()));
+    }
+
+    /// Adversarial: PassesComplete before RootDiscovered — must not panic.
+    #[test]
+    fn test_passes_complete_without_prior_discovered() {
+        let c = make_consumer();
+        let result = c.on_event(&ExtractionEvent::PassesComplete {
+            slug: slug("api"),
+            nodes: std::sync::Arc::from(vec![].into_boxed_slice()),
+            edges: std::sync::Arc::from(vec![].into_boxed_slice()),
+            detected_frameworks: std::collections::HashSet::new(),
+        });
+        assert!(result.is_ok(), "PassesComplete without prior events must not panic");
+        // Root is complete despite no prior events
+        let stats = c.stats.read().unwrap();
+        assert!(stats.roots_complete.contains_key("api"));
+        // has_activity is still false (roots_queued == 0)
+        assert!(!stats.has_activity(), "roots_queued not incremented — no RootDiscovered fired");
+    }
+}

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -27,6 +27,7 @@ impl RnaHandler {
         let graph = Arc::clone(&self.graph);
         let repo_root = self.repo_root.clone();
         let lance_write_lock = Arc::clone(&self.lance_write_lock);
+        let scan_stats = Arc::clone(&self.scan_stats);
         tokio::spawn(async move {
             // Track root slugs from the previous tick to detect removed worktrees.
             // Seed from the current resolved roots so the first tick doesn't
@@ -286,6 +287,7 @@ impl RnaHandler {
                             root_pairs,
                             primary_slug.clone(),
                             repo_root.clone(),
+                            Some(Arc::clone(&scan_stats)),
                         ) {
                             Ok((enriched_nodes, enriched_edges, detected_frameworks)) => {
                                 graph_state.nodes = enriched_nodes;

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -602,6 +602,7 @@ impl RnaHandler {
                     root_pairs,
                     primary_slug,
                     self.repo_root.clone(),
+                    Some(Arc::clone(&self.scan_stats)),
                 )?;
             all_nodes = enriched_nodes;
             all_edges = enriched_edges;
@@ -1072,6 +1073,7 @@ impl RnaHandler {
                     root_pairs_incremental,
                     primary_slug.clone(),
                     self.repo_root.clone(),
+                    Some(Arc::clone(&self.scan_stats)),
                 ).map_err(|e| {
                     // Pipeline invariant violated — abort the incremental update so the
                     // partial graph is not persisted. Scanner state is not committed on

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -157,11 +157,18 @@ impl RnaHandler {
             std::collections::HashSet::new()
         };
 
+        // Read the live scan stats from ScanStatsConsumer (populated during active scans).
+        // On cold start (no scan since process started) this will have no activity and
+        // list_roots_from_slugs will fall back to the graph-state/sentinel-file view.
+        let stats_guard = self.scan_stats.read().ok();
+        let scan_stats_ref = stats_guard.as_deref();
+
         let markdown = crate::service::list_roots_from_slugs(
             &self.repo_root,
             &active_slugs,
             graph_state_ref,
             Some(&self.lsp_status),
+            scan_stats_ref,
         );
         Ok(text_result(markdown))
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -81,6 +81,11 @@ pub struct RnaHandler {
     /// Populated from `[workspace.roots]` entries whose paths are subdirectories of `repo_root`.
     /// Each entry is `(slug, absolute_path)`.
     pub lsp_only_roots: Arc<Vec<(String, PathBuf)>>,
+    /// Live scan state maintained by `ScanStatsConsumer`.
+    /// Populated during active scans; empty/default until the first `RootDiscovered` event.
+    /// `list_roots` reads from this for in-progress status; falls back to sentinel files
+    /// on cold start when no bus events have fired for the current process lifetime.
+    pub scan_stats: Arc<std::sync::RwLock<crate::extract::scan_stats::ScanStats>>,
 }
 
 impl Default for RnaHandler {
@@ -99,6 +104,9 @@ impl Default for RnaHandler {
             non_code_root_slugs_cache: std::sync::Mutex::new(None),
             lance_write_lock: Arc::new(tokio::sync::Mutex::new(())),
             lsp_only_roots: Arc::new(Vec::new()),
+            scan_stats: Arc::new(std::sync::RwLock::new(
+                crate::extract::scan_stats::ScanStats::default(),
+            )),
         }
     }
 }

--- a/src/service/roots.rs
+++ b/src/service/roots.rs
@@ -3,9 +3,10 @@
 use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 
+use crate::extract::scan_stats::ScanStats;
+
 /// Per-root stats tuple: (node_count, edge_count) and language set.
 type RootStatsMap = (HashMap<String, (usize, usize)>, HashMap<String, BTreeSet<String>>);
-
 use crate::server::state::{LspEnrichmentStatus, LspState};
 
 // ── List roots ──────────────────────────────────────────────────────
@@ -23,11 +24,14 @@ use crate::server::state::{LspEnrichmentStatus, LspState};
 ///
 /// When `graph_state` is provided, per-root symbol and edge counts are included.
 /// When `lsp_status` is provided, LSP working/missing info is included.
+/// When `scan_stats` is provided and has live activity, per-root in-progress
+/// status is shown instead of the WAL-file fallback.
 pub fn list_roots_from_slugs(
     repo_root: &Path,
     active_slugs: &std::collections::HashSet<String>,
     graph_state: Option<&crate::server::state::GraphState>,
     lsp_status: Option<&LspEnrichmentStatus>,
+    scan_stats: Option<&ScanStats>,
 ) -> String {
     let workspace = crate::roots::WorkspaceConfig::load()
         .with_primary_root(repo_root.to_path_buf())
@@ -119,8 +123,53 @@ pub fn list_roots_from_slugs(
                 r.slug, primary, r.path.display(), r.config.root_type, r.config.git_aware);
 
             // Per-root stats line.
+            // Prefer live bus stats (ScanStatsConsumer) over WAL sentinel fallback.
             let (node_count, edge_count) = root_stats.get(&r.slug).copied().unwrap_or((0, 0));
-            if graph_state.is_some() {
+            if let Some(stats) = scan_stats {
+                if stats.has_activity() {
+                    // Live data from ScanStatsConsumer — can distinguish in-progress from idle.
+                    if stats.is_root_in_progress(&r.slug) {
+                        // Root is queued but PassesComplete not yet received.
+                        let in_flight_langs: Vec<String> = stats
+                            .languages_in_flight
+                            .get(&r.slug)
+                            .cloned()
+                            .unwrap_or_default();
+                        if in_flight_langs.is_empty() {
+                            line.push_str("\n  Scan: in progress");
+                        } else {
+                            line.push_str(&format!(
+                                "\n  Scan: in progress (enriching: {})",
+                                in_flight_langs.join(", ")
+                            ));
+                        }
+                    } else if stats.is_root_complete(&r.slug) {
+                        // Root completed in this process lifetime.
+                        if let Some(complete) = stats.roots_complete.get(&r.slug) {
+                            let secs = complete.completed_at.elapsed().as_secs();
+                            let age = if secs < 60 { "just now".to_string() }
+                                else if secs < 3600 { format!("{}m ago", secs / 60) }
+                                else if secs < 86400 { format!("{}h ago", secs / 3600) }
+                                else { format!("{}d ago", secs / 86400) };
+                            line.push_str(&format!(
+                                "\n  Last scan: {} | {} symbols | {} edges",
+                                age,
+                                format_count(complete.symbol_count),
+                                format_count(complete.edge_count),
+                            ));
+                        }
+                    }
+                    // else: root not yet seen in this scan — no stats line from bus
+                } else if graph_state.is_some() {
+                    // No bus activity yet (cold start): fall back to graph state.
+                    let scan_part = last_scan_age.as_deref().unwrap_or("not yet scanned");
+                    line.push_str(&format!("\n  Last scan: {} | {} symbols | {} edges",
+                        scan_part,
+                        format_count(node_count),
+                        format_count(edge_count)));
+                }
+            } else if graph_state.is_some() {
+                // No scan_stats provided: fall back to graph state (sentinel-derived).
                 let scan_part = last_scan_age.as_deref().unwrap_or("not yet scanned");
                 line.push_str(&format!("\n  Last scan: {} | {} symbols | {} edges",
                     scan_part,
@@ -206,7 +255,7 @@ fn format_count(n: usize) -> String {
 }
 
 pub fn list_roots(repo_root: &Path) -> String {
-    list_roots_from_slugs(repo_root, &std::collections::HashSet::new(), None, None)
+    list_roots_from_slugs(repo_root, &std::collections::HashSet::new(), None, None, None)
 }
 
 #[cfg(test)]
@@ -223,7 +272,7 @@ mod tests {
     #[test]
     fn test_list_roots_from_slugs_empty_falls_back_to_config() {
         let repo = std::env::current_dir().unwrap();
-        let result = list_roots_from_slugs(&repo, &std::collections::HashSet::new(), None, None);
+        let result = list_roots_from_slugs(&repo, &std::collections::HashSet::new(), None, None, None);
         // The primary root always exists (current dir is the RNA repo).
         assert!(result.contains("## Workspace Roots"), "should produce a roots header");
         assert!(result.contains("root(s)"), "should report root count");
@@ -248,7 +297,7 @@ mod tests {
         let mut active_slugs = std::collections::HashSet::new();
         active_slugs.insert(primary_slug.clone());
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, None, None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, None, None, None);
         assert!(result.contains("## Workspace Roots"), "should produce header");
         assert!(result.contains("1 root(s)"), "should show exactly 1 root when only primary slug is active");
         assert!(result.contains(&primary_slug), "should contain primary slug");
@@ -261,7 +310,7 @@ mod tests {
         let mut active_slugs = std::collections::HashSet::new();
         active_slugs.insert("ghost-root".to_string());
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, None, None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, None, None, None);
         assert!(result.contains("ghost-root"), "orphaned slug should appear");
         assert!(result.contains("path unknown"), "orphaned slug should have placeholder text");
     }
@@ -274,7 +323,7 @@ mod tests {
         // Simulate a ghost entry: empty slug from a pruned worktree
         active_slugs.insert("".to_string());
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, None, None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, None, None, None);
         // Empty slug must never appear as a root line "- ****: (path unknown ...)"
         assert!(!result.contains("- ****: (path unknown"), "empty slug should be excluded from output");
     }
@@ -287,7 +336,7 @@ mod tests {
         active_slugs.insert("".to_string());
         active_slugs.insert("real-orphan-zzz".to_string());
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, None, None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, None, None, None);
         assert!(!result.contains("- ****: (path unknown"), "empty slug should be excluded");
         assert!(result.contains("real-orphan-zzz"), "real orphan slug should still appear");
     }
@@ -299,7 +348,7 @@ mod tests {
         let mut active_slugs = std::collections::HashSet::new();
         active_slugs.insert("external".to_string());
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, None, None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, None, None, None);
         // "external" is filtered out; with nothing else the result reports 0 roots
         // or the fallback fires. Either way "external" must not appear as a root.
         assert!(!result.contains("**external**"), "external pseudo-slug should be excluded");
@@ -315,7 +364,7 @@ mod tests {
         let mut active_slugs = std::collections::HashSet::new();
         active_slugs.insert("definitely-not-primary-zzz".to_string());
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, None, None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, None, None, None);
         // The placeholder line for the orphaned slug should appear.
         assert!(result.contains("definitely-not-primary-zzz"), "non-primary orphan slug should appear");
         // The primary root slug (repo-native-alignment or similar) should NOT appear
@@ -342,7 +391,7 @@ mod tests {
         active_slugs.insert(primary_slug.clone());
         active_slugs.insert("external".to_string());
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, None, None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, None, None, None);
         // external should be excluded, primary should appear
         assert!(!result.contains("**external**"), "external should be excluded");
         assert!(result.contains(&primary_slug), "primary slug should appear");
@@ -359,7 +408,7 @@ mod tests {
         active_slugs.insert("external".to_string());
         active_slugs.insert("only-real-zzz".to_string());
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, None, None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, None, None, None);
         assert!(!result.contains("- ****: (path unknown"), "empty slug must be excluded");
         assert!(!result.contains("**external**"), "external must be excluded");
         assert!(result.contains("only-real-zzz"), "real orphan must appear");
@@ -444,7 +493,7 @@ mod tests {
         let edges = vec![make_edge_for_root(&primary_slug)];
         let gs = make_test_graph_state(nodes, edges);
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), None, None);
         assert!(result.contains("Last scan:"), "should show scan line, got: {}", result);
         assert!(result.contains("2 symbols"), "should show 2 symbols, got: {}", result);
         assert!(result.contains("1 edges"), "should show 1 edge, got: {}", result);
@@ -454,7 +503,7 @@ mod tests {
     #[test]
     fn test_list_roots_from_slugs_without_stats() {
         let repo = std::env::current_dir().unwrap();
-        let result = list_roots_from_slugs(&repo, &std::collections::HashSet::new(), None, None);
+        let result = list_roots_from_slugs(&repo, &std::collections::HashSet::new(), None, None, None);
         assert!(!result.contains("Last scan:"), "no stats line without graph_state, got: {}", result);
         assert!(!result.contains("symbols"), "no symbol count without graph_state, got: {}", result);
     }
@@ -477,7 +526,7 @@ mod tests {
         active_slugs.insert(primary_slug.clone());
 
         let gs = make_test_graph_state(vec![], vec![]);
-        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), None, None);
         assert!(result.contains("not yet scanned"), "should show not yet scanned, got: {}", result);
         assert!(result.contains("0 symbols"), "should show 0 symbols, got: {}", result);
     }
@@ -506,7 +555,7 @@ mod tests {
         lsp.set_server_name("rust-analyzer");
         lsp.set_complete(8410);
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), Some(&lsp));
+        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), Some(&lsp), None);
         assert!(result.contains("LSP: rust-analyzer"), "should show LSP server, got: {}", result);
         assert!(result.contains("8,410 edges"), "should show edge count with commas, got: {}", result);
     }
@@ -553,7 +602,7 @@ mod tests {
         let ts_langs: std::collections::HashSet<String> = ["typescript".to_string()].into();
         assert!(lsp_server_relevant_for_languages("typescript-language-server", &ts_langs));
 
-        let _ = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), Some(&lsp));
+        let _ = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), Some(&lsp), None);
     }
 
     /// format_count produces comma-separated thousands.
@@ -591,7 +640,7 @@ mod tests {
         let nodes = vec![make_node_for_root("other-root-xyz", "rust")];
         let gs = make_test_graph_state(nodes, vec![]);
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), None, None);
         assert!(result.contains("0 symbols"), "root with no nodes should show 0 symbols, got: {}", result);
         assert!(result.contains("0 edges"), "root with no edges should show 0 edges, got: {}", result);
     }
@@ -620,7 +669,7 @@ mod tests {
         let lsp = crate::server::state::LspEnrichmentStatus::default();
         lsp.set_complete(100); // Complete but no server_name set
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), Some(&lsp));
+        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), Some(&lsp), None);
         // Should not show "LSP:  (100 edges)" with empty server name.
         // The if let Some(ref name) guard prevents this.
         assert!(!result.contains("LSP:  ("), "should not show LSP line with empty server name, got: {}", result);
@@ -649,7 +698,7 @@ mod tests {
         let lsp = crate::server::state::LspEnrichmentStatus::default();
         lsp.set_unavailable(); // All servers unavailable
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), Some(&lsp));
+        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), Some(&lsp), None);
         // When LSP unavailable and no relevant missing servers: show "LSP: none detected".
         // (missing_servers is empty since we used default(), not probe_for_servers())
         assert!(result.contains("LSP: none detected"), "should show 'LSP: none detected' when unavailable, got: {}", result);
@@ -693,7 +742,7 @@ mod tests {
         };
         let gs = make_test_graph_state(nodes, vec![cross_edge]);
 
-        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), None);
+        let result = list_roots_from_slugs(&repo, &active_slugs, Some(&gs), None, None);
         // Cross-root edge counted under primary_slug (from.root == primary_slug).
         assert!(result.contains("1 edges"), "cross-root edge should be counted under from-root, got: {}", result);
     }


### PR DESCRIPTION
## Summary

- Adds `ScanStatsConsumer` in `src/extract/scan_stats.rs` that subscribes to extraction events and maintains live scan state in `Arc<RwLock<ScanStats>>`
- Registers `ScanStatsConsumer` first in `build_builtin_bus()` so it sees every event and the shared `Arc` is returned alongside the bus
- Wires `RnaHandler.scan_stats` field (already declared) to the live consumer via `build_builtin_bus()` in `build_full_graph_inner` and the background scanner
- `handle_list_roots` passes `scan_stats` to `list_roots_from_slugs`, which prefers live bus stats when `has_activity()` is true and falls back to graph-state/sentinel-file view on cold start
- `list_roots_from_slugs` shows `"Scan: in progress (enriching: rust, typescript)"` during active scans and `"Last scan: Xs ago | N symbols | M edges"` when complete via bus events

Also fixes pre-existing test regressions introduced in prior commits:
- `extractor_config.rs`: `topic_arg` is now `Option<usize>` — update test assertions from `0` to `Some(0)`  
- `service/roots.rs`: 8 tests called `list_roots_from_slugs` with 6 args instead of 5 — remove extra trailing `None`
- `extract/lsp/mod.rs`: add `use std::str::FromStr;` in the test module so `Uri::from_str()` resolves

Closes #521.

## Test plan

- [x] `cargo check --lib --tests` passes with no errors
- [x] `cargo test --lib` passes: 1565 tests, 0 failed
- [x] `ScanStatsConsumer` tests: `test_root_discovered_increments_queued`, `test_passes_complete_marks_root_complete_and_clears_intermediate`, `test_stats_handle_shares_same_arc`, adversarial tests
- [x] `build_builtin_bus` test verifies consumer count includes `ScanStatsConsumer`
- [x] `test_builtin_bus_returns_scan_stats_handle` verifies `RootDiscovered` → `stats.has_activity()` round-trip
- [x] `list_roots_from_slugs` stats tests: with/without scan_stats, in-progress vs complete states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live scan progress tracking shows real-time extraction/enrichment status for each root.
  * Roots listing now displays per-root stats: symbol count, edge count, and completion time when available.
  * In-progress scans indicate which languages are currently being enriched.
  * If live stats are unavailable, the roots listing falls back to the prior last-scan display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->