### PR TITLE
fix: align MCP search top_k to limit, document graph mode equivalence

### DIFF
--- a/src/server/tools.rs
+++ b/src/server/tools.rs
@@ -31,7 +31,7 @@ pub struct OutcomeProgress {
 
 #[macros::mcp_tool(
     name = "search",
-    description = "USE THIS INSTEAD OF Grep/Read for code understanding. Searches code symbols, docs, business artifacts, and commits in one call. Add `mode` for graph traversal (neighbors/impact/reachable/tests_for/cycles/path). Use `compact: true` to save tokens. Use `rerank: true` for natural language queries. Use `subsystem` to scope to a subsystem from repo_map. Use `target_subsystem` with mode to find cross-subsystem edges. Use `depth` with mode='neighbors' to walk N levels deep (e.g., module → members → their members)."
+    description = "USE THIS INSTEAD OF Grep/Read for code understanding. Searches code symbols, docs, business artifacts, and commits in one call. Add `mode` for graph traversal (neighbors/impact/reachable/tests_for/cycles/path) — equivalent to the `graph` CLI command. Use `compact: true` to save tokens. Use `rerank: true` for natural language queries. Use `subsystem` to scope to a subsystem from repo_map. Use `target_subsystem` with mode to find cross-subsystem edges. Use `depth` with mode='neighbors' to walk N levels deep (e.g., module → members → their members). Use `limit` to control max results (flat default: 10, traversal default: 1)."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct Search {
@@ -69,8 +69,8 @@ pub struct Search {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub root: Option<String>,
     /// Max results (flat default: 10, traversal default: 1)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub top_k: Option<u32>,
+    #[serde(default, alias = "top_k", skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
     /// Sort: "relevance" (default), "complexity", "importance"
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sort_by: Option<String>,
@@ -186,15 +186,25 @@ mod tests {
     }
 
     #[test]
-    fn test_search_traversal_with_top_k() {
+    fn test_search_traversal_with_limit() {
         let s = parse_search(json!({
             "query": "database",
             "mode": "impact",
+            "limit": 5
+        }))
+        .unwrap();
+        assert_eq!(s.limit, Some(5));
+        assert_eq!(s.mode, Some("impact".to_string()));
+    }
+
+    #[test]
+    fn test_search_top_k_alias_still_works() {
+        let s = parse_search(json!({
+            "query": "database",
             "top_k": 5
         }))
         .unwrap();
-        assert_eq!(s.top_k, Some(5));
-        assert_eq!(s.mode, Some("impact".to_string()));
+        assert_eq!(s.limit, Some(5));
     }
 
     #[test]
@@ -231,15 +241,15 @@ mod tests {
     }
 
     #[test]
-    fn test_search_flat_default_top_k_is_10() {
+    fn test_search_flat_default_limit_is_10() {
         let s = parse_search(json!({"query": "test"})).unwrap();
-        assert!(s.top_k.is_none()); // default applied by handler, not struct
+        assert!(s.limit.is_none()); // default applied by handler, not struct
     }
 
     #[test]
-    fn test_search_traversal_default_top_k_is_1() {
+    fn test_search_traversal_default_limit_is_1() {
         let s = parse_search(json!({"query": "test", "mode": "neighbors"})).unwrap();
-        assert!(s.top_k.is_none()); // default applied by handler
+        assert!(s.limit.is_none()); // default applied by handler
     }
 
     #[test]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -104,7 +104,7 @@ impl SearchParams {
             kind: args.kind.clone(),
             language: args.language.clone(),
             file: args.file.clone(),
-            limit: args.top_k.map(|k| k as usize),
+            limit: args.limit.map(|k| k as usize),
             sort_by: args.sort_by.clone(),
             min_complexity: args.min_complexity,
             synthetic: args.synthetic,


### PR DESCRIPTION
## Summary
- Rename MCP `top_k` parameter to `limit` on the `Search` tool struct, matching the CLI's `--limit` flag. A serde `alias = "top_k"` preserves backward compatibility for existing callers.
- Update the MCP search tool description to document that graph traversal modes (`neighbors`, `impact`, `reachable`, `tests_for`, `cycles`, `path`) are the MCP equivalent of the `graph` CLI command, and mention the `limit` parameter with its defaults.
- Freshness info (issue item #2) was already present in MCP responses via the service layer's `format_freshness_full` call -- no changes needed.

## Test plan
- [x] `cargo check --lib` passes
- [x] All 52 `tools::tests` pass, including new `test_search_top_k_alias_still_works` test
- [x] All 149 relevant unit tests (tools, helpers, service/search) pass
- [x] Backward compat: sending `{"top_k": 5}` still deserializes correctly via alias

Closes #592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the search tool's parameter name from `top_k` to `limit`.
  * Added backward compatibility to accept both `limit` and legacy `top_k` keys.

* **Documentation**
  * Updated search tool documentation to describe the `limit` parameter and its default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->