### PR TITLE
fix: validate LSP indexing after probe-based readiness

### DIFF
--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -737,11 +737,31 @@ impl LspEnricher {
                                     if kind == "begin" || kind == "end" {
                                         tracing::info!("{} progress {}: {}", self.server_command, kind, title);
                                     }
+                                } else if method == "experimental/serverStatus" {
+                                    // A late serverStatus notification arrived during Phase B.
+                                    // If quiescent=true, the server has finished indexing —
+                                    // skip the rest of validation and accept the authoritative signal.
+                                    let quiescent = msg.pointer("/params/quiescent")
+                                        .and_then(|q| q.as_bool())
+                                        .unwrap_or(false);
+                                    if quiescent {
+                                        tracing::info!(
+                                            "{} received experimental/serverStatus quiescent=true during Phase B validation — accepting",
+                                            self.server_command
+                                        );
+                                        server_ready = true;
+                                        saw_quiescent = true;
+                                    }
                                 }
                             }
                         }
                         _ => break, // No more pending messages
                     }
+                }
+
+                // If serverStatus arrived during drain, skip validation
+                if server_ready {
+                    break;
                 }
 
                 let validation_result = tokio::time::timeout(
@@ -781,10 +801,12 @@ impl LspEnricher {
                         );
                     }
                     Err(_) => {
-                        // Timeout — server is busy indexing.
-                        consecutive_empty += 1;
+                        // Timeout — server is busy indexing. Do NOT count toward
+                        // consecutive_empty: a timeout means the server is actively
+                        // working (not that it returned empty results). Let the
+                        // attempt counter and circuit breaker handle slow servers.
                         tracing::info!(
-                            "{} indexing validation {}/{}: workspace/symbol(\"{}\") timed out ({}s elapsed)",
+                            "{} indexing validation {}/{}: workspace/symbol(\"{}\") timed out ({}s elapsed, not counting as empty)",
                             self.server_command, attempt, MAX_INDEXING_VALIDATION_ATTEMPTS,
                             query, elapsed
                         );
@@ -4049,6 +4071,10 @@ mod tests {
         assert!(queries.len() >= 3,
             "need at least 3 validation queries to avoid false negatives \
              from projects that happen to lack a particular symbol name");
+        // Verify no empty strings — an empty query would bypass validation
+        // since workspace/symbol("") returns all symbols (or matches anything).
+        assert!(queries.iter().all(|q| !q.is_empty()),
+            "validation queries must be non-empty strings — empty query bypasses validation");
         // Verify no duplicates
         let unique: std::collections::HashSet<&&str> = queries.iter().collect();
         assert_eq!(unique.len(), queries.len(),
@@ -4057,10 +4083,8 @@ mod tests {
 
     /// Adversarial: verify the early-exit condition for indexing validation.
     /// The code exits early when consecutive_empty >= 3 && attempt >= 3.
-    /// This test verifies the boundary conditions:
-    /// - 2 consecutive empties at attempt 3 → should NOT exit (needs 3)
-    /// - 3 consecutive empties at attempt 2 → should NOT exit (needs attempt >= 3)
-    /// - 3 consecutive empties at attempt 3 → SHOULD exit
+    /// Note: only empty responses and errors count toward consecutive_empty.
+    /// Timeouts do NOT count (the server is actively working, not empty).
     #[test]
     fn test_indexing_validation_early_exit_boundary() {
         // Simulate the early exit condition from ensure_initialized
@@ -4086,6 +4110,12 @@ mod tests {
 
         // Edge: attempt 1 with 0 empties — never exit
         assert!(!check_early_exit(0, 1));
+
+        // Scenario: 3 timeouts + 0 empties at attempt 3 — should NOT exit
+        // because timeouts don't count toward consecutive_empty
+        // (server is actively indexing, not returning empty results)
+        assert!(!check_early_exit(0, 3),
+            "timeouts should not trigger early exit — only empty results and errors count");
     }
 
     /// Adversarial: verify validation query rotation covers all queries


### PR DESCRIPTION
## Summary

Closes #576.

- For LSP servers without `experimental/serverStatus` (pyright, typescript-language-server), the readiness probe declared servers ready after 2 consecutive `workspace/symbol` responses. But responding to probes does not mean the server has indexed the workspace. On Innovation-Connector (22K Python nodes, 15K TypeScript nodes), pyright responded to probes in 5s but produced 0 edges from 13 nodes, and tsserver processed 13187 nodes in 1s with 0 edges.
- Adds a two-phase readiness check: Phase A confirms responsiveness (unchanged), Phase B validates actual indexing by sending `workspace/symbol` with non-empty queries ("main", "init", "test", "get", "set", "app"). An indexed server returns results; an unindexed one returns `[]`.
- Phase B uses exponential backoff (5s, 10s, 20s, ...) with up to 6 attempts. After 3 consecutive empty responses on different queries, the server is declared "responsive but not indexed" and `saw_quiescent` stays false, causing Pass 1 and Pass 3 to be skipped (correct behavior -- sending requests to an unindexed server produces 0 edges).

## Test plan

- [x] `cargo check --lib` passes
- [x] All 140 LSP-related tests pass (138 existing + 2 new)
- [x] New test `test_was_quiescent_probe_validation_path` verifies the quiescence logic for all 5 state combinations (probe+validation success, probe success + validation failure, no probe success, serverStatus quiescent, serverStatus timeout)
- [x] New test `test_indexing_validation_queries_not_empty` verifies validation query diversity
- [ ] Integration test on IC repo with pyright and tsserver (manual)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Language Server Protocol initialization to more accurately determine server readiness, with improved support for servers lacking advanced status reporting features.
  * Implemented refined validation approach to better distinguish between servers that are responsive and those with complete symbol indexing capabilities.
  * Reduced false positive server readiness detection to improve editor stability and overall language server reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->