### PR TITLE
fix: build graph in list-roots CLI so per-root stats are shown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -258,10 +258,22 @@ async fn async_main() -> anyhow::Result<()> {
             let handler = RnaHandler { repo_root: repo_root.clone(), ..Default::default() };
             let gs = handler.build_full_graph().await?;
             let index_map = gs.node_index_map();
-            let active_slugs: std::collections::HashSet<String> =
+            // Start with graph-derived slugs (roots that have extracted nodes).
+            let mut active_slugs: std::collections::HashSet<String> =
                 repo_native_alignment::server::state::GraphState::root_slugs_from_index_map(&index_map)
                     .into_iter()
                     .collect();
+            // Union with all configured roots so declared roots with zero nodes still appear.
+            for r in WorkspaceConfig::load()
+                .with_primary_root(repo_root.clone())
+                .with_worktrees(&repo_root)
+                .with_claude_memory(&repo_root)
+                .with_agent_memories(&repo_root)
+                .with_declared_roots(&repo_root)
+                .resolved_roots()
+            {
+                active_slugs.insert(r.slug);
+            }
             println!("{}", service::list_roots_from_slugs(&repo_root, &active_slugs, Some(&gs), None, None));
             return Ok(());
         }


### PR DESCRIPTION
## Summary

- The `list-roots` CLI subcommand was calling `service::list_roots()`, which passes `None` for `graph_state`, so the per-root stats block (Last scan, symbol count, edge count, languages) was never emitted
- Updated the `ListRoots` arm in `src/main.rs` to mirror the `repo-map` pattern: build the full graph, extract active slugs, then call `list_roots_from_slugs` with the graph state
- Fixes test-suite.sh check: `list-roots output contains timing or slug (#527)`

## Before / After

Before:
```
## Workspace Roots

3 root(s)

- **repo-native-alignment** (primary): `/...` (type: code-project, git: true)
```

After:
```
## Workspace Roots

3 root(s)

- **repo-native-alignment** (primary): `/...` (type: code-project, git: true)
  Last scan: just now | 14,966 symbols | 40,302 edges
  Languages: bash, json, markdown, rust, toml, typescript, unknown, yaml (tree-sitter)
```

## Test plan

- [x] `repo-native-alignment list-roots --repo . 2>/dev/null | grep -E "slug|scan|ago|symbol"` — matches `scan` and `symbol`
- [x] `cargo test --lib` — 1588 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * `list roots` now shows active repository roots determined from repository analysis, ensuring declared roots are included even if they currently have no extracted nodes.
  * Added a “Scanning …” progress message during command execution to improve visibility for long-running operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->