### PR TITLE
feat: surface cold start, stale results, and enrichment failures

### DIFF
--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -539,7 +539,7 @@ impl RnaHandler {
                             }
                             Err(e) => {
                                 tracing::warn!("[background] Embedding table check failed: {}", e);
-                                embed_status.set_complete(0);
+                                embed_status.set_failed(format!("{}", e));
                                 return;
                             }
                         };
@@ -552,13 +552,13 @@ impl RnaHandler {
                             }
                             Err(e) => {
                                 tracing::warn!("[background] Embedding failed: {}", e);
-                                embed_status.set_complete(0);
+                                embed_status.set_failed(format!("{}", e));
                             }
                         }
                     }
                     Err(e) => {
                         tracing::warn!("[background] EmbeddingIndex init failed: {}", e);
-                        embed_status.set_complete(0);
+                        embed_status.set_failed(format!("{}", e));
                     }
                 }
             };
@@ -641,7 +641,7 @@ impl RnaHandler {
                 Ok(r) => r,
                 Err(e) => {
                     tracing::error!("[cache-hit bus] emit_enrichment_pipeline failed: {:#}", e);
-                    bg_lsp_status.set_unavailable();
+                    bg_lsp_status.set_failed(&format!("{}", e));
                     return;
                 }
             };

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -135,14 +135,23 @@ impl RnaHandler {
             return Ok(Arc::clone(gs));
         }
 
-        let new_state = self.build_full_graph().await?;
-        let new_arc = Arc::new(new_state);
-        self.graph.store(Arc::new(Some(Arc::clone(&new_arc))));
-        *self.last_scan.lock().unwrap() = std::time::Instant::now();
-        if !self.background_scanner_started.swap(true, std::sync::atomic::Ordering::Relaxed) {
-            self.spawn_background_scanner();
+        self.graph_build_status.set_building(0);
+        match self.build_full_graph().await {
+            Ok(new_state) => {
+                let new_arc = Arc::new(new_state);
+                self.graph.store(Arc::new(Some(Arc::clone(&new_arc))));
+                *self.last_scan.lock().unwrap() = std::time::Instant::now();
+                self.graph_build_status.set_ready();
+                if !self.background_scanner_started.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                    self.spawn_background_scanner();
+                }
+                Ok(new_arc)
+            }
+            Err(e) => {
+                self.graph_build_status.set_failed(format!("{}", e));
+                Err(e)
+            }
         }
-        Ok(new_arc)
     }
 
     /// Build the full graph from scratch. This is the original get_graph logic.
@@ -352,6 +361,13 @@ impl RnaHandler {
             scanners.push((root_slug.clone(), scanner, scan_result, root_path.clone(), root_has_changes));
         }
 
+        {
+            let total_files: usize = scanners.iter()
+                .map(|(_, _, scan, _, _)| scan.new_files.len() + scan.changed_files.len())
+                .sum();
+            self.graph_build_status.set_building(total_files);
+        }
+
         // 2. If no changes anywhere, try loading full graph from LanceDB
         if !any_root_changed {
             match load_graph_from_lance(&self.repo_root).await {
@@ -415,13 +431,13 @@ impl RnaHandler {
                         }
                     }
 
-                    // No changes detected -- safe to commit scanner state
                     for (_slug, scanner, _scan, _path, _changed) in &scanners {
                         if let Err(e) = scanner.commit_state() {
                             tracing::error!("Failed to commit scanner state: {}", e);
                         }
                     }
 
+                    self.graph_build_status.set_ready();
                     return Ok(state);
                 }
                 Err(e) => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use store::{
     check_and_migrate_schema, graph_lance_path,
     persist_graph_incremental, persist_graph_to_lance,
 };
-pub use state::{EmbeddingStatus, GraphState, LspEnrichmentStatus, LspState};
+pub use state::{EmbeddingStatus, GraphBuildState, GraphBuildStatus, GraphState, LspEnrichmentStatus, LspState};
 pub use helpers::format_freshness;
 
 use std::path::{Path, PathBuf};
