### PR TITLE
test: add ADR constraint checks using RNA CLI queries (#543)

### DIFF
--- a/scripts/test-suite.sh
+++ b/scripts/test-suite.sh
@@ -369,7 +369,7 @@ check "ADR: PostExtractionRegistry zero .rs references in src/ (#523)" \
 check "ADR: subsystem_node_pass indexed by RNA (#542)" \
   "repo-native-alignment search 'subsystem_node_pass' --repo $RNA_REPO --kind function --limit 3 2>/dev/null" "subsystem_node_pass"
 check "ADR: subsystem_node_pass bypass tracked in open issue #542" \
-  "gh issue view 542 --repo open-horizon-labs/repo-native-alignment 2>/dev/null || echo 'SKIP_NO_GH'" "OPEN\|SKIP_NO_GH"
+  "gh issue view 542 --repo open-horizon-labs/repo-native-alignment --json state -q '.state' 2>/dev/null || echo 'SKIP_NO_GH'" "OPEN\|SKIP_NO_GH"
 
 echo ""
 echo "=== RESULTS: $PASS passed, $FAIL failed, $SKIP skipped ==="


### PR DESCRIPTION
## Summary

- Adds a new `--- ADR Architecture Constraints (#543) ---` section to `scripts/test-suite.sh` with 9 checks that use RNA CLI (`search`, graph) as assertions — RNA enforcing its own architecture through its own graph
- Fixes 4 stale checks that referenced `post_extraction.rs` (deleted in #523) and `PostExtractionConsumer` (renamed to `EnrichmentFinalizer` in #523), which would have been failing silently

## Constraints implemented

| # | Constraint | Mechanism |
|---|-----------|-----------|
| 1 | `PostExtractionRegistry` absent from `src/` | `grep` on `src/` |
| 2 | No `if framework ==` in `src/server/` | `grep` on `src/server/` |
| 3 | `api_link_pass` not bypassed in `src/server/`; indexed by RNA | grep + RNA `search --kind function` |
| 4 | `FastapiRouterPrefixConsumer` subscribes to `FrameworkDetected` (not unconditional); indexed as struct | grep `subscribes_to` + RNA `search --kind struct` |
| 5 | `PostExtractionRegistry` zero `.rs` references in `src/` | `grep --include='*.rs'` |
| 6 | `subsystem_node_pass` indexed by RNA; bypass tracked in open issue #542 | RNA `search --kind function` + `gh issue view 542` |

## Stale checks fixed

- `PostExtractionRegistry (#493)` section: 3 checks referencing deleted `post_extraction.rs` → replaced with verification that the file is gone and `EnrichmentFinalizer` took its place
- FastAPI Router Prefix section (#519, #531): 2 checks referencing `reg.register.*FastapiRouterPrefixPass` in deleted `post_extraction.rs` → updated to check `FastapiRouterPrefixConsumer` in `consumers.rs`
- LspConsumer + AllEnrichmentsGate section (#528): `PostExtractionConsumer subscribes to AllEnrichmentsDone` → updated to `EnrichmentFinalizer subscribes to AllEnrichmentsDone`

## Test plan

- [x] All 15 new/updated checks pass locally (verified before commit)
- [x] `bash scripts/test-suite.sh` produces 0 FAIL
- [x] Breaking a constraint (e.g., adding `if framework == "fastapi"` to `server/graph.rs`) causes the relevant check to FAIL

Closes #543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened test suite to validate migration to an event/consumer architecture, including consumer subscriptions, router wiring, and end-to-end enrichment completion.
  * Added repository-level architectural invariant checks and a conditional verification against an external issue tracker.

* **Chores**
  * Updated test scripts and infrastructure to enforce code-organization and architectural constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->