### PR TITLE
perf: cache node_index_map + HashSet for files_to_remove

### DIFF
--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -1314,20 +1314,20 @@ impl RnaHandler {
         ));
 
         // Store graph state atomically so it is available for queries during embed+LSP.
-        self.graph.store(Arc::new(Some(Arc::new(GraphState {
-            nodes: graph_state.nodes.clone(),
-            edges: graph_state.edges.clone(),
-            index: {
-                let mut idx = crate::graph::index::GraphIndex::new();
-                idx.rebuild_from_edges(&graph_state.edges);
-                for node in &graph_state.nodes {
-                    idx.ensure_node(&node.stable_id(), &node.id.kind.to_string());
-                }
-                idx
-            },
-            last_scan_completed_at: graph_state.last_scan_completed_at,
-            detected_frameworks: graph_state.detected_frameworks.clone(),
-        }))));
+        {
+            let mut idx = crate::graph::index::GraphIndex::new();
+            idx.rebuild_from_edges(&graph_state.edges);
+            for node in &graph_state.nodes {
+                idx.ensure_node(&node.stable_id(), &node.id.kind.to_string());
+            }
+            self.graph.store(Arc::new(Some(Arc::new(GraphState::new(
+                graph_state.nodes.clone(),
+                graph_state.edges.clone(),
+                idx,
+                graph_state.last_scan_completed_at,
+                graph_state.detected_frameworks.clone(),
+            )))));
+        }
 
         // Phase 2: Embed + LSP enrichment (parallel -- they use independent data stores)
         let embeddable_nodes: Vec<Node> = graph_state.nodes.iter()

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -1029,13 +1029,13 @@ impl RnaHandler {
             *self.embed_handle.lock().await = Some(handle);
         }
 
-        Ok(GraphState {
-            nodes: all_nodes,
-            edges: all_edges,
+        Ok(GraphState::new(
+            all_nodes,
+            all_edges,
             index,
-            last_scan_completed_at: Some(symbols_ready_at),
-            detected_frameworks: all_detected_frameworks,
-        })
+            Some(symbols_ready_at),
+            all_detected_frameworks,
+        ))
     }
 
     /// Incrementally update the graph, accepting an optional pre-computed scan.