@@ -128,6 +128,7 @@ pub struct RnaHandler {
     /// to avoid duplicate work (two tool calls both detecting "no graph" and both
     /// running the full extraction pipeline).
     pub graph_build_lock: Arc<tokio::sync::Mutex<()>>,
+    pub graph_build_status: Arc<GraphBuildStatus>,
 }
 
 impl Default for RnaHandler {
@@ -153,6 +154,7 @@ impl Default for RnaHandler {
             prewarm_notify: Arc::new(tokio::sync::Notify::new()),
             prewarm_started: std::sync::atomic::AtomicBool::new(false),
             graph_build_lock: Arc::new(tokio::sync::Mutex::new(())),
+            graph_build_status: Arc::new(GraphBuildStatus::default()),
         }
     }
 }
@@ -184,6 +186,7 @@ impl RnaHandler {
             prewarm_notify: Arc::clone(&self.prewarm_notify),
             prewarm_started: std::sync::atomic::AtomicBool::new(false),
             graph_build_lock: Arc::clone(&self.graph_build_lock),
+            graph_build_status: Arc::clone(&self.graph_build_status),
         }
     }
 
@@ -197,8 +200,10 @@ impl RnaHandler {
     /// the graph populated when the first tool call arrives.
     fn start_prewarm(&self) {
         self.prewarm_started.store(true, std::sync::atomic::Ordering::Relaxed);
+        self.graph_build_status.set_building(0);
         let handler = self.clone_shared();
         let notify = Arc::clone(&self.prewarm_notify);
+        let build_status = Arc::clone(&self.graph_build_status);
         tokio::spawn(async move {
             tracing::info!("Pre-warming graph index in background...");
             let t0 = std::time::Instant::now();
@@ -216,6 +221,7 @@ impl RnaHandler {
                     if !handler.background_scanner_started.swap(true, std::sync::atomic::Ordering::Relaxed) {
                         handler.spawn_background_scanner();
                     }
+                    build_status.set_ready();
                     tracing::info!(
                         "Graph pre-warm complete: {} symbols, {} edges in {:.2}s",
                         node_count,
@@ -224,8 +230,7 @@ impl RnaHandler {
                     );
                 }
                 Err(e) => {
-                    // Pre-warm failure is non-fatal -- get_graph() will retry
-                    // on the first tool call.
+                    build_status.set_failed(format!("{}", e));
                     tracing::warn!("Graph pre-warm failed (will retry on first tool call): {}", e);
                 }
             }
@@ -277,6 +282,12 @@ impl RnaHandler {
             Some(slug) => Some(slug.to_string()),
             None => Some(self.primary_root_slug()),
         }
+    }
+
+    pub(crate) fn cold_start_building_message(&self) -> Option<String> {
+        let current = self.graph.load_full();
+        if current.is_some() { return None; }
+        self.graph_build_status.status_message()
     }
 
     /// Return the set of root slugs that correspond to non-code roots
@@ -437,6 +448,12 @@ impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
         } else {
             None
         };
+
+        if params.name != "list_roots" {
+            if let Some(building_msg) = self.cold_start_building_message() {
+                return Ok(helpers::text_result(building_msg));
+            }
+        }
 
         let mut result = match params.name.as_str() {
             "outcome_progress" => {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -108,6 +108,110 @@ impl GraphState {
     }
 }
 
+
+// ── Graph build status ───────────────────────────────────────────────
+
+/// Named states for the graph build lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum GraphBuildState {
+    NotStarted = 0,
+    Building = 1,
+    Ready = 2,
+    Failed = 3,
+}
+
+impl GraphBuildState {
+    fn from_u8(v: u8) -> Self {
+        match v {
+            0 => Self::NotStarted,
+            1 => Self::Building,
+            2 => Self::Ready,
+            3 => Self::Failed,
+            _ => Self::NotStarted,
+        }
+    }
+}
+
+/// Tracks graph build progress so tool calls can report "index building"
+/// instead of blocking silently during cold start.
+pub struct GraphBuildStatus {
+    state: std::sync::atomic::AtomicU8,
+    started_at: std::sync::Mutex<Option<std::time::Instant>>,
+    file_count: std::sync::atomic::AtomicUsize,
+    last_error: std::sync::Mutex<Option<String>>,
+}
+
+impl Default for GraphBuildStatus {
+    fn default() -> Self {
+        Self {
+            state: std::sync::atomic::AtomicU8::new(GraphBuildState::NotStarted as u8),
+            started_at: std::sync::Mutex::new(None),
+            file_count: std::sync::atomic::AtomicUsize::new(0),
+            last_error: std::sync::Mutex::new(None),
+        }
+    }
+}
+
+impl GraphBuildStatus {
+    pub fn current_state(&self) -> GraphBuildState {
+        GraphBuildState::from_u8(self.state.load(std::sync::atomic::Ordering::Acquire))
+    }
+
+    pub fn set_building(&self, file_count: usize) {
+        self.file_count.store(file_count, std::sync::atomic::Ordering::Release);
+        *self.started_at.lock().unwrap() = Some(std::time::Instant::now());
+        *self.last_error.lock().unwrap() = None;
+        self.state.store(GraphBuildState::Building as u8, std::sync::atomic::Ordering::Release);
+    }
+
+    pub fn set_ready(&self) {
+        self.state.store(GraphBuildState::Ready as u8, std::sync::atomic::Ordering::Release);
+    }
+
+    pub fn set_failed(&self, error: String) {
+        *self.last_error.lock().unwrap() = Some(error);
+        self.state.store(GraphBuildState::Failed as u8, std::sync::atomic::Ordering::Release);
+    }
+
+    pub fn elapsed(&self) -> Option<std::time::Duration> {
+        self.started_at.lock().unwrap().map(|t| t.elapsed())
+    }
+
+    pub fn status_message(&self) -> Option<String> {
+        match self.current_state() {
+            GraphBuildState::NotStarted | GraphBuildState::Ready => None,
+            GraphBuildState::Building => {
+                let files = self.file_count.load(std::sync::atomic::Ordering::Acquire);
+                let elapsed = self.elapsed().map(|d| d.as_secs()).unwrap_or(0);
+                if files > 0 {
+                    Some(format!("Index building ({} files, {}s elapsed)... retry in a few seconds", files, elapsed))
+                } else {
+                    Some(format!("Index building ({}s elapsed)... retry in a few seconds", elapsed))
+                }
+            }
+            GraphBuildState::Failed => {
+                let err = self.last_error.lock().unwrap();
+                match err.as_deref() {
+                    Some(msg) => Some(format!("Index build failed: {}", msg)),
+                    None => Some("Index build failed (unknown error)".to_string()),
+                }
+            }
+        }
+    }
+
+    pub fn footer_segment(&self) -> Option<String> {
+        match self.current_state() {
+            GraphBuildState::NotStarted | GraphBuildState::Ready => None,
+            GraphBuildState::Building => {
+                let elapsed = self.elapsed().map(|d| d.as_secs()).unwrap_or(0);
+                Some(format!("building ({}s)", elapsed))
+            }
+            GraphBuildState::Failed => Some("build failed".to_string()),
+        }
+    }
+}
+
 // ── Embedding build status ───────────────────────────────────────────
 
 /// Tracks embedding build progress so the search footer can show
@@ -121,6 +225,7 @@ pub struct EmbeddingStatus {
     total: std::sync::atomic::AtomicUsize,
     /// Final count after completion.
     completed_count: std::sync::atomic::AtomicUsize,
+    last_error: std::sync::Mutex<Option<String>>,
 }
 
 impl Default for EmbeddingStatus {
@@ -130,6 +235,7 @@ impl Default for EmbeddingStatus {
             current: std::sync::atomic::AtomicUsize::new(0),
             total: std::sync::atomic::AtomicUsize::new(0),
             completed_count: std::sync::atomic::AtomicUsize::new(0),
+            last_error: std::sync::Mutex::new(None),
         }
     }
 }
@@ -139,6 +245,7 @@ impl EmbeddingStatus {
     pub fn set_building(&self, total: usize) {
         self.total.store(total, std::sync::atomic::Ordering::Release);
         self.current.store(0, std::sync::atomic::Ordering::Release);
+        *self.last_error.lock().unwrap() = None;
         self.state.store(1, std::sync::atomic::Ordering::Release);
     }
 
@@ -153,7 +260,11 @@ impl EmbeddingStatus {
         self.state.store(2, std::sync::atomic::Ordering::Release);
     }
 
-    /// Render a footer segment for the search footer, or `None` if not started.
+    pub fn set_failed(&self, error: String) {
+        *self.last_error.lock().unwrap() = Some(error);
+        self.state.store(3, std::sync::atomic::Ordering::Release);
+    }
+
     pub fn footer_segment(&self) -> Option<String> {
         match self.state.load(std::sync::atomic::Ordering::Acquire) {
             0 => None,
@@ -165,6 +276,13 @@ impl EmbeddingStatus {
             2 => {
                 let count = self.completed_count.load(std::sync::atomic::Ordering::Acquire);
                 Some(format!("{} embedded", count))
+            }
+            3 => {
+                let err = self.last_error.lock().unwrap();
+                match err.as_deref() {
+                    Some(msg) => Some(format!("embedding failed: {}", msg)),
+                    None => Some("embedding failed".to_string()),
+                }
             }
             _ => None,
         }
@@ -184,6 +302,7 @@ pub enum LspState {
     Unavailable = 3,
     /// Server binary found on PATH but enrichment hasn't started yet.
     ServerFound = 4,
+    Failed = 5,
 }
 
 impl LspState {
@@ -194,6 +313,7 @@ impl LspState {
             2 => Self::Complete,
             3 => Self::Unavailable,
             4 => Self::ServerFound,
+            5 => Self::Failed,
             _ => Self::NotStarted,
         }
     }
@@ -205,6 +325,7 @@ impl LspState {
             Self::Complete => "COMPLETE",
             Self::Unavailable => "UNAVAILABLE",
             Self::ServerFound => "SERVER_FOUND",
+            Self::Failed => "FAILED",
         }
     }
 }
@@ -239,6 +360,7 @@ pub struct LspEnrichmentStatus {
     /// LSP server binaries that were checked but not found on PATH during probe.
     /// Used by list_roots to show "LSP available but not installed" for relevant languages.
     missing_servers: std::sync::Mutex<Vec<String>>,
+    last_error: std::sync::Mutex<Option<String>>,
 }
 
 impl Default for LspEnrichmentStatus {
@@ -253,6 +375,7 @@ impl Default for LspEnrichmentStatus {
             last_transition_at: std::sync::Mutex::new(now),
             server_name: std::sync::Mutex::new(None),
             missing_servers: std::sync::Mutex::new(Vec::new()),
+            last_error: std::sync::Mutex::new(None),
         }
     }
 }
@@ -264,6 +387,7 @@ impl LspEnrichmentStatus {
     const COMPLETE: u8 = LspState::Complete as u8;
     const UNAVAILABLE: u8 = LspState::Unavailable as u8;
     const SERVER_FOUND: u8 = LspState::ServerFound as u8;
+    const FAILED: u8 = LspState::Failed as u8;
 
     /// Log a state transition with elapsed time.
     fn log_transition(&self, from: LspState, to: LspState, detail: &str) {
@@ -347,6 +471,12 @@ impl LspEnrichmentStatus {
             self.state.swap(Self::UNAVAILABLE, std::sync::atomic::Ordering::AcqRel)
         );
         self.log_transition(prev, LspState::Unavailable, "no server detected");
+    }
+
+    pub fn set_failed(&self, error: &str) {
+        *self.last_error.lock().unwrap() = Some(error.to_string());
+        let prev = LspState::from_u8(self.state.swap(Self::FAILED, std::sync::atomic::Ordering::AcqRel));
+        self.log_transition(prev, LspState::Failed, error);
     }
 
     /// Mark that at least one LSP server binary was found on PATH.
@@ -527,9 +657,14 @@ impl LspEnrichmentStatus {
                 }
             }
             Self::UNAVAILABLE => {
-                // Always show unavailable status (no 30s auto-hide) so agents
-                // know LSP enrichment didn't run and why.
                 Some("LSP: no server detected".to_string())
+            }
+            Self::FAILED => {
+                let err = self.last_error.lock().unwrap();
+                match err.as_deref() {
+                    Some(msg) => Some(format!("LSP: enrichment failed: {}", msg)),
+                    None => Some("LSP: enrichment failed".to_string()),
+                }
             }
             _ => None,
         }
