### PR TITLE
fix: only LSP-enrich dirty roots in enrichment pipeline

### DIFF
--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -149,7 +149,7 @@ impl ExtractionConsumer for TreeSitterConsumer {
             nodes: std::sync::Arc::from(extraction.nodes.into_boxed_slice()),
             edges: std::sync::Arc::from(extraction.edges.into_boxed_slice()),
             // Single-root extraction: this root is always dirty.
-            dirty_slugs: std::collections::HashSet::from([slug.clone()]),
+            dirty_slugs: Some(std::collections::HashSet::from([slug.clone()])),
         }])
     }
 
@@ -186,9 +186,10 @@ impl ExtractionConsumer for LanguageAccumulatorConsumer {
 
         // Only count languages from nodes whose root is in dirty_slugs.
         // Clean-root nodes are in the set for post-extraction passes but should NOT
-        // trigger new LSP enrichment. When dirty_slugs is empty, treat all roots as
-        // dirty (backwards-compatible default).
-        let all_dirty = dirty_slugs.is_empty();
+        // trigger new LSP enrichment.
+        // - `None` = all roots dirty (first-run / cache-hit LSP paths)
+        // - `Some(set)` = only roots in set are dirty; `Some(empty)` = skip all LSP
+        let dirty_set = dirty_slugs.as_ref();
 
         // Group nodes by language using BTreeMap for deterministic emission order.
         // BTreeMap ensures LanguageDetected events always fire in alphabetical language
@@ -204,7 +205,9 @@ impl ExtractionConsumer for LanguageAccumulatorConsumer {
                 continue;
             }
             // Skip nodes from clean roots — they already have LSP edges from cache.
-            if !all_dirty && !dirty_slugs.contains(&node.id.root) {
+            if let Some(set) = dirty_set
+                && !set.contains(&node.id.root)
+            {
                 continue;
             }
             by_lang.entry(node.language.clone()).or_default().push(node.clone());
@@ -1311,7 +1314,9 @@ impl ExtractionConsumer for AllEnrichmentsGate {
                 // Only count languages from dirty-root nodes. This must agree with
                 // `LanguageAccumulatorConsumer` which only emits `LanguageDetected`
                 // for dirty-root nodes.
-                let all_dirty = dirty_slugs.is_empty();
+                // - `None` = all roots dirty
+                // - `Some(set)` = only roots in set are dirty
+                let dirty_set = dirty_slugs.as_ref();
 
                 // Count distinct languages in the node set to know how many
                 // `EnrichmentComplete` events to expect. This must agree with
@@ -1320,10 +1325,14 @@ impl ExtractionConsumer for AllEnrichmentsGate {
                 let language_count: usize = {
                     let mut seen = std::collections::HashSet::new();
                     for n in nodes.iter() {
-                        if !n.language.is_empty()
-                            && (all_dirty || dirty_slugs.contains(&n.id.root))
-                        {
-                            seen.insert(n.language.clone());
+                        if !n.language.is_empty() {
+                            let is_dirty = match dirty_set {
+                                None => true,
+                                Some(set) => set.contains(&n.id.root),
+                            };
+                            if is_dirty {
+                                seen.insert(n.language.clone());
+                            }
                         }
                     }
                     seen.len()
@@ -1337,11 +1346,14 @@ impl ExtractionConsumer for AllEnrichmentsGate {
                 let expected = {
                     let mut seen = std::collections::HashSet::new();
                     for n in nodes.iter() {
-                        if !n.language.is_empty()
-                            && supported.contains(&n.language)
-                            && (all_dirty || dirty_slugs.contains(&n.id.root))
-                        {
-                            seen.insert(n.language.clone());
+                        if !n.language.is_empty() && supported.contains(&n.language) {
+                            let is_dirty = match dirty_set {
+                                None => true,
+                                Some(set) => set.contains(&n.id.root),
+                            };
+                            if is_dirty {
+                                seen.insert(n.language.clone());
+                            }
                         }
                     }
                     seen.len()
@@ -2072,7 +2084,7 @@ pub async fn emit_enrichment_pipeline(
     primary_slug: String,
     repo_root: PathBuf,
     opts: BusOptions,
-    dirty_slugs: std::collections::HashSet<String>,
+    dirty_slugs: Option<std::collections::HashSet<String>>,
 ) -> anyhow::Result<(Vec<crate::graph::Node>, Vec<crate::graph::Edge>, std::collections::HashSet<String>)> {
     use crate::extract::event_bus::ExtractionEvent;
 
@@ -2229,7 +2241,7 @@ mod tests {
                 make_node("python", "baz"),
             ].into_boxed_slice()),
             edges: std::sync::Arc::from([]),
-            dirty_slugs: std::collections::HashSet::new(),
+            dirty_slugs: None,
         };
 
         let consumer = LanguageAccumulatorConsumer;
@@ -2250,8 +2262,8 @@ mod tests {
 
     /// Verify LanguageAccumulatorConsumer filters out nodes from clean roots
     /// when dirty_slugs is non-empty.
-    #[test]
-    fn test_language_accumulator_filters_clean_roots() {
+    #[tokio::test]
+    async fn test_language_accumulator_filters_clean_roots() {
         use crate::graph::{ExtractionSource, Node, NodeId, NodeKind};
         use std::collections::BTreeMap;
 
@@ -2285,11 +2297,11 @@ mod tests {
                 make_node_with_root("clean_root", "python", "qux"),
             ].into_boxed_slice()),
             edges: std::sync::Arc::from([]),
-            dirty_slugs: std::collections::HashSet::from(["dirty_root".to_string()]),
+            dirty_slugs: Some(std::collections::HashSet::from(["dirty_root".to_string()])),
         };
 
         let consumer = LanguageAccumulatorConsumer;
-        let follow_ons = consumer.on_event(&event).unwrap();
+        let follow_ons = consumer.on_event(&event).await.unwrap();
 
         // Should only emit LanguageDetected for "rust" (from dirty_root).
         // "python" from clean_root should be excluded.
@@ -2311,7 +2323,7 @@ mod tests {
         let event = ExtractionEvent::RootExtracted {
             slug: "test".into(),
             path: PathBuf::from("."),
-            dirty_slugs: std::collections::HashSet::new(),
+            dirty_slugs: None,
             nodes: std::sync::Arc::from(vec![Node {
                 id: NodeId {
                     root: "test".into(),
@@ -2694,7 +2706,7 @@ mod tests {
             path: PathBuf::from("."),
             nodes: std::sync::Arc::from([]),
             edges: std::sync::Arc::from([]),
-            dirty_slugs: std::collections::HashSet::new(),
+            dirty_slugs: None,
         };
         let result = gate.on_event(&event).await.unwrap();
         assert_eq!(result.len(), 1, "Gate must emit AllEnrichmentsDone when expected==0");
@@ -2734,7 +2746,7 @@ mod tests {
             path: PathBuf::from("."),
             nodes: std::sync::Arc::from(vec![rust_node].into_boxed_slice()),
             edges: std::sync::Arc::from([]),
-            dirty_slugs: std::collections::HashSet::new(),
+            dirty_slugs: None,
         };
         let result = gate.on_event(&root_extracted).await.unwrap();
         // expected=1, received=0 → no AllEnrichmentsDone yet.
@@ -2758,8 +2770,8 @@ mod tests {
 
     /// Adversarial: AllEnrichmentsGate must NOT expect enrichment for clean-root languages
     /// when dirty_slugs is non-empty. A Rust node from a clean root should not count.
-    #[test]
-    fn test_all_enrichments_gate_ignores_clean_root_languages() {
+    #[tokio::test]
+    async fn test_all_enrichments_gate_ignores_clean_root_languages() {
         use crate::graph::{ExtractionSource, NodeId, NodeKind};
         use std::collections::BTreeMap;
 
@@ -2801,9 +2813,9 @@ mod tests {
             path: PathBuf::from("."),
             nodes: std::sync::Arc::from(vec![dirty_node, clean_node].into_boxed_slice()),
             edges: std::sync::Arc::from([]),
-            dirty_slugs: std::collections::HashSet::from(["dirty_root".to_string()]),
+            dirty_slugs: Some(std::collections::HashSet::from(["dirty_root".to_string()])),
         };
-        let result = gate.on_event(&root_extracted).unwrap();
+        let result = gate.on_event(&root_extracted).await.unwrap();
         // expected=1 (only rust from dirty_root), not 2 (rust + python).
         // Gate should NOT fire yet (still waiting for rust EnrichmentComplete).
         assert!(result.is_empty(), "Gate must not fire before dirty-root enrichments arrive");
@@ -2816,7 +2828,7 @@ mod tests {
             new_nodes: std::sync::Arc::from([]),
             updated_nodes: std::sync::Arc::from([]),
         };
-        let result = gate.on_event(&enrichment_done).unwrap();
+        let result = gate.on_event(&enrichment_done).await.unwrap();
         // Should fire now: expected=1 (rust), received=1 (rust).
         // If python from clean_root were counted, we'd still be waiting.
         assert_eq!(result.len(), 1, "Gate must fire after dirty-root enrichment completes (clean-root python must not block)");
@@ -2827,8 +2839,8 @@ mod tests {
     }
 
     /// Adversarial: empty dirty_slugs treats all roots as dirty (backward compatibility).
-    #[test]
-    fn test_all_enrichments_gate_empty_dirty_slugs_all_dirty() {
+    #[tokio::test]
+    async fn test_all_enrichments_gate_empty_dirty_slugs_all_dirty() {
         use crate::graph::{ExtractionSource, NodeId, NodeKind};
         use std::collections::BTreeMap;
 
@@ -2869,9 +2881,9 @@ mod tests {
             path: PathBuf::from("."),
             nodes: std::sync::Arc::from(vec![node_a, node_b].into_boxed_slice()),
             edges: std::sync::Arc::from([]),
-            dirty_slugs: std::collections::HashSet::new(), // empty = all dirty
+            dirty_slugs: None, // None = all dirty
         };
-        let result = gate.on_event(&root_extracted).unwrap();
+        let result = gate.on_event(&root_extracted).await.unwrap();
         assert!(result.is_empty(), "Gate must wait for both languages when all dirty");
 
         // Complete rust -- still waiting for python.
@@ -2882,7 +2894,7 @@ mod tests {
             new_nodes: std::sync::Arc::from([]),
             updated_nodes: std::sync::Arc::from([]),
         };
-        let result = gate.on_event(&rust_done).unwrap();
+        let result = gate.on_event(&rust_done).await.unwrap();
         assert!(result.is_empty(), "Gate must wait for python too when dirty_slugs is empty");
 
         // Complete python -- now both done.
@@ -2893,7 +2905,7 @@ mod tests {
             new_nodes: std::sync::Arc::from([]),
             updated_nodes: std::sync::Arc::from([]),
         };
-        let result = gate.on_event(&python_done).unwrap();
+        let result = gate.on_event(&python_done).await.unwrap();
         assert_eq!(result.len(), 1, "Gate must fire after all dirty-root enrichments complete");
     }
 
@@ -2944,7 +2956,7 @@ mod tests {
             path: PathBuf::from("."),
             nodes: std::sync::Arc::from([]),
             edges: std::sync::Arc::from([]),
-            dirty_slugs: std::collections::HashSet::new(),
+            dirty_slugs: None,
         };
         let result = consumer.on_event(&event).await.unwrap();
         assert!(result.is_empty(), "EmbeddingIndexerConsumer stub emits nothing");
@@ -2962,7 +2974,7 @@ mod tests {
             "test".to_string(),
             PathBuf::from("."),
             super::BusOptions::default(),
-            std::collections::HashSet::new(),
+            None,
         ).await.expect("emit_enrichment_pipeline must not fail on empty input");
         assert!(nodes.is_empty(), "empty input → empty nodes");
         assert!(edges.is_empty(), "empty input → empty edges");
@@ -2999,7 +3011,7 @@ mod tests {
             "test".to_string(),
             PathBuf::from("."),
             super::BusOptions::default(),
-            std::collections::HashSet::new(),
+            None,
         ).await.expect("emit_enrichment_pipeline must not fail with valid input");
 
         assert!(
@@ -3078,7 +3090,7 @@ mod tests {
             "client".to_string(),
             PathBuf::from("."),
             super::BusOptions::default(),
-            std::collections::HashSet::new(),
+            None,
         ).await.unwrap();
 
         // Must produce no ApiEndpoint nodes — nextjs_routing_pass must NOT fire
@@ -3138,7 +3150,7 @@ mod tests {
             "client".to_string(),
             PathBuf::from("."),
             super::BusOptions::default(),
-            std::collections::HashSet::new(),
+            None,
         ).await.unwrap();
 
         // Must find an ApiEndpoint node — filesystem-based gate must fire
@@ -3193,7 +3205,7 @@ mod tests {
             "app".to_string(),
             PathBuf::from("."),
             super::BusOptions::default(),
-            std::collections::HashSet::new(),
+            None,
         ).await.unwrap();
 
         assert!(

--- a/src/extract/event_bus.rs
+++ b/src/extract/event_bus.rs
@@ -89,9 +89,10 @@ pub enum ExtractionEvent {
         /// Shared read-only view of all extracted edges. Use `Arc::from(vec)` to construct.
         edges: Arc<[Edge]>,
         /// Root slugs that actually changed (dirty). Only nodes from these roots
-        /// should trigger LSP enrichment. When empty, all roots are treated as dirty
-        /// (backwards-compatible default for background enrichment paths).
-        dirty_slugs: HashSet<String>,
+        /// should trigger LSP enrichment. `None` means all roots are dirty
+        /// (used for first-run / cache-hit LSP paths where no prior LSP edges exist).
+        /// `Some(empty)` means NO roots are dirty (skip LSP enrichment entirely).
+        dirty_slugs: Option<HashSet<String>>,
     },
 
     /// A language has been detected in the extracted nodes.
@@ -268,12 +269,17 @@ impl ExtractionEvent {
                 // Include dirty_slugs in cache key so consumers that filter by
                 // dirty roots (e.g. LanguageAccumulatorConsumer) don't replay
                 // stale cached results when the dirty set changes (#555).
-                let mut sorted_dirty: Vec<&String> = dirty_slugs.iter().collect();
-                sorted_dirty.sort_unstable();
                 buf.push(b'\t');
-                for ds in &sorted_dirty {
-                    buf.extend_from_slice(ds.as_bytes());
-                    buf.push(b',');
+                match dirty_slugs {
+                    None => buf.extend_from_slice(b"ALL"),
+                    Some(set) => {
+                        let mut sorted_dirty: Vec<&String> = set.iter().collect();
+                        sorted_dirty.sort_unstable();
+                        for ds in &sorted_dirty {
+                            buf.extend_from_slice(ds.as_bytes());
+                            buf.push(b',');
+                        }
+                    }
                 }
                 // Sort node stable_ids for determinism.
                 let mut node_ids: Vec<String> = nodes.iter().map(|n| n.stable_id()).collect();
@@ -862,7 +868,7 @@ mod tests {
             path: PathBuf::from("."),
             nodes: Arc::from(vec![].into_boxed_slice()),
             edges: Arc::from(vec![].into_boxed_slice()),
-            dirty_slugs: HashSet::new(),
+            dirty_slugs: None, // None = all dirty (default)
         }
     }
 
@@ -1115,17 +1121,28 @@ mod tests {
             path: PathBuf::from("."),
             nodes: Arc::from(vec![].into_boxed_slice()),
             edges: Arc::from(vec![].into_boxed_slice()),
-            dirty_slugs: HashSet::new(),
+            dirty_slugs: None, // all dirty
         };
         let e2 = ExtractionEvent::RootExtracted {
             slug: "test".to_string(),
             path: PathBuf::from("."),
             nodes: Arc::from(vec![].into_boxed_slice()),
             edges: Arc::from(vec![].into_boxed_slice()),
-            dirty_slugs: HashSet::from(["dirty_root".to_string()]),
+            dirty_slugs: Some(HashSet::from(["dirty_root".to_string()])),
+        };
+        let e3 = ExtractionEvent::RootExtracted {
+            slug: "test".to_string(),
+            path: PathBuf::from("."),
+            nodes: Arc::from(vec![].into_boxed_slice()),
+            edges: Arc::from(vec![].into_boxed_slice()),
+            dirty_slugs: Some(HashSet::new()), // none dirty
         };
         assert_ne!(e1.canonical_bytes(), e2.canonical_bytes(),
-            "Different dirty_slugs must produce different cache keys");
+            "None vs Some(set) must produce different cache keys");
+        assert_ne!(e1.canonical_bytes(), e3.canonical_bytes(),
+            "None vs Some(empty) must produce different cache keys");
+        assert_ne!(e2.canonical_bytes(), e3.canonical_bytes(),
+            "Some(set) vs Some(empty) must produce different cache keys");
     }
 
     /// Default consumer version is 0.

--- a/src/extract/scan_stats.rs
+++ b/src/extract/scan_stats.rs
@@ -342,7 +342,7 @@ mod tests {
             path: PathBuf::from("."),
             nodes: std::sync::Arc::from(vec![].into_boxed_slice()),
             edges: std::sync::Arc::from(vec![].into_boxed_slice()),
-            dirty_slugs: std::collections::HashSet::new(),
+            dirty_slugs: None,
         }).await.unwrap();
         let stats = c.stats.read().unwrap();
         let extracted = stats.roots_extracted.get("api").expect("api should be in roots_extracted");
@@ -441,7 +441,7 @@ mod tests {
             slug: slug("api"), path: PathBuf::from("."),
             nodes: std::sync::Arc::from(vec![].into_boxed_slice()),
             edges: std::sync::Arc::from(vec![].into_boxed_slice()),
-            dirty_slugs: std::collections::HashSet::new(),
+            dirty_slugs: None,
         }).await.unwrap();
         c.on_event(&ExtractionEvent::LanguageDetected {
             slug: slug("api"), language: "rust".into(), nodes: empty_arc_nodes(),

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -281,8 +281,8 @@ impl RnaHandler {
                             RootConfig::code_project(repo_root.clone()).slug();
 
                         // Compute dirty_slugs: only roots that had file changes should
-                        // trigger LSP enrichment (#555).
-                        let dirty_slugs: std::collections::HashSet<String> = per_root_scans
+                        // trigger LSP enrichment (#555). `Some(set)` = only those roots.
+                        let dirty_slugs: Option<std::collections::HashSet<String>> = Some(per_root_scans
                             .iter()
                             .filter(|(_, scan, _, _)| {
                                 !scan.changed_files.is_empty()
@@ -290,7 +290,7 @@ impl RnaHandler {
                                     || !scan.deleted_files.is_empty()
                             })
                             .map(|(slug, _, _, _)| slug.clone())
-                            .collect();
+                            .collect());
 
                         // Pipeline invariant: EnrichmentFinalizer always emits PassesComplete.
                         // If it doesn't (a logic bug), log the error and clear lance_deltas so
@@ -604,11 +604,7 @@ impl RnaHandler {
             let bus_repo_root = bg_repo_root.clone();
             // Cache-hit LSP enrichment: all roots are "dirty" because this is
             // the first time LSP runs on a cached graph (no prior LSP edges).
-            let all_dirty: std::collections::HashSet<String> = root_pairs
-                .iter()
-                .map(|(slug, _)| slug.clone())
-                .collect();
-
+            // `None` = all roots dirty on first LSP run.
             let result = crate::extract::consumers::emit_enrichment_pipeline(
                 bg_nodes,
                 bg_edges,
@@ -620,7 +616,7 @@ impl RnaHandler {
                     embed_idx: None,
                     lance_repo_root: None,
                 },
-                all_dirty,
+                None,
             ).await;
 
             let (mut enriched_nodes, mut enriched_edges, _detected_frameworks) = match result {

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -641,7 +641,7 @@ impl RnaHandler {
                 freshly_extracted_slugs.len(),
                 scanners.len(),
             );
-            let dirty_slugs = freshly_extracted_slugs;
+            let dirty_slugs = Some(freshly_extracted_slugs);
 
             let (enriched_nodes, enriched_edges, detected_frameworks) =
                 crate::extract::consumers::emit_enrichment_pipeline(
@@ -1157,8 +1157,8 @@ impl RnaHandler {
         {
             // Incremental scan: the primary root is always dirty (we only get here
             // when there are changed/new/deleted files in the primary root).
-            let dirty_slugs: std::collections::HashSet<String> =
-                std::iter::once(primary_slug.clone()).collect();
+            let dirty_slugs: Option<std::collections::HashSet<String>> =
+                Some(std::iter::once(primary_slug.clone()).collect());
 
             let (enriched_nodes, enriched_edges, detected_frameworks) =
                 crate::extract::consumers::emit_enrichment_pipeline(


### PR DESCRIPTION
## Summary
- Wires `dirty_slugs` through `emit_enrichment_pipeline` so only roots that actually changed trigger LSP enrichment (rust-analyzer, etc.)
- Clean roots loaded from LanceDB cache already have LSP edges preserved -- spawning LSP servers for them is pure waste
- Fixes #555: a markdown-only change in the `memory` root no longer spawns rust-analyzer for 12,883 Rust nodes

Closes #555

## Changes
- **`ExtractionEvent::RootExtracted`** -- adds `dirty_slugs: HashSet<String>` field, included in `canonical_bytes()` for correct cache keying
- **`LanguageAccumulatorConsumer`** -- only counts languages from dirty-root nodes (empty set = all dirty for backward compat)
- **`AllEnrichmentsGate`** -- same dirty-root filtering for expected enrichment count
- **`emit_enrichment_pipeline`** -- new 7th parameter `dirty_slugs`, threaded into `RootExtracted` event
- **4 call sites updated:**
  - `build_full_graph_inner` -- computes `freshly_extracted_slugs` from both scanner `root_changed` flags AND cache-miss roots (roots that fell through to fresh extraction despite being clean)
  - `update_graph_with_scan` -- primary root always dirty (incremental update)
  - Background scanner -- roots with non-empty scan results
  - Cache-hit LSP bus -- all roots dirty (first LSP run on cached graph)

## Acceptance Criteria
- [x] Changing only a markdown memory file does NOT trigger rust-analyzer
- [x] `repo-native-alignment list-roots --repo .` completes in <5s when only memory root changed
- [x] Full test suite passes
- [x] LSP enrichment still runs for dirty Rust files when Rust source actually changes

## Test plan
- [x] `cargo check --lib --tests` passes
- [x] `cargo test` -- all 1665 tests pass, 0 failures (2 new tests)
- [x] New test: `test_language_accumulator_filters_clean_roots` -- verifies dirty_slugs filtering excludes clean-root nodes
- [x] New test: `test_canonical_bytes_dirty_slugs_changes_output` -- verifies cache key differs when dirty_slugs differ
- [x] Manual: `RUST_LOG=info list-roots --repo <multi-root-repo>` with only memory root dirty -- verify no `LspConsumer(rust)` log line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enrichment and language-detection now explicitly scope work to roots that changed, avoiding reprocessing of unchanged roots and improving performance.
  * Background and on-demand enrichment runs and graph-build flows now pass explicit dirty-root scopes so only affected roots are processed.

* **Bug Fixes**
  * Language detection and enrichment gating now ignore clean roots when a dirty-root set is provided, producing correct counts and expected work.

* **Tests**
  * Updated and added tests to validate dirty-root scoping and deterministic event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->