@@ -1084,8 +1084,9 @@ impl RnaHandler {
 
         let registry = ExtractorRegistry::with_builtins();
 
-        // Remove nodes/edges for deleted + changed files
-        let mut files_to_remove: Vec<PathBuf> = scan
+        // Remove nodes/edges for deleted + changed files.
+        // HashSet for O(1) lookup instead of O(F) Vec scan per edge (#586).
+        let mut files_to_remove: std::collections::HashSet<PathBuf> = scan
             .deleted_files
             .iter()
             .chain(scan.changed_files.iter())
@@ -1098,9 +1099,8 @@ impl RnaHandler {
             .edges
             .iter()
             .filter(|e| {
-                files_to_remove
-                    .iter()
-                    .any(|f| e.from.file == *f || e.to.file == *f)
+                files_to_remove.contains(&e.from.file)
+                    || files_to_remove.contains(&e.to.file)
             })
             .map(|e| e.stable_id())
             .collect();
@@ -1109,9 +1109,8 @@ impl RnaHandler {
             .nodes
             .retain(|n| !files_to_remove.contains(&n.id.file));
         graph.edges.retain(|e| {
-            !files_to_remove
-                .iter()
-                .any(|f| e.from.file == *f || e.to.file == *f)
+            !files_to_remove.contains(&e.from.file)
+                && !files_to_remove.contains(&e.to.file)
         });
 
         // Extract new + changed files
@@ -1478,12 +1477,13 @@ impl RnaHandler {
         // failure, so the next scan re-detects and retries the persist.
         let persist_result = {
             let _lance_guard = self.lance_write_lock.lock().await;
+            let files_to_remove_vec: Vec<PathBuf> = files_to_remove.into_iter().collect();
             persist_graph_incremental(
                 &self.repo_root,
                 &upsert_nodes,
                 &upsert_edges,
                 &deleted_edge_ids,
-                &files_to_remove,
+                &files_to_remove_vec,
             )
             .await
         };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1738,13 +1738,13 @@ mod tests {
         let graph: Arc<ArcSwap<Option<Arc<GraphState>>>> = Arc::new(ArcSwap::from_pointee(None));
 
         // Store initial graph with 2 nodes.
-        let mut initial = GraphState {
-            nodes: vec![],
-            edges: vec![],
-            index: crate::graph::index::GraphIndex::new(),
-            last_scan_completed_at: None,
-            detected_frameworks: std::collections::HashSet::new(),
-        };
+        let mut initial = GraphState::new(
+            vec![],
+            vec![],
+            crate::graph::index::GraphIndex::new(),
+            None,
+            std::collections::HashSet::new(),
+        );
         for name in &["alpha", "beta"] {
             initial.nodes.push(crate::graph::Node {
                 id: crate::graph::NodeId {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,6 +1,7 @@
 //! Graph state and LSP enrichment status types.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
 
 use crate::graph::{Node, Edge};
 use crate::graph::index::GraphIndex;
@@ -11,7 +12,6 @@ use crate::graph::index::GraphIndex;
 /// In-memory graph state: extraction results + petgraph index + embedding index.
 /// Lazily initialized on first tool call. Embeddings are built as part of the
 /// graph pipeline — not as a separate lazy init that races with graph building.
-#[derive(Clone)]
 pub struct GraphState {
     pub nodes: Vec<Node>,
     pub edges: Vec<Edge>,
@@ -23,9 +23,46 @@ pub struct GraphState {
     /// Used to gate conditional extractors (pub/sub, SSE/WebSocket, gRPC, etc.) so they
     /// only run when their target framework is present. Empty until the first scan completes.
     pub detected_frameworks: HashSet<String>,
+    /// Cached stable_id -> index map, built lazily on first access.
+    /// Each GraphState snapshot is immutable once published via ArcSwap,
+    /// so the cache is valid for the lifetime of the snapshot.
+    node_index_cache: OnceLock<HashMap<String, usize>>,
+}
+
+impl Clone for GraphState {
+    fn clone(&self) -> Self {
+        Self {
+            nodes: self.nodes.clone(),
+            edges: self.edges.clone(),
+            index: self.index.clone(),
+            last_scan_completed_at: self.last_scan_completed_at,
+            detected_frameworks: self.detected_frameworks.clone(),
+            // Start with an empty cache -- the clone is typically a mutable
+            // working copy for incremental scan whose nodes will change.
+            node_index_cache: OnceLock::new(),
+        }
+    }
 }
 
 impl GraphState {
+    /// Construct a new `GraphState` with an empty node-index cache.
+    pub fn new(
+        nodes: Vec<Node>,
+        edges: Vec<Edge>,
+        index: GraphIndex,
+        last_scan_completed_at: Option<std::time::Instant>,
+        detected_frameworks: HashSet<String>,
+    ) -> Self {
+        Self {
+            nodes,
+            edges,
+            index,
+            last_scan_completed_at,
+            detected_frameworks,
+            node_index_cache: OnceLock::new(),
+        }
+    }
+
     /// Check whether a given framework was detected in this workspace.
     ///
     /// Framework IDs use kebab-case: "fastapi", "kafkajs", "nextjs-app-router", etc.
@@ -42,14 +79,17 @@ impl GraphState {
 }
 
 impl GraphState {
-    /// Build a HashMap from stable_id -> index for O(1) node lookups.
-    /// Call once per search context instead of O(N) linear scans per result.
-    pub fn node_index_map(&self) -> std::collections::HashMap<String, usize> {
-        self.nodes
-            .iter()
-            .enumerate()
-            .map(|(i, n)| (n.stable_id(), i))
-            .collect()
+    /// Return a cached HashMap from stable_id -> index for O(1) node lookups.
+    /// Built lazily on first access, then reused for the lifetime of this snapshot.
+    /// Previously rebuilt on every search call (O(N) with 87K String allocations).
+    pub fn node_index_map(&self) -> &HashMap<String, usize> {
+        self.node_index_cache.get_or_init(|| {
+            self.nodes
+                .iter()
+                .enumerate()
+                .map(|(i, n)| (n.stable_id(), i))
+                .collect()
+        })
     }
 
     /// Resolve a node ID that may be missing its root prefix.
@@ -883,7 +923,7 @@ mod tests {
         for n in &nodes {
             index.ensure_node(&n.stable_id(), &n.id.kind.to_string());
         }
-        GraphState { nodes, edges: vec![], index, last_scan_completed_at: None, detected_frameworks: std::collections::HashSet::new() }
+        GraphState::new(nodes, vec![], index, None, std::collections::HashSet::new())
     }
 
     #[test]

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -1498,7 +1498,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
         index.ensure_node(&node.stable_id(), &node.id.kind.to_string());
     }
 
-    Ok(GraphState { nodes, edges, index, last_scan_completed_at: Some(std::time::Instant::now()), detected_frameworks: std::collections::HashSet::new() })
+    Ok(GraphState::new(nodes, edges, index, Some(std::time::Instant::now()), std::collections::HashSet::new()))
 }
 
 /// Parse a NodeId from its stable_id string (format: "root:file:name:kind").

--- a/src/service/repomap.rs
+++ b/src/service/repomap.rs
@@ -236,7 +236,7 @@ mod tests {
 
     fn make_graph_state(nodes: Vec<Node>) -> GraphState {
         let index = GraphIndex::new();
-        GraphState { nodes, edges: vec![], index, last_scan_completed_at: None, detected_frameworks: std::collections::HashSet::new() }
+        GraphState::new(nodes, vec![], index, None, std::collections::HashSet::new())
     }
 
     // ── repo_map root prefix tests (#270) ───────────────────────────

--- a/src/service/roots.rs
+++ b/src/service/roots.rs
@@ -522,13 +522,7 @@ mod tests {
     fn make_test_graph_state(nodes: Vec<Node>, edges: Vec<Edge>) -> crate::server::state::GraphState {
         use crate::graph::index::GraphIndex;
         let index = GraphIndex::new();
-        crate::server::state::GraphState {
-            nodes,
-            edges,
-            index,
-            last_scan_completed_at: None,
-            detected_frameworks: std::collections::HashSet::new(),
-        }
+        crate::server::state::GraphState::new(nodes, edges, index, None, std::collections::HashSet::new())
     }
 
     /// With graph_state provided, per-root symbol and edge counts appear.

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -1117,7 +1117,7 @@ mod tests {
 
     fn make_graph_state(nodes: Vec<Node>) -> GraphState {
         let index = GraphIndex::new();
-        GraphState { nodes, edges: vec![], index, last_scan_completed_at: None, detected_frameworks: std::collections::HashSet::new() }
+        GraphState::new(nodes, vec![], index, None, std::collections::HashSet::new())
     }
 
     fn make_graph_state_with_edges(nodes: Vec<Node>, edges: Vec<crate::graph::Edge>) -> GraphState {
@@ -1126,7 +1126,7 @@ mod tests {
         for node in &nodes {
             index.ensure_node(&node.stable_id(), &node.id.kind.to_string());
         }
-        GraphState { nodes, edges, index, last_scan_completed_at: None, detected_frameworks: std::collections::HashSet::new() }
+        GraphState::new(nodes, edges, index, None, std::collections::HashSet::new())
     }
 
     fn make_edge(from: &Node, to: &Node, kind: crate::graph::EdgeKind) -> crate::graph::Edge {

--- a/src/smoke_test.rs
+++ b/src/smoke_test.rs
@@ -1578,13 +1578,13 @@ async fn run_impact_output_size_check(index: &GraphIndex, nodes: &[Node]) -> Che
     let node_id = best_node.stable_id();
 
     // Build a GraphState using the caller's index (which has real edges)
-    let graph_state = GraphState {
-        nodes: nodes.to_vec(),
-        edges: Vec::new(),
-        index: index.clone(),
-        last_scan_completed_at: None,
-        detected_frameworks: std::collections::HashSet::new(),
-    };
+    let graph_state = GraphState::new(
+        nodes.to_vec(),
+        Vec::new(),
+        index.clone(),
+        None,
+        std::collections::HashSet::new(),
+    );
 
     let ctx = crate::service::SearchContext {
         graph_state: &graph_state,
@@ -1685,13 +1685,13 @@ fn run_short_id_resolution_check(_index: &GraphIndex, _nodes: &[Node]) -> Check 
     let mut index = GraphIndex::new();
     index.ensure_node(&full_id, &kind.to_string());
 
-    let graph_state = GraphState {
-        nodes: vec![node],
-        edges: Vec::new(),
+    let graph_state = GraphState::new(
+        vec![node],
+        Vec::new(),
         index,
-        last_scan_completed_at: None,
-        detected_frameworks: std::collections::HashSet::new(),
-    };
+        None,
+        std::collections::HashSet::new(),
+    );
 
     // Strip the root prefix to get the short ID
     let short_id = match full_id.split_once(':') {


### PR DESCRIPTION
## Summary

Fixes #586 -- two O() hotspots that impact user-perceived search latency.

- **node_index_map cached per snapshot**: Previously rebuilt on every search call (O(N) with 87K `String` allocations, 5-15ms per call). Now uses `OnceLock` to build lazily on first access and reuse for the lifetime of each immutable `GraphState` snapshot behind ArcSwap.
- **files_to_remove as HashSet**: `edges.retain()` scanned a `Vec<PathBuf>` per edge -- O(E*F) with 19M PathBuf comparisons at E=190K, F=100 changed files. Converted to `HashSet<PathBuf>` for O(1) lookup.
- Introduces `GraphState::new()` constructor to encapsulate the private `node_index_cache` field, replacing struct literal construction across 9 files.

## Test plan

- [x] `cargo check --tests` passes
- [x] All 8 `resolve_node_id` tests pass (exercise `node_index_map`)
- [x] All 43 `state::tests` pass
- [x] All 143 search service tests pass
- [x] All 82 roots tests pass