@@ -547,6 +682,7 @@ mod tests {
         assert_eq!(LspState::Complete.label(), "COMPLETE");
         assert_eq!(LspState::Unavailable.label(), "UNAVAILABLE");
         assert_eq!(LspState::ServerFound.label(), "SERVER_FOUND");
+        assert_eq!(LspState::Failed.label(), "FAILED");
     }
 
     #[test]
@@ -557,6 +693,7 @@ mod tests {
             LspState::Complete,
             LspState::Unavailable,
             LspState::ServerFound,
+            LspState::Failed,
         ] {
             assert_eq!(LspState::from_u8(state as u8), state);
         }
@@ -785,6 +922,7 @@ mod tests {
                             | LspState::Complete
                             | LspState::Unavailable
                             | LspState::ServerFound
+                            | LspState::Failed
                     ));
                     let _footer = s.footer_segment(); // must not panic
                 })
@@ -843,7 +981,7 @@ mod tests {
     fn test_adversarial_invalid_state_u8() {
         // Values beyond the enum range should fall back to NotStarted
         assert_eq!(LspState::from_u8(255), LspState::NotStarted);
-        assert_eq!(LspState::from_u8(5), LspState::NotStarted);
+        assert_eq!(LspState::from_u8(6), LspState::NotStarted);
         assert_eq!(LspState::from_u8(100), LspState::NotStarted);
     }
 
@@ -1088,5 +1226,45 @@ mod tests {
                 seg
             );
         }
