### PR TITLE
fix: setup downloads release binary when source unavailable

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -302,11 +302,13 @@ fn download_rna_binary(target_path: &Path) -> Result<()> {
     println!("  Downloading: {url}");
     println!("  Target: {}", target_path.display());
 
-    let status = Command::new("curl")
+    let mut curl_child = Command::new("curl")
         .args(["-fSL", &url])
         .stdout(std::process::Stdio::piped())
         .spawn()
-        .context("Failed to launch `curl`. Install curl or download the binary manually.")?
+        .context("Failed to launch `curl`. Install curl or download the binary manually.")?;
+
+    let curl_stdout = curl_child
         .stdout
         .take()
         .ok_or_else(|| anyhow::anyhow!("Failed to capture curl stdout"))?;
@@ -321,13 +323,22 @@ fn download_rna_binary(target_path: &Path) -> Result<()> {
                 .to_str()
                 .context("Target directory path is not valid UTF-8")?,
         ])
-        .stdin(status)
+        .stdin(curl_stdout)
         .status()
         .context("Failed to launch `tar`")?;
 
+    // Reap the curl child process and check its exit status.
+    let curl_status = curl_child.wait().context("Failed to wait on `curl`")?;
+    if !curl_status.success() {
+        bail!(
+            "Download failed: curl exited with {curl_status}. URL: {url}\n  \
+             Check network connectivity and that the release exists."
+        );
+    }
+
     if !tar_status.success() {
         bail!(
-            "Download failed. URL: {url}\n  \
+            "Download failed: tar extraction failed. URL: {url}\n  \
              Your platform ({os}/{arch}) may not have a pre-built binary.\n  \
              Build from source instead: cargo install --locked --git https://github.com/open-horizon-labs/repo-native-alignment"
         );


### PR DESCRIPTION
## Summary

- When `repo-native-alignment setup` runs without the source repo cloned and no binary is installed, it now downloads the appropriate release binary from GitHub Releases instead of failing with a dead-end error
- Adds platform detection (Darwin arm64 M1/M2+, Linux x86_64) matching the logic in `/setup-rna` skill (`plugin/commands/setup.md`)
- Adds `curl` preflight check when download path is needed
- Updates dry-run messaging to reflect the download path

## Test plan

- [x] All 12 existing + 4 new setup tests pass (`cargo test setup`)
- [x] `cargo check --lib` clean
- [x] `setup --dry-run` shows download intent when source path doesn't exist (verified via dry-run code path in tests)
- [x] Download code uses same URLs and platform logic as `/setup-rna` skill

Closes #563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RNA installation now supports automatic fallback to downloading platform-specific binaries from GitHub Releases when the local source directory is unavailable.

* **Improvements**
  * Enhanced dependency validation to verify curl availability when downloads are required.
  * Improved error handling and validation output to reflect download-based installation paths.
  * Added support for platform-specific asset detection and installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->