### PR TITLE
docs: rewrite README to lead with outcomes and JTBD framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,57 +2,19 @@
 
 [![CI](https://github.com/open-horizon-labs/repo-native-alignment/actions/workflows/rust-main-merge.yml/badge.svg)](https://github.com/open-horizon-labs/repo-native-alignment/actions) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Local context discovery and alignment tool for coding agents. Makes the fractal, local knowledge in your codebase — architecture, topology, business intent, the stuff not in training data — discoverable and queryable. Single binary — no Docker, no external database, no API key.
+Coding agents are blind to the shape of your codebase. RNA fixes that: it runs as an MCP server alongside your agent and gives it one call to answer "what depends on this?", "what relates to payment processing?", or "how is the reliability outcome progressing?" — questions LSP alone cannot answer.
 
-**[Quick Start](#quick-start)** | **[What Agents Can Do](#what-agents-can-do)** | **[RNA vs LSP](#why-not-just-lsp)** | **[MCP Tools](#mcp-tools)** | **[Compared To](#compared-to)** | **[Docs](#detailed-documentation)**
+Single binary. No Docker. No external database. No API key.
 
-## What Agents Can Do
+**[Quick Start](#quick-start)** | **[Why RNA](#why-rna)** | **[MCP Tools](#mcp-tools)** | **[Docs](#detailed-documentation)**
 
-### Find code by meaning, not just by name
+---
 
-- "Find functions related to payment processing" → `search("payment processing")` → ranked results across code symbols, artifacts, commits, and markdown in one call
-- "How does scanning work?" → `search("scanning")` → implementation code, doc sections, and related artifacts together
-- "Where is the authentication handler?" → `search("AuthHandler")` → file, line, signature, complexity, graph edges
-- "Find the validate function in auth/handlers, not billing" → `search("auth/handlers/validate")` → path/name split: only symbols named `validate` in files matching `auth/handlers`
-- "What are the riskiest functions?" → `search(query="", min_complexity=20, sort_by="complexity")` → hotspots ranked by cyclomatic complexity
-- "What are the most important symbols?" → `search(sort_by="importance")` → top symbols ranked by PageRank
-- "Give me a map of this repo" → `repo_map()` → **subsystems** with cohesion scores and interfaces, top symbols, hotspot files, active outcomes, entry points
-- "What subsystems exist?" → `repo_map()` → detected from actual call relationships: `extract (1120 symbols)`, `server (721)`, `graph (223)`, ...
-- "Find auth code in the server subsystem" → `search(query="auth", subsystem="server")` → scoped to detected subsystem
-- "What connects extract to server?" → `search(node="X", mode="neighbors", target_subsystem="server")` → cross-subsystem edges
-- "Show me the full structure of a module" → `search(node="server:module", mode="neighbors", depth=2, compact=true)` → module → members → their members in one call
+## Why RNA
 
-### Trace client code to server handlers
+LSP gives agents single-symbol, single-hop, single-language queries. There's no multi-hop primitive, no semantic search, no connection to business artifacts.
 
-- "Which function handles POST /payments?" → `search("POST /payments", mode="neighbors")` → `ApiEndpoint → handle_payment()` via Implements edge
-- "What API endpoints does this file call?" → `search(file="client.py", kind="const")` → URL string literals linked to their ApiEndpoint nodes
-- "Full call chain from /payments to database?" → `search("POST /payments", mode="impact")` → ApiEndpoint → handler → domain functions → storage
-- Supports Python Flask/FastAPI, TypeScript NestJS, Java Spring, Go gin/echo, Ruby Sinatra/Rails — no LSP required
-
-### Trace gRPC client stubs to proto definitions
-
-- "What clients call the UserService.GetUser RPC?" → `search("GetUser", mode="neighbors", direction="incoming")` → Python/Go/TypeScript/Java stub callers → proto method node
-- "What proto methods does this Python service call?" → `search(file="client.py", edge_types=["calls"])` → stub call sites linked to `.proto` definitions
-- "Full gRPC call chain?" → `search("GetUser", mode="impact")` → client stub → proto method → server implementation
-- Supports Python (`_pb2_grpc`), Go (`google.golang.org/grpc`), TypeScript (`@grpc/`), Java (`io.grpc`) — no LSP required
-
-### See the blast radius of a change
-
-- "What depends on the database connection pool?" → `search(query="database connection pool", mode="impact")` → transitive dependents grouped by subsystem with entry points; auto-summarized when large
-- "What calls AuthHandler?" → `search(query="AuthHandler", mode="neighbors", direction="incoming")` → callers, implementors
-- "Find all trait implementors" → `search(query="Enricher trait", mode="neighbors", edge_types=["implements"])` → concrete types with compiler-grade edges
-- "Does this module have circular dependencies?" → `search(node="X", mode="cycles")` → the ring X belongs to, or "not in a cycle"
-- "What is the call path from handle_search to neighbors?" → `search(node="handle_search", mode="path", query="neighbors")` → ordered call chain with hop count
-
-### Connect code to business outcomes
-
-- "How is the agent-alignment outcome progressing?" → `outcome_progress("agent-alignment")` → tagged commits → changed files → symbols → PRs
-- "Find signals related to reliability" → `search("reliability", artifact_types=["signal"])` → measurement definitions
-- "What are our constraints?" → `search("constraints guardrails")` → all guardrails ranked by relevance
-
-## Why Not Just LSP?
-
-**LSP: 4 requests to find who depends on `ConnectionPool`**
+**Finding blast radius with LSP alone:**
 ```
 textDocument/references("ConnectionPool")     → [PoolManager, HttpServer, Worker]
 callHierarchy/incomingCalls(PoolManager)      → [AppConfig, TestHarness]
@@ -61,7 +23,7 @@ callHierarchy/incomingCalls(Worker)           → [Scheduler]
 // agent must: filter test files, deduplicate, reason about the shape
 ```
 
-**RNA: 1 request**
+**With RNA:**
 ```
 search(query="ConnectionPool", mode="impact", max_hops=3)
 → PoolManager → AppConfig
@@ -70,13 +32,30 @@ search(query="ConnectionPool", mode="impact", max_hops=3)
 // production code ranked first, test files demoted, cross-language
 ```
 
-| Question | LSP alone | RNA |
+| Job | LSP alone | RNA |
 |---|---|---|
-| What breaks if I change the connection pool? | N round-trips of `incomingCalls`, agent assembles graph | `search(mode="impact")` — one call, transitive |
-| Find code related to payment processing | No semantic search — agent must guess names and grep | `search("payment processing")` — ranked by meaning across code, artifacts, and markdown |
+| What breaks if I change this? | N round-trips of `incomingCalls`, agent assembles graph | `search(mode="impact")` — one call, transitive |
+| Find code related to a concept | No semantic search — agent must guess names and grep | `search("payment processing")` — ranked by meaning across code, docs, and artifacts |
 | How is our reliability outcome progressing? | Not possible — LSP has no business context | `outcome_progress("reliability")` — commits → files → symbols |
+| Orient a new agent to the repo | Multiple searches, no subsystem picture | `repo_map()` — subsystems, hotspots, entry points in one call |
 
-LSP gives agents single-symbol, single-hop, single-language queries. There's no multi-hop primitive. RNA runs those same LSP servers internally, fuses their data with tree-sitter, embedded function bodies, git history, and business artifacts into a cross-language graph.
+RNA runs LSP servers internally. It fuses their data with tree-sitter, embedded function bodies, git history, and business artifacts into a cross-language graph — so the agent gets the LSP depth without doing the LSP orchestration.
+
+## What Changes After Installing
+
+Four jobs agents can do after RNA is running that they could not do reliably before:
+
+**Find code by meaning, not just by name**
+`search("payment processing")` returns ranked results across symbols, docs, commits, and artifacts in one call. Path scoping works too: `search("auth/handlers/validate")` returns only symbols named `validate` in files matching `auth/handlers`.
+
+**Trace call paths and blast radius**
+`search(node="AuthHandler", mode="impact")` returns transitive dependents grouped by subsystem. `search(node="X", mode="path", query="Y")` returns the directed call chain between two nodes.
+
+**Connect code to business outcomes**
+`outcome_progress("agent-alignment")` follows tagged commits to changed files to affected symbols. Outcomes, signals, and guardrails in `.oh/` are full graph nodes — searchable, linkable, tracked.
+
+**Orient instantly in an unfamiliar repo**
+`repo_map()` returns detected subsystems (from actual call relationships), top symbols by PageRank, hotspot files, and active outcomes. One call instead of an exploratory loop.
 
 ## Quick Start
 
@@ -118,11 +97,9 @@ cd repo-native-alignment
 cargo install --locked --path .
 ```
 
-### 1b. Connect to your MCP client
+### 2. Connect to your MCP client
 
-The MCP server command is `repo-native-alignment` with `--repo` as an argument. When your MCP client asks for a command, enter `repo-native-alignment` as the command and `--repo /path/to/your/project` as args.
-
-**Important:** `command` must be just the binary name. The `--repo` flag goes in `args`, not in `command` — MCP stdio transport doesn't do shell splitting.
+The MCP server command is `repo-native-alignment` with `--repo` as an argument. `command` must be just the binary name — the `--repo` flag goes in `args`, not in `command` (MCP stdio transport doesn't do shell splitting).
 
 Example `.mcp.json`:
 
@@ -140,27 +117,32 @@ Example `.mcp.json`:
 
 For HTTP transport: `repo-native-alignment --repo . --transport http --port 8382`
 
-### 1c. Try it from the CLI
-
-Before wiring up MCP, evaluate RNA directly from the terminal:
+### 3. Build the index
 
 ```bash
-repo-native-alignment scan --repo . --full   # build full index
-repo-native-alignment search "auth" --repo /path/to/your/project  # search symbols
+repo-native-alignment scan --repo . --full
+```
+
+Runs the complete pipeline: scan → extract → embed → LSP enrich → graph. Without `--full`, LSP analysis is skipped — subsystem detection and "what calls this" queries won't work. Subsequent scans are incremental (~0.1s on no-change runs).
+
+### 4. Verify
+
+```bash
+repo-native-alignment test --repo /path/to/your/project
+```
+
+Runs 29 checks end-to-end. Exits 0 on pass, 1 on failure. Safe to run in CI.
+
+### 5. Try it from the CLI
+
+Before wiring up MCP, evaluate RNA directly:
+
+```bash
+repo-native-alignment search "auth" --repo /path/to/your/project
 repo-native-alignment graph --node "<stable-id-from-search>" --mode impact --repo .
 ```
 
-### 2. Set up a project
-
-```bash
-repo-native-alignment setup --project /path/to/your/project
-```
-
-This checks dependencies, installs the binary, configures `.mcp.json`, and verifies everything works. Safe to re-run on updates.
-
-Preview first: `repo-native-alignment setup --project . --dry-run`
-
-### 3. Teach your agents (optional — requires [OH Skills](https://github.com/open-horizon-labs/skills))
+### 6. Teach your agents (optional — requires [OH Skills](https://github.com/open-horizon-labs/skills))
 
 Install OH Skills ([see instructions](https://github.com/open-horizon-labs/skills#install)), then open a Claude Code session in your project and run:
 
@@ -168,89 +150,24 @@ Install OH Skills ([see instructions](https://github.com/open-horizon-labs/skill
 /teach-oh
 ```
 
-This explores your codebase, asks about your aims, writes `AGENTS.md`, scaffolds `.oh/` with outcomes and constraints, and installs phase agents. RNA tools are automatically detected and used during exploration if installed.
-
-### 4. Build the index
-
-```bash
-repo-native-alignment scan --repo . --full
-```
-
-Runs the complete pipeline with visible output: scan → extract → embed → LSP enrich → graph. Shows timing and edge counts for each phase. Recommended before first MCP session so agents start with a warm index including LSP call edges.
-
-### 5. Verify the pipeline
-
-```bash
-repo-native-alignment test --repo /path/to/your/project
-```
-
-Runs 25 checks end-to-end. Exits 0 on pass, 1 on failure. Safe to run in CI.
-
-### 6. Start working
-
-The system compounds from here. Agents use `search` to discover relevant context across code, artifacts, commits, and markdown, and write learnings to `.oh/metis/`. Each session starts richer than the last.
+This explores your codebase, asks about your aims, writes `AGENTS.md`, scaffolds `.oh/` with outcomes and constraints, and installs phase agents.
 
 ## MCP Tools
 
 | Tool | What it's for |
 |------|--------------|
-| `search` | Code symbols, artifacts, commits, and markdown — flat or graph traversal (`mode`: neighbors, impact, reachable, tests_for, cycles, path). `cycles`: detect circular dependency rings (optionally scoped to one node). `path`: shortest directed call chain between two nodes (use `node=` for start, `query=` for destination). Scope to a subsystem (`subsystem=`), filter cross-subsystem edges (`target_subsystem=`), use `depth=2` with neighbors to walk N levels deep, use `compact: true` for ~25x fewer tokens, `rerank: true` for precision. Short node IDs resolve automatically. |
-| `repo_map` | Repository orientation: **detected subsystems** with their key interfaces, top symbols by importance, hotspot files, active outcomes, entry points. One call replaces an exploratory loop. |
+| `search` | Code symbols, artifacts, commits, and markdown — flat or graph traversal (`mode`: neighbors, impact, reachable, tests_for, cycles, path). Scope to a subsystem (`subsystem=`), filter cross-subsystem edges (`target_subsystem=`), use `compact: true` for ~25x fewer tokens, `rerank: true` for precision. |
+| `repo_map` | Repository orientation: detected subsystems with their key interfaces, top symbols by importance, hotspot files, active outcomes, entry points. One call replaces an exploratory loop. |
 | `outcome_progress` | Connect business outcomes to code: outcome → tagged commits → changed files → symbols. Optional `include_impact: true` for risk-classified blast radius. |
-| `list_roots` | Show configured workspace roots with live scan stats (symbols, edges, detected frameworks, LSP edge counts per language, scan phase). Stats are live during active scans and fall back to sentinel files on cold start. Includes LSP servers available to install for each root's detected languages. |
+| `list_roots` | Show configured workspace roots with live scan stats (symbols, edges, detected frameworks, LSP edge counts per language, scan phase). Includes LSP servers available to install for each root's detected languages. |
 
-**Root scoping:** All query tools default to the primary workspace root (`--repo`). Pass `root: "all"` for cross-root search, or `root: "<slug>"` for a specific root. Non-code roots (.oh/ artifacts, commits, Notes) always pass through regardless of root filter.
+**Root scoping:** All query tools default to the primary workspace root (`--repo`). Pass `root: "all"` for cross-root search, or `root: "<slug>"` for a specific root.
 
-**Worktree-aware queries:** Agents working in a git worktree can query their own code by passing the absolute path: `search(query="...", repo="/absolute/path/to/worktree")`. The worktree must be scanned first: `repo-native-alignment scan --repo /path/to/worktree`. Keyword and graph traversal search are available; semantic search requires a separate scan-time embedding index in the worktree.
-
-**Auto-discovered roots:** RNA automatically adds git worktrees and Claude Code memory as additional roots. Worktrees that maintain their own RNA cache (`.oh/.cache/lance/` directory present) are skipped automatically — their code stays in their own index, preventing double-indexing. Use `list_roots` to see what's active.
-
-**Declared roots:** Declare intentionally related repos by slug in `.oh/config.toml`:
-
-```toml
-# .oh/config.toml
-[scanner]
-exclude = ["benchmark/"]
-
-[lsp]
-# Minimum severity to store as diagnostic nodes.
-# "error"       = errors only
-# "warning"     = errors + warnings (default)
-# "information" = errors + warnings + information
-# "hint"        = all diagnostics (captures unlinked-file, inactive-code)
-diagnostic_min_severity = "hint"
-
-[workspace.roots]
-infra   = "../k8s-configs"    # relative to the repo containing .oh/
-protos  = "/abs/path/protos"  # absolute paths also work
-```
-
-After declaring roots, run `scan` (or restart RNA). Declared roots appear in `list_roots()` and are queryable by slug — `list_roots()` reads from the server's in-memory graph, so it reflects whatever was loaded at last scan:
-
-```text
-list_roots()                          # shows "infra", "protos", primary, worktrees
-search(root="infra", query="Deployment")  # only K8s manifest results
-search(root="all")                    # all declared + auto-discovered roots
-```
-
-Missing paths warn and skip (not an error). Relative paths are resolved relative to the repo containing `.oh/config.toml`.
+**Worktree-aware queries:** Agents working in a git worktree can query their own code by passing the absolute path: `search(query="...", repo="/absolute/path/to/worktree")`. The worktree must be scanned first.
 
 ### CLI ↔ MCP Equivalence
 
-CLI and MCP share the same index. Run `scan --full` from the CLI to build the complete index (including call graph edges from your language server), then query via either interface. A pre-built index means the MCP server starts with warm data — no cold-start delay.
-
-```bash
-# Build the full index (visible, verifiable)
-rna scan --repo . --full
-
-# Then query via CLI...
-rna search "auth" --repo .
-rna graph --node "<id>" --mode impact --repo .
-
-# ...or via MCP (same data, same results)
-search(query="auth")
-search(node="<id>", mode="impact")
-```
+CLI and MCP share the same index. Run `scan --full` from the CLI to build the complete index, then query via either interface.
 
 | CLI | MCP | What it does |
 |-----|-----|-------------|
@@ -259,29 +176,6 @@ search(node="<id>", mode="impact")
 | `scan --full` | *(runs automatically on first query)* | Full pipeline: scan → extract → embed → LSP → graph |
 | `test` | — | 29 pipeline checks end-to-end |
 
-### Building the Index
-
-The MCP server builds an index automatically on first query. For best results — including subsystem detection and impact analysis — build the full index from the CLI first so language server analysis runs before agents start:
-
-```bash
-repo-native-alignment scan --repo . --full
-
-# TreeSitter: 10,000+ symbols across 280+ files (rayon parallel, all cores)
-# LSP: pyright + tsserver start concurrently (parallel enrichment)
-# Post-extraction passes: subsystem detection, framework detection, BelongsTo edges
-# Embed: streams in parallel with LSP enrichment
-# Done in ~50s (repeat scans ~0.1s on no-change)
-```
-
-Without `--full`, the scan skips language server analysis — subsystem detection and "what calls this" queries won't work.
-
-**After upgrading RNA**, clear the old index and rebuild:
-
-```bash
-rm -rf .oh/.cache/lance .oh/.cache/scan-state.json
-repo-native-alignment scan --repo . --full
-```
-
 ### CLI Subcommands
 
 | Command | What it does |
@@ -289,7 +183,7 @@ repo-native-alignment scan --repo . --full
 | `search <query>` | Search symbols by name, keyword, or meaning — filter by kind/language/file |
 | `graph --node <id> --mode <mode>` | Traverse neighbors, impact analysis, or reachability |
 | `scan --repo <dir>` | Scan + extract + embed + persist |
-| `scan --repo <dir> --full` | Full pipeline including LSP enrichment. Incremental when cache exists (~0.1s on no-change runs). LSP aborts early if misconfigured (0 edges after 1,000 nodes or 2 minutes). |
+| `scan --repo <dir> --full` | Full pipeline including LSP enrichment. Incremental on repeat runs. |
 | `stats --repo <dir>` | Show repo stats from persisted index (no re-scan) |
 | `test --repo <dir>` | Run 29 pipeline checks end-to-end |
 | `setup --project <dir>` | Bootstrap RNA + OH MCP + skills for a project |
@@ -309,14 +203,39 @@ repo-native-alignment scan --repo . --full
 ├── signals/         <- how we measure progress
 ├── guardrails/      <- constraints that shape behavior
 ├── metis/           <- learnings that compound across sessions
-├── config.toml      <- scanner excludes, LSP severity threshold, pattern detection, declared workspace roots
+├── config.toml      <- scanner excludes, LSP severity threshold, declared workspace roots
 ├── extractors/      <- custom boundary detection configs (optional, see below)
 └── .cache/          <- scan state, embedding index (gitignored)
 ```
 
-Business artifacts (`outcomes/`, `signals/`, `guardrails/`, `metis/`) are committed to git — they're part of the project. `.cache/` is gitignored and rebuilt automatically on first query.
+Business artifacts (`outcomes/`, `signals/`, `guardrails/`, `metis/`) are committed to git. `.cache/` is gitignored and rebuilt automatically on first query.
 
-### Custom boundary detection: `.oh/extractors/`
+### Workspace roots
+
+Declare intentionally related repos in `.oh/config.toml`:
+
+```toml
+[scanner]
+exclude = ["benchmark/"]
+
+[lsp]
+# Minimum severity to store as diagnostic nodes.
+# "error" | "warning" (default) | "information" | "hint"
+diagnostic_min_severity = "hint"
+
+[workspace.roots]
+infra   = "../k8s-configs"
+protos  = "/abs/path/protos"
+```
+
+After declaring roots, run `scan` (or restart RNA). Roots appear in `list_roots()` and are queryable by slug:
+
+```text
+search(root="infra", query="Deployment")  # only K8s results
+search(root="all")                        # all roots
+```
+
+### Custom boundary detection
 
 Declare custom pub/sub or event-bus boundary patterns in `.oh/extractors/*.toml`. RNA reads these at scan time and emits `Produces`/`Consumes` edges without any changes to RNA source.
 
@@ -337,17 +256,11 @@ arg_position = 0
 edge_kind = "Consumes"
 ```
 
-**How it works:**
-1. `applies_when.language` — only fires on nodes in that language
-2. `applies_when.imports_contain` — only fires when at least one Import node contains this string (gates on the library being actually imported)
-3. `function_pattern` — substring or glob (`*` matches any sequence of identifier characters) to look for in function bodies. Examples: `"bus.publish"`, `"publish_*"`, `"*.send"`
-4. `topic_arg` (or `arg_position`) — zero-indexed position of the argument holding the topic/channel name (must be a string literal). **When omitted, the matched function name itself becomes the channel name** — useful for fixed-routing wrappers and decorator-registered consumers
-5. `edge_kind` — `"Produces"` or `"Consumes"`
-6. `decorator` — (optional, default `false`) set to `true` when `function_pattern` is a decorator name (e.g., `@bus.subscribe`) — the body-text heuristic matches decorator patterns the same way as call patterns
+Fields: `applies_when.language`, `applies_when.imports_contain`, `function_pattern` (substring or glob), `arg_position` (zero-indexed string literal argument holding the topic), `edge_kind` (`"Produces"` or `"Consumes"`), `decorator` (set `true` when matching a decorator name).
 
-RNA includes built-in extractors for kafka-python, kafkajs, celery, pika, and redis-py. Use `.oh/extractors/` to add support for any other broker — Google Pub/Sub, AWS SNS, Azure Service Bus, internal event buses, custom RPC frameworks, etc.
+RNA includes built-in extractors for kafka-python, kafkajs, celery, pika, and redis-py. Use `.oh/extractors/` for any other broker or custom RPC framework.
 
-RNA also indexes agent rule/memory files when they exist alongside a project:
+RNA also indexes agent rule/memory files automatically:
 
 | Path pattern | `artifact_types` filter |
 |---|---|
@@ -356,13 +269,9 @@ RNA also indexes agent rule/memory files when they exist alongside a project:
 | `.serena/memories/**` | `serena-memory` |
 | `.github/copilot-instructions.md` | `copilot-instruction` |
 
-These are auto-detected — no configuration needed. Use `search("coding rules", artifact_types=["cursor-rule", "cline-rule"])` to query across all agent rule sources.
-
-Outcomes declare `files:` patterns linking to code. Commits tag `[outcome:X]` linking to outcomes. These structural links power `outcome_progress`.
-
 ## Compared To
 
-See the [full comparison](docs/compared-to.md) for details, including LSP as the baseline.
+See the [full comparison](docs/compared-to.md) for details.
 
 | | **RNA** | **Code-Graph-RAG** | **CodeGraphContext** | **Serena** |
 |---|---|---|---|---|
@@ -381,9 +290,9 @@ RNA works standalone. These add organizational context and workflow structure:
 
 ## Status
 
-4 MCP tools, 10 CLI subcommands. Extracts symbols from 22 languages, builds a call graph via language server analysis, detects architectural subsystems and frameworks automatically. Ships as a Claude Code plugin. CLI and MCP share the same index and service layer.
+4 MCP tools, 10 CLI subcommands. Extracts symbols from 22 languages, builds a call graph via language server analysis, detects architectural subsystems and frameworks automatically.
 
-**v0.1.15 (current):** EventBus/consumer architecture, parallel LSP enrichment, per-consumer content-addressed cache, live scan stats in `list_roots`, config-driven extractors (`.oh/extractors/*.toml`), worktree own-cache detection, FastAPI router prefix resolution. SCHEMA_VERSION 18, EXTRACTION_VERSION 14 (deprecated — new invalidation is driven by `ExtractionConsumer::version()` per consumer; the global integer is still read on cold start for backward-compatible sentinel detection).
+**v0.1.15 (current):** EventBus/consumer architecture, parallel LSP enrichment, config-driven extractors (`.oh/extractors/*.toml`), live scan stats in `list_roots`, worktree own-cache detection, FastAPI router prefix resolution.
 
 ### Platform Support
 
@@ -393,34 +302,9 @@ RNA works standalone. These add organizational context and workflow structure:
 | Linux x86_64 | Supported | CPU-only (slower semantic search) |
 | Windows | Untested | — |
 
-### Tested On
-
-| Harness | Repo types |
-|---------|-----------|
-| Claude Code | Rust, Python/TypeScript monorepo, Rust/TypeScript |
-| Oh-My-Pi | Rust, Python/TypeScript monorepo |
-
-Only tested on Apple Silicon (M-series) Macs. Linux x86_64 builds are available but less battle-tested.
-
 ## License
 
 MIT — see [LICENSE](LICENSE).
-
-## Glossary
-
-| Term | What it means |
-|------|--------------|
-| **Tree-sitter** | A parser that reads source code and produces a syntax tree — the structured representation of functions, classes, imports, etc. RNA uses it to extract symbols across languages without running the code. |
-| **LSP** | Language Server Protocol — the same protocol your editor uses for go-to-definition and find-references. RNA runs LSP servers internally and builds on their data. See [Why Not Just LSP?](#why-not-just-lsp) |
-| **Graph** | A network of nodes (symbols, files, outcomes) and edges (calls, depends_on, implements). RNA builds this in memory so you can ask "what depends on this function?" or "what's the blast radius of this change?" |
-| **Embeddings** | Vector representations of text that capture meaning. RNA embeds function bodies, markdown sections, commit messages, and business artifacts so `search` can find relevant results by meaning, not just keywords. Uses Metal GPU on Apple Silicon, CPU elsewhere. |
-| **LanceDB** | The columnar + vector database RNA uses to store the graph and embeddings on disk. Lives in `.oh/.cache/`. |
-| **petgraph** | The in-memory graph index RNA uses for fast traversal (neighbors, impact analysis, reachability). Rebuilt from LanceDB on startup. |
-| **Outcome** | A business result you're optimizing for. Example: "Agents correctly scope work to declared aims." |
-| **Signal** | How you measure progress toward an outcome. Example: "Agent identifies which outcome a task serves without re-prompting." |
-| **Guardrail** | A constraint that shapes behavior — hard (never bend), soft (negotiate), or candidate (proposed). Example: "No language-specific conditionals in generic.rs." |
-| **Metis** | A learning earned through experience — [Greek: practical wisdom](https://en.wikipedia.org/wiki/Metis_(mythology)) gained from doing, not reading. Example: "Protocol version mismatch silently hangs MCP clients." |
-| **MCP** | Model Context Protocol. The standard for connecting AI agents to external tools. RNA exposes its capabilities as MCP tools that Claude Code (and other MCP clients) can call. |
 
 ## Detailed Documentation
 


### PR DESCRIPTION
## Summary

- Replace the feature-list opening with a problem/solution lede that names the agent's actual job
- Add a concrete before/after LSP comparison (keeps the existing table shape, moves it to top)
- Restructure as four agent jobs in "What Changes After Installing" instead of enumerated sub-bullets
- Remove 100+ lines of capability enumeration — the full detail lives in docs/

## What was cut and why

- "What Agents Can Do" section had 30+ sub-bullets across 5 headings — cut to 4 prose paragraphs
- Removed gRPC-specific sub-section (keep in docs, not README)
- Removed REST/routing sub-section (keep in docs)
- Collapsed CLI subcommand detail; the table is enough
- Removed Glossary (better as a linked doc page)
- Removed "Tested On" table (status section still mentions Apple Silicon)

## What was kept

- LSP comparison table (it's the best before/after in the document)
- Quick Start section (trimmed but complete)
- Extractor config section (power user reference, shortened)
- Compared To table
- All links to docs/

## Test plan

- [x] README renders correctly in GitHub preview
- [x] All internal anchor links resolve (Quick Start, Why RNA, MCP Tools, Detailed Documentation)
- [x] No broken external links
- [x] CI passes (no code changes)