+    }
+
+    #[test]
+    fn test_graph_build_status_default() {
+        let status = GraphBuildStatus::default();
+        assert_eq!(status.current_state(), GraphBuildState::NotStarted);
+        assert!(status.status_message().is_none());
+    }
+
+    #[test]
+    fn test_graph_build_status_building() {
+        let status = GraphBuildStatus::default();
+        status.set_building(500);
+        let msg = status.status_message().unwrap();
+        assert!(msg.contains("500 files"), "got: {}", msg);
+        assert!(msg.contains("retry in a few seconds"), "got: {}", msg);
+    }
+
+    #[test]
+    fn test_graph_build_status_failed() {
+        let status = GraphBuildStatus::default();
+        status.set_failed("disk full".to_string());
+        let msg = status.status_message().unwrap();
+        assert!(msg.contains("disk full"), "got: {}", msg);
+    }
+
+    #[test]
+    fn test_embedding_status_failed() {
+        let status = EmbeddingStatus::default();
+        status.set_failed("model error".to_string());
+        let footer = status.footer_segment().unwrap();
+        assert!(footer.contains("embedding failed"), "got: {}", footer);
+    }
+
+    #[test]
+    fn test_lsp_status_failed() {
+        let status = LspEnrichmentStatus::default();
+        status.set_failed("server crashed");
+        let footer = status.footer_segment().unwrap();
+        assert!(footer.contains("enrichment failed"), "got: {}", footer);
     }
 }


