### PR TITLE
feat: route subsystem detection through EventBus pipeline (#542)

### DIFF
--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -1605,7 +1605,7 @@ impl ExtractionConsumer for SubsystemConsumer {
     }
 
     fn on_event(&self, event: &ExtractionEvent) -> anyhow::Result<Vec<ExtractionEvent>> {
-        let ExtractionEvent::CommunityDetectionComplete { slug, subsystems, nodes, .. } = event else {
+        let ExtractionEvent::CommunityDetectionComplete { slug, subsystems, nodes } = event else {
             return Ok(vec![]);
         };
 
@@ -2026,7 +2026,6 @@ pub fn emit_community_detection(
     slug: String,
     subsystems: Vec<crate::graph::index::Subsystem>,
     nodes: Vec<crate::graph::Node>,
-    edges: Vec<crate::graph::Edge>,
 ) -> anyhow::Result<(Vec<crate::graph::Node>, Vec<crate::graph::Edge>)> {
     use crate::extract::event_bus::{EventBus, ExtractionEvent};
 
@@ -2037,7 +2036,6 @@ pub fn emit_community_detection(
         slug,
         subsystems: Arc::from(subsystems.into_boxed_slice()),
         nodes: Arc::from(nodes.into_boxed_slice()),
-        edges: Arc::from(edges.into_boxed_slice()),
     });
 
     // Collect SubsystemNodesComplete — emitted by SubsystemConsumer.
@@ -2604,7 +2602,6 @@ mod tests {
             slug: "test".into(),
             subsystems: std::sync::Arc::from([]),
             nodes: std::sync::Arc::from([]),
-            edges: std::sync::Arc::from([]),
         };
         let result = consumer.on_event(&event).unwrap();
         assert_eq!(result.len(), 1, "SubsystemConsumer must emit exactly one SubsystemNodesComplete");

--- a/src/extract/event_bus.rs
+++ b/src/extract/event_bus.rs
@@ -169,14 +169,16 @@ pub enum ExtractionEvent {
     /// any direct coupling to `graph.rs`.
     ///
     /// `slug` is the primary root slug used to anchor subsystem node `stable_id`s.
+    ///
+    /// Note: edges are intentionally omitted. `subsystem_node_pass` and
+    /// `subsystem_framework_aggregation_pass` only read nodes, so passing the
+    /// full edge set would be pure overhead (O(N) clone for no benefit).
     CommunityDetectionComplete {
         slug: String,
         /// Detected subsystems from `GraphIndex::detect_communities()`.
         subsystems: Arc<[Subsystem]>,
         /// Full node set with PageRank importance written into `node.metadata`.
         nodes: Arc<[Node]>,
-        /// Full edge set at the point community detection finished.
-        edges: Arc<[Edge]>,
     },
 
     /// `SubsystemConsumer` has finished running `subsystem_node_pass` and
@@ -406,26 +408,34 @@ impl ExtractionEvent {
                     buf.extend_from_slice(values.as_bytes());
                 }
             }
-            ExtractionEvent::CommunityDetectionComplete { slug, subsystems, nodes, edges } => {
+            ExtractionEvent::CommunityDetectionComplete { slug, subsystems, nodes } => {
                 buf.extend_from_slice(slug.as_bytes());
-                // Hash subsystem names (sorted) as a proxy for the subsystem set.
-                let mut sub_names: Vec<&str> = subsystems.iter().map(|s| s.name.as_str()).collect();
-                sub_names.sort_unstable();
-                for name in &sub_names {
+                // Hash each subsystem's name AND sorted member_ids so that membership
+                // changes (nodes moving between clusters) invalidate the cache even when
+                // subsystem names remain the same.
+                let mut subs: Vec<(&str, Vec<&str>)> = subsystems
+                    .iter()
+                    .map(|s| {
+                        let mut members: Vec<&str> = s.member_ids.iter().map(|m| m.as_str()).collect();
+                        members.sort_unstable();
+                        (s.name.as_str(), members)
+                    })
+                    .collect();
+                // Sort by name for determinism.
+                subs.sort_unstable_by_key(|(name, _)| *name);
+                for (name, members) in &subs {
                     buf.push(b'\n');
                     buf.extend_from_slice(name.as_bytes());
+                    for m in members {
+                        buf.push(b':');
+                        buf.extend_from_slice(m.as_bytes());
+                    }
                 }
                 let mut node_ids: Vec<String> = nodes.iter().map(|n| n.stable_id()).collect();
                 node_ids.sort_unstable();
                 for id in &node_ids {
                     buf.push(b'\n');
                     buf.extend_from_slice(id.as_bytes());
-                }
-                let mut edge_keys: Vec<String> = edges.iter().map(canonical_edge_key).collect();
-                edge_keys.sort_unstable();
-                for key in &edge_keys {
-                    buf.push(b'\n');
-                    buf.extend_from_slice(key.as_bytes());
                 }
             }
             ExtractionEvent::SubsystemNodesComplete { slug, added_nodes, added_edges } => {

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -780,7 +780,6 @@ impl RnaHandler {
                     primary_slug.clone(),
                     subsystems.clone(),
                     all_nodes.clone(),
-                    all_edges.clone(),
                 ).unwrap_or_else(|e| {
                     tracing::warn!("Subsystem promotion via bus failed (non-fatal): {}", e);
                     (vec![], vec![])
@@ -1288,7 +1287,6 @@ impl RnaHandler {
                     primary_slug.clone(),
                     subsystems.clone(),
                     graph.nodes.clone(),
-                    graph.edges.clone(),
                 ).unwrap_or_else(|e| {
                     tracing::warn!("Incremental subsystem promotion via bus failed (non-fatal): {}", e);
                     (vec![], vec![])


### PR DESCRIPTION
## Summary

Closes #542.

`subsystem_node_pass` and `subsystem_framework_aggregation_pass` were called directly from `graph.rs` (lines 778, 792, 1295, 1307), bypassing the EventBus and violating ADR Constraint 7 ("All pipeline paths go through `EventBus::run()`").

- Add `CommunityDetectionComplete { slug, subsystems, nodes, edges }` event fired by `graph.rs` after PageRank + community detection — this carries everything `SubsystemConsumer` needs
- Add `SubsystemNodesComplete { slug, added_nodes, added_edges }` event emitted by `SubsystemConsumer` carrying only the newly promoted nodes/edges
- Upgrade `SubsystemConsumer` from Phase 2 stub (subscribed to `PassesComplete`, did nothing) to real implementation: subscribes to `CommunityDetectionComplete`, runs `subsystem_node_pass` + `subsystem_framework_aggregation_pass`, emits `SubsystemNodesComplete`
- Add `emit_community_detection()` in `consumers.rs` — the public API `graph.rs` calls instead of invoking pass functions directly
- Remove all 4 direct call sites from `graph.rs` (both full-build and incremental paths)

## ADR Constraint 7 check

```
grep -n "subsystem_node_pass\|subsystem_framework_aggregation" src/server/graph.rs
# → no output (only imports/comments before this PR; imports removed too)
```

## Test plan

- [x] `cargo check --lib` — clean
- [x] `cargo test` — 1618 passed, 0 failed, 3 ignored
- [x] `test_subsystem_consumer_subscription` updated to assert `CommunityDetectionComplete` subscription and `SubsystemNodesComplete` emission
- [x] Existing integration tests (`test_incremental_update_preserves_root_slug`, `test_get_graph_detects_file_edits`) pass — subsystem promotion still works end-to-end through the bus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Subsystem processing now runs as a separate community-detection stage in the pipeline, improving modularity and ordering.

* **New Features**
  * Added a public call to emit community-detection and receive newly added nodes/edges.
  * Subsystem processing caches results and returns only newly promoted nodes/edges.

* **Behavior**
  * Failures in the subsystem stage are logged and treated as non-fatal (no graph changes).

* **Tests**
  * Updated tests to match the new event-driven subsystem flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->