### PR DESCRIPTION
## Summary

- During cold start, tool calls return immediately with "Index building (N files, Xs elapsed)... retry in a few seconds" instead of blocking silently for 10-60s
- When background enrichment fails (embedding or LSP), the next tool call's footer surfaces the error instead of silently swallowing it
- Adds `GraphBuildStatus` state machine to track build lifecycle and `Failed` states to `EmbeddingStatus` and `LspEnrichmentStatus`

## Changes

**`src/server/state.rs`** -- New `GraphBuildStatus` type with `NotStarted -> Building -> Ready/Failed` lifecycle. Added `set_failed(error)` and `Failed` state to both `EmbeddingStatus` and `LspEnrichmentStatus` with error message tracking. 5 new tests.

**`src/server/mod.rs`** -- `RnaHandler` gains `graph_build_status: Arc<GraphBuildStatus>` field. `start_prewarm()` sets building/ready/failed. `handle_call_tool_request()` checks `cold_start_building_message()` before dispatching (list_roots exempt).

**`src/server/graph.rs`** -- `get_graph()` build-from-scratch path tracks status. `build_full_graph_inner()` updates file count after scanning and sets ready on cache-hit return.

**`src/server/enrichment.rs`** -- Replaces silent `set_complete(0)` with `set_failed(error)` in embedding error paths. Replaces `set_unavailable()` with `set_failed(error)` when enrichment pipeline fails.

## Test plan

- [x] `cargo check --lib` passes
- [x] All 48 state.rs tests pass (including 5 new ones)
- [ ] Manual: start MCP server with cold cache, first tool call returns building message
- [ ] Manual: kill LSP server mid-enrichment, verify footer shows failure

Closes #585