### PR TITLE
fix: restore background LSP enrichment to unblock cold scan

### DIFF
--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -1334,6 +1334,9 @@ impl ExtractionConsumer for LspConsumer {
 pub struct AllEnrichmentsGate {
     /// Shared state protected by a Mutex — on_event is &self but needs mutation.
     state: Mutex<GateState>,
+    /// When true, LSP consumers are skipped (#574) — force expected=0 so the gate
+    /// emits AllEnrichmentsDone immediately on RootExtracted.
+    skip_lsp: bool,
 }
 
 struct GateState {
@@ -1372,6 +1375,26 @@ impl AllEnrichmentsGate {
                 updated_nodes: Vec::new(),
                 fired: false,
             }),
+            skip_lsp: false,
+        }
+    }
+
+    /// Create a gate that skips LSP — forces expected=0 so AllEnrichmentsDone
+    /// fires immediately. Used when LSP is deferred to background (#574).
+    pub fn with_skip_lsp() -> Self {
+        Self {
+            state: Mutex::new(GateState {
+                expected: 0,
+                received: 0,
+                base_nodes: None,
+                base_edges: None,
+                slug: None,
+                lsp_edges: Vec::new(),
+                lsp_nodes: Vec::new(),
+                updated_nodes: Vec::new(),
+                fired: false,
+            }),
+            skip_lsp: true,
         }
     }
 }
@@ -1427,7 +1450,12 @@ impl ExtractionConsumer for AllEnrichmentsGate {
                 // never produce EnrichmentComplete, so we must not count them.
                 let supported = crate::extract::EnricherRegistry::with_builtins()
                     .supported_languages();
-                let expected = {
+                let expected = if self.skip_lsp {
+                    // #574: LSP consumers are not registered — no EnrichmentComplete
+                    // events will arrive. Force expected=0 so we emit AllEnrichmentsDone
+                    // immediately, allowing non-LSP passes to run without waiting.
+                    0
+                } else {
                     let mut seen = std::collections::HashSet::new();
                     for n in nodes.iter() {
                         if !n.language.is_empty() && supported.contains(&n.language) {
@@ -1884,6 +1912,10 @@ pub struct BusOptions {
     pub embed_idx: Option<Arc<crate::embed::EmbeddingIndex>>,
     /// When `Some`, `LanceDBConsumer` fires a background persist on `PassesComplete`.
     pub lance_repo_root: Option<Arc<PathBuf>>,
+    /// When `true`, `LspConsumer` instances are NOT registered in the bus.
+    /// This allows the enrichment pipeline to run non-LSP passes only (fast path),
+    /// with LSP enrichment deferred to a background task (#574).
+    pub skip_lsp: bool,
 }
 
 /// Build an `EventBus` pre-loaded with all built-in consumers.
@@ -1927,7 +1959,7 @@ pub fn build_builtin_bus(
     repo_root: PathBuf,
     opts: BusOptions,
 ) -> (crate::extract::event_bus::EventBus, Arc<RwLock<ScanStats>>) {
-    let BusOptions { scan_stats, embed_idx, lance_repo_root } = opts;
+    let BusOptions { scan_stats, embed_idx, lance_repo_root, skip_lsp } = opts;
     use crate::extract::event_bus::EventBus;
 
     let mut bus = EventBus::new();
@@ -1949,7 +1981,13 @@ pub fn build_builtin_bus(
     // AllEnrichmentsGate: must subscribe to RootExtracted BEFORE LspConsumers
     // fire so it captures the language count before any EnrichmentComplete arrives.
     // Registration order matches subscription order in the sync bus.
-    bus.register(Box::new(AllEnrichmentsGate::new()));
+    // When skip_lsp=true (#574), the gate forces expected=0 so AllEnrichmentsDone
+    // fires immediately without waiting for EnrichmentComplete events.
+    bus.register(Box::new(if skip_lsp {
+        AllEnrichmentsGate::with_skip_lsp()
+    } else {
+        AllEnrichmentsGate::new()
+    }));
 
     // OpenApi, gRPC, Embedding — subscribe to RootExtracted independently.
     bus.register(Box::new(OpenApiConsumer));
@@ -1965,33 +2003,40 @@ pub fn build_builtin_bus(
     // Per the ADR: "ALL fire concurrently, one per language."
     // Currently sequential in the sync bus; Phase 4 promotes to async parallel.
     //
-    // Build the enricher registry once and extract individual enrichers per language.
-    // Each `LspConsumer` owns an `Arc<dyn Enricher>` so it doesn't re-instantiate.
-    let enricher_registry = crate::extract::EnricherRegistry::with_builtins();
-    let lsp_roots: Arc<Vec<(String, PathBuf)>> = Arc::new(root_pairs.clone());
+    // When `skip_lsp=true` (#574), LspConsumers are omitted entirely so the bus
+    // completes without waiting for LSP servers. The caller spawns LSP enrichment
+    // in background and ArcSwaps the enriched graph when it finishes.
+    if !skip_lsp {
+        // Build the enricher registry once and extract individual enrichers per language.
+        // Each `LspConsumer` owns an `Arc<dyn Enricher>` so it doesn't re-instantiate.
+        let enricher_registry = crate::extract::EnricherRegistry::with_builtins();
+        let lsp_roots: Arc<Vec<(String, PathBuf)>> = Arc::new(root_pairs.clone());
 
-    // Build enrichers indexed by language for O(1) lookup.
-    // EnricherRegistry does not expose individual enrichers, so we rebuild
-    // per-language enrichers via LspEnricher::new (same as EnricherRegistry internals).
-    // This avoids exposing registry internals and keeps consumers self-contained.
-    let mut supported_languages: Vec<String> = enricher_registry
-        .supported_languages()
-        .into_iter()
-        .collect();
-    supported_languages.sort(); // deterministic registration order
+        // Build enrichers indexed by language for O(1) lookup.
+        // EnricherRegistry does not expose individual enrichers, so we rebuild
+        // per-language enrichers via LspEnricher::new (same as EnricherRegistry internals).
+        // This avoids exposing registry internals and keeps consumers self-contained.
+        let mut supported_languages: Vec<String> = enricher_registry
+            .supported_languages()
+            .into_iter()
+            .collect();
+        supported_languages.sort(); // deterministic registration order
 
-    for lang in &supported_languages {
-        // Build a single-language enricher for this consumer.
-        // The enricher is the same type as what EnricherRegistry uses internally.
-        // We use `EnricherRegistry::with_builtins()` filtered to this language
-        // rather than duplicating the language-server config table.
-        let single_lang_enricher = build_single_language_enricher(lang);
-        bus.register(Box::new(LspConsumer {
-            language: lang.clone(),
-            enricher: single_lang_enricher,
-            repo_root: repo_root.clone(),
-            lsp_roots: Arc::clone(&lsp_roots),
-        }));
+        for lang in &supported_languages {
+            // Build a single-language enricher for this consumer.
+            // The enricher is the same type as what EnricherRegistry uses internally.
+            // We use `EnricherRegistry::with_builtins()` filtered to this language
+            // rather than duplicating the language-server config table.
+            let single_lang_enricher = build_single_language_enricher(lang);
+            bus.register(Box::new(LspConsumer {
+                language: lang.clone(),
+                enricher: single_lang_enricher,
+                repo_root: repo_root.clone(),
+                lsp_roots: Arc::clone(&lsp_roots),
+            }));
+        }
+    } else {
+        tracing::info!("skip_lsp=true: LspConsumers omitted from bus — LSP will run in background");
     }
 
     // --- AllEnrichmentsDone consumers ---

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -315,6 +315,7 @@ impl RnaHandler {
                                 scan_stats: Some(Arc::clone(&scan_stats)),
                                 embed_idx: None, // embed handled by background scanner's own reindex pass
                                 lance_repo_root: None, // LanceDB persist handled by background scanner's lance_deltas
+                                skip_lsp: false, // background scanner: LSP runs inline
                             },
                             dirty_slugs,
                         ).await {
@@ -493,6 +494,253 @@ impl RnaHandler {
         tracing::info!("Background scanner started (event-driven + 15min heartbeat, worktree-aware)");
     }
 
+    /// Spawn background LSP enrichment after the initial graph build returns (#574).
+    ///
+    /// The initial `build_full_graph_inner` runs with `skip_lsp=true` so it returns
+    /// in seconds (tree-sitter + non-LSP passes only). This method spawns LSP enrichment
+    /// in the background: when complete, it ArcSwaps the fully enriched graph and
+    /// re-persists to LanceDB with LSP edges.
+    ///
+    /// This restores the v0.1.14 behavior where `build_full_graph_inner` returned
+    /// immediately and LSP ran via `spawn_background_enrichment`.
+    pub(crate) fn spawn_background_lsp_enrichment(
+        &self,
+        nodes: Vec<crate::graph::Node>,
+        edges: Vec<crate::graph::Edge>,
+        dirty_slugs: std::collections::HashSet<String>,
+        detected_frameworks: std::collections::HashSet<String>,
+    ) {
+        let repo_root = self.repo_root.clone();
+        let graph_arc = Arc::clone(&self.graph);
+        let lsp_status = Arc::clone(&self.lsp_status);
+        let scan_stats = Arc::clone(&self.scan_stats);
+        let lance_write_lock = Arc::clone(&self.lance_write_lock);
+
+        tokio::spawn(async move {
+            let t0 = std::time::Instant::now();
+            tracing::info!(
+                "[background-lsp] Starting LSP enrichment: {} nodes, {} edges",
+                nodes.len(), edges.len()
+            );
+
+            // Build root pairs for the enrichment pipeline
+            let workspace = crate::roots::WorkspaceConfig::load()
+                .with_primary_root(repo_root.clone())
+                .with_worktrees(&repo_root)
+                .with_declared_roots(&repo_root);
+            let root_pairs: Vec<(String, std::path::PathBuf)> = workspace
+                .resolved_roots()
+                .iter()
+                .map(|r| (r.slug.clone(), r.path.clone()))
+                .collect();
+            let primary_slug = crate::roots::RootConfig::code_project(repo_root.clone()).slug();
+
+            // Run enrichment pipeline WITH LSP (skip_lsp=false)
+            let result = crate::extract::consumers::emit_enrichment_pipeline(
+                nodes,
+                edges,
+                root_pairs,
+                primary_slug.clone(),
+                repo_root.clone(),
+                crate::extract::consumers::BusOptions {
+                    scan_stats: Some(Arc::clone(&scan_stats)),
+                    embed_idx: None,
+                    lance_repo_root: None,
+                    skip_lsp: false, // this time LSP runs
+                },
+                Some(dirty_slugs),
+            ).await;
+
+            match result {
+                Ok((mut enriched_nodes, mut enriched_edges, enriched_frameworks)) => {
+                    // Update LSP status
+                    let lsp_edge_count = enriched_edges.iter()
+                        .filter(|e| e.source == crate::graph::ExtractionSource::Lsp)
+                        .count();
+                    let lsp_call_edge_count = enriched_edges.iter()
+                        .filter(|e| {
+                            e.source == crate::graph::ExtractionSource::Lsp
+                                && matches!(e.kind, crate::graph::EdgeKind::Calls)
+                        })
+                        .count();
+                    if lsp_edge_count > 0 {
+                        lsp_status.set_complete(lsp_call_edge_count);
+                        tracing::info!(
+                            "[background-lsp] LSP enrichment complete: {} LSP call edges, {} total LSP edges in {:.2}s",
+                            lsp_call_edge_count, lsp_edge_count, t0.elapsed().as_secs_f64()
+                        );
+                    } else {
+                        lsp_status.set_unavailable();
+                        tracing::info!(
+                            "[background-lsp] LSP enrichment produced no edges in {:.2}s",
+                            t0.elapsed().as_secs_f64()
+                        );
+                    }
+
+                    // Dedup
+                    {
+                        let mut seen_nodes = std::collections::HashSet::new();
+                        enriched_nodes.reverse();
+                        enriched_nodes.retain(|n| seen_nodes.insert(n.stable_id()));
+                        enriched_nodes.reverse();
+                        let mut seen_edges = std::collections::HashSet::new();
+                        enriched_edges.retain(|e| seen_edges.insert(e.stable_id()));
+                    }
+
+                    // Rebuild petgraph index
+                    let mut index = crate::graph::index::GraphIndex::new();
+                    index.rebuild_from_edges(&enriched_edges);
+                    for node in &enriched_nodes {
+                        index.ensure_node(&node.stable_id(), &node.id.kind.to_string());
+                    }
+
+                    // Recompute PageRank with LSP edges
+                    let pagerank_scores = index.compute_pagerank(0.85, 20);
+                    for node in &mut enriched_nodes {
+                        if let Some(&score) = pagerank_scores.get(&node.stable_id()) {
+                            node.metadata.insert("importance".to_string(), format!("{:.6}", score));
+                        }
+                    }
+
+                    // Re-run subsystem detection with updated PageRank
+                    {
+                        let node_file_map: std::collections::HashMap<String, String> = enriched_nodes
+                            .iter()
+                            .filter(|n| n.id.root != "external")
+                            .map(|n| (n.stable_id(), n.id.file.display().to_string()))
+                            .collect();
+                        let mut subsystems = index.detect_communities(&pagerank_scores, &node_file_map);
+                        // Dedup subsystem names
+                        {
+                            let mut name_counts: std::collections::HashMap<String, usize> =
+                                std::collections::HashMap::new();
+                            for s in &subsystems {
+                                *name_counts.entry(s.name.clone()).or_default() += 1;
+                            }
+                            for s in &mut subsystems {
+                                if name_counts.get(&s.name).copied().unwrap_or(0) > 1
+                                    && let Some(iface) = s.interfaces.first() {
+                                        let short = iface
+                                            .node_id
+                                            .split(':')
+                                            .rev()
+                                            .nth(1)
+                                            .unwrap_or(&iface.node_id);
+                                        s.name = format!("{}/{}", s.name, short);
+                                    }
+                            }
+                        }
+                        let mut node_subsystem: std::collections::HashMap<String, String> =
+                            std::collections::HashMap::new();
+                        for subsystem in &subsystems {
+                            for member_id in &subsystem.member_ids {
+                                node_subsystem.insert(member_id.clone(), subsystem.name.clone());
+                            }
+                        }
+                        // Remove stale virtual nodes
+                        enriched_nodes.retain(|n| !matches!(&n.id.kind, crate::graph::NodeKind::Other(s) if matches!(s.as_str(), "subsystem" | "framework" | "channel" | "event")));
+                        enriched_edges.retain(|e| {
+                            !matches!(&e.to.kind, crate::graph::NodeKind::Other(s) if s == "subsystem")
+                                && e.kind != crate::graph::EdgeKind::UsesFramework
+                                && e.kind != crate::graph::EdgeKind::Produces
+                                && e.kind != crate::graph::EdgeKind::Consumes
+                        });
+                        for node in &mut enriched_nodes {
+                            if let Some(subsystem_name) = node_subsystem.get(&node.stable_id()) {
+                                node.metadata.insert(
+                                    super::graph::SUBSYSTEM_KEY.to_owned(),
+                                    subsystem_name.clone(),
+                                );
+                            } else {
+                                node.metadata.remove(super::graph::SUBSYSTEM_KEY);
+                            }
+                        }
+                        // Emit subsystem virtual nodes
+                        let (sub_added_nodes, sub_added_edges) =
+                            crate::extract::consumers::emit_community_detection(
+                                primary_slug,
+                                subsystems,
+                                enriched_nodes.clone(),
+                            ).await.unwrap_or_else(|e| {
+                                tracing::warn!("[background-lsp] Subsystem promotion failed: {}", e);
+                                (vec![], vec![])
+                            });
+                        enriched_nodes.extend(sub_added_nodes);
+                        enriched_edges.extend(sub_added_edges);
+
+                        // Re-add virtual nodes to index
+                        for node in &enriched_nodes {
+                            if matches!(&node.id.kind, crate::graph::NodeKind::Other(s) if matches!(s.as_str(), "subsystem" | "framework" | "channel" | "event")) {
+                                index.ensure_node(&node.stable_id(), &node.id.kind.to_string());
+                            }
+                        }
+                        for edge in &enriched_edges {
+                            if matches!(&edge.to.kind, crate::graph::NodeKind::Other(s) if matches!(s.as_str(), "subsystem" | "framework" | "channel" | "event")) {
+                                index.add_edge(
+                                    &edge.from.to_stable_id(),
+                                    &edge.from.kind.to_string(),
+                                    &edge.to.to_stable_id(),
+                                    &edge.to.kind.to_string(),
+                                    edge.kind.clone(),
+                                );
+                            }
+                        }
+                    }
+
+                    // Final dedup
+                    {
+                        let mut seen_edges = std::collections::HashSet::new();
+                        enriched_edges.retain(|e| seen_edges.insert(e.stable_id()));
+                    }
+
+                    // Persist to LanceDB with LSP edges
+                    {
+                        let _lance_guard = lance_write_lock.lock().await;
+                        if let Err(e) = super::store::persist_graph_to_lance(
+                            &repo_root, &enriched_nodes, &enriched_edges
+                        ).await {
+                            tracing::error!("[background-lsp] LanceDB persist failed: {}", e);
+                        } else {
+                            super::sentinel::write_extract_sentinel(
+                                &repo_root, enriched_nodes.len(), enriched_edges.len()
+                            );
+                            let has_lsp_edges = enriched_edges.iter()
+                                .any(|e| e.source == crate::graph::ExtractionSource::Lsp);
+                            if has_lsp_edges {
+                                super::sentinel::write_lsp_sentinel(
+                                    &repo_root, enriched_nodes.len(), enriched_edges.len()
+                                );
+                            }
+                            tracing::info!(
+                                "[background-lsp] LanceDB re-persisted with LSP edges: {} nodes, {} edges",
+                                enriched_nodes.len(), enriched_edges.len()
+                            );
+                        }
+                    }
+
+                    // ArcSwap the fully enriched graph
+                    let all_frameworks = detected_frameworks.union(&enriched_frameworks).cloned().collect();
+                    let new_state = super::state::GraphState::new(
+                        enriched_nodes,
+                        enriched_edges,
+                        index,
+                        Some(std::time::Instant::now()),
+                        all_frameworks,
+                    );
+                    graph_arc.store(Arc::new(Some(Arc::new(new_state))));
+                    tracing::info!(
+                        "[background-lsp] Enriched graph swapped in after {:.2}s",
+                        t0.elapsed().as_secs_f64()
+                    );
+                }
+                Err(e) => {
+                    tracing::error!("[background-lsp] LSP enrichment pipeline failed: {:#}", e);
+                    lsp_status.set_unavailable();
+                }
+            }
+        });
+    }
+
     /// Spawn background embedding after a full graph build.
     ///
     /// **Phase 3**: LSP enrichment has been moved into `LspConsumer` within the event bus
@@ -633,6 +881,7 @@ impl RnaHandler {
                     scan_stats: Some(bg_scan_stats),
                     embed_idx: None,
                     lance_repo_root: None,
+                    skip_lsp: false,
                 },
                 None,
             ).await;
@@ -999,6 +1248,7 @@ impl RnaHandler {
                 scan_stats: Some(Arc::clone(&self.scan_stats)),
                 embed_idx: None,
                 lance_repo_root: None,
+                skip_lsp: false,
             },
             dirty_slugs,
         ).await;
@@ -1213,6 +1463,7 @@ impl RnaHandler {
                     scan_stats: Some(Arc::clone(&self.scan_stats)),
                     embed_idx: None,
                     lance_repo_root: None,
+                    skip_lsp: false,
                 },
                 None, // full rebuild: all roots dirty
             ).await;
@@ -1376,6 +1627,7 @@ impl RnaHandler {
                 scan_stats: Some(Arc::clone(&self.scan_stats)),
                 embed_idx: None,
                 lance_repo_root: None,
+                skip_lsp: false,
             },
             None, // no sentinel means all roots need enrichment
         ).await;

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -261,6 +261,7 @@ impl RnaHandler {
                                 scan_stats: Some(Arc::clone(&scan_stats)),
                                 embed_idx: None,
                                 lance_repo_root: None,
+                                skip_lsp: false, // incremental background path: LSP runs inline
                             },
                             dirty_slugs,
                         ).await {
@@ -550,12 +551,14 @@ impl RnaHandler {
 
     /// Build the full graph from scratch. This is the original get_graph logic.
     ///
-    /// When `spawn_background` is true (default for MCP server), embedding is
-    /// spawned as a background task so the graph is queryable immediately.
-    /// LSP enrichment now runs synchronously via `LspConsumer` in the event bus
-    /// (`emit_enrichment_pipeline`), so it completes before this function returns.
-    /// When false (used by `run_pipeline_foreground`), no background tasks are
-    /// spawned -- the caller handles embed itself.
+    /// When `spawn_background` is true (default for MCP server), LSP enrichment
+    /// and embedding are spawned as background tasks so the graph is queryable
+    /// immediately with tree-sitter + non-LSP pass results (#574). The background
+    /// LSP task runs `emit_enrichment_pipeline` with LSP enabled, then ArcSwaps
+    /// the fully enriched graph when complete (restoring v0.1.14 behavior).
+    ///
+    /// When false (used by `run_pipeline_foreground`), LSP runs inline via the
+    /// event bus and no background tasks are spawned -- the caller handles embed.
     pub async fn build_full_graph(&self) -> anyhow::Result<GraphState> {
         self.build_full_graph_inner(true).await
     }
@@ -1079,6 +1082,8 @@ impl RnaHandler {
         // uses the embed index created just below), and LanceDB persist runs after PageRank
         // + subsystem detection so the stored data is complete. Using real consumers here
         // would either duplicate work (embed) or persist an incomplete graph (lance).
+        // Clone dirty slugs for the background LSP task before they're consumed by the bus.
+        let dirty_slugs_for_lsp = freshly_extracted_slugs.clone();
         {
             // Mark LSP as running before the bus call so status is visible immediately.
             if spawn_background {
@@ -1114,6 +1119,7 @@ impl RnaHandler {
                         scan_stats: Some(Arc::clone(&self.scan_stats)),
                         embed_idx: None, // embed handled by spawn_background_enrichment after graph is ready
                         lance_repo_root: None, // LanceDB persist handled directly after PageRank/subsystem passes
+                        skip_lsp: spawn_background, // #574: MCP server path skips LSP here, spawns it in background
                     },
                     dirty_slugs,
                 ).await?;
@@ -1121,13 +1127,10 @@ impl RnaHandler {
             all_edges = enriched_edges;
             all_detected_frameworks = detected_frameworks;
 
-            // Count LSP edges added by LspConsumer during bus execution.
-            // These are ExtractionSource::Lsp edges in all_edges.
-            // Use only LSP-sourced edges to drive the status: non-LSP Calls edges
-            // (e.g. from GrpcClientCallsPass) must not falsely mark LSP as complete,
-            // and a metadata-only enrichment (updated_nodes, no new edges) must not
-            // report as unavailable.
-            if spawn_background {
+            // When skip_lsp=true (spawn_background path), LSP didn't run yet.
+            // LSP status stays "running" — the background LSP task will update it.
+            // When skip_lsp=false (CLI path), check LSP edges now.
+            if !spawn_background {
                 let lsp_edge_count = all_edges.iter()
                     .filter(|e| e.source == crate::graph::ExtractionSource::Lsp)
                     .count();
@@ -1144,8 +1147,6 @@ impl RnaHandler {
                         lsp_call_edge_count, lsp_edge_count,
                     );
                 } else {
-                    // No LSP edges — either no server available or no enrichable nodes.
-                    // Mark as unavailable so the status shows "no server" not "running".
                     self.lsp_status.set_unavailable();
                 }
             }
@@ -1336,11 +1337,9 @@ impl RnaHandler {
         // Persisting here would write only tree-sitter edges, and a subsequent
         // `repo-map` loading from LanceDB cache would miss LSP edges (#311).
         if spawn_background {
-            // Phase 3 (issue #520): LSP enrichment now runs synchronously inside
-            // `emit_enrichment_pipeline` (via `LspConsumer` + `AllEnrichmentsGate`).
-            // The graph already contains LSP edges at this point, so we can write
-            // both sentinels in one persist rather than clearing+rewriting.
-            // We no longer need to clear the LSP sentinel here since LSP ran before persist.
+            // #574: LSP enrichment is deferred to background. The graph here contains
+            // tree-sitter + non-LSP passes only. Persist now so the graph is queryable,
+            // then the background LSP task will re-persist with LSP edges.
 
             let _lance_guard = self.lance_write_lock.lock().await;
             if let Err(e) = persist_graph_to_lance(&self.repo_root, &all_nodes, &all_edges).await {
@@ -1348,25 +1347,11 @@ impl RnaHandler {
                 return Err(e.context("LanceDB full persist failed during graph build"));
             }
 
-            // Write both sentinels inside the lock: LSP enrichment already completed
-            // above (synchronously via bus), so the persisted graph includes LSP edges.
-            // Writing the LSP sentinel here avoids a subsequent startup re-running LSP
-            // on an already-enriched graph (#477).
+            // Write extraction sentinel but NOT the LSP sentinel — LSP hasn't run yet.
+            // The background LSP task will write the LSP sentinel after enrichment.
             super::sentinel::write_extract_sentinel(&self.repo_root, all_nodes.len(), all_edges.len());
-            // Write or clear the LSP sentinel depending on whether LSP produced edges.
-            // If LSP ran but produced no edges (no server, no supported language, empty result),
-            // we must clear any stale sentinel left from a previous run. A stale sentinel would
-            // cause the next startup to skip LSP enrichment even though the persisted graph is
-            // tree-sitter-only, which would hide the "no server" situation.
-            let has_lsp_edges = all_edges.iter()
-                .any(|e| e.source == crate::graph::ExtractionSource::Lsp);
-            if has_lsp_edges {
-                super::sentinel::write_lsp_sentinel(&self.repo_root, all_nodes.len(), all_edges.len());
-            } else {
-                // No LSP data in this build — clear the old sentinel so the next startup
-                // knows to re-run LSP enrichment rather than trusting stale data.
-                super::sentinel::clear_lsp_sentinel(&self.repo_root);
-            }
+            // Clear any stale LSP sentinel so the next startup knows LSP is pending.
+            super::sentinel::clear_lsp_sentinel(&self.repo_root);
             drop(_lance_guard);
 
             // Post-persist sanity check: if any new roots were detected, verify they
@@ -1414,7 +1399,8 @@ impl RnaHandler {
         }
 
         // Graph is ready -- return immediately so agents can query.
-        // LSP enrichment already ran synchronously via LspConsumer in the bus above (#520).
+        // When spawn_background=true: LSP enrichment is deferred to background (#574).
+        // When spawn_background=false: LSP already ran inline via the bus.
         // Embedding runs in the background task below.
         let symbols_ready_at = std::time::Instant::now();
 
@@ -1433,6 +1419,16 @@ impl RnaHandler {
         };
 
         if spawn_background {
+            // #574: spawn background LSP enrichment (restores v0.1.14 pattern).
+            // The graph returned below has tree-sitter + non-LSP passes only.
+            // This task runs LSP, re-computes PageRank/subsystems, and ArcSwaps.
+            self.spawn_background_lsp_enrichment(
+                all_nodes.clone(),
+                all_edges.clone(),
+                dirty_slugs_for_lsp,
+                all_detected_frameworks.clone(),
+            );
+
             let handle = self.spawn_background_enrichment(&all_nodes);
             // Store the handle so CLI callers can await it before the runtime
             // shuts down, preventing JoinError::Cancelled panics (#560).
@@ -1638,6 +1634,7 @@ impl RnaHandler {
                         scan_stats: Some(Arc::clone(&self.scan_stats)),
                         embed_idx: None, // embed handled below via targeted reindex_nodes after PageRank
                         lance_repo_root: None, // LanceDB persist handled below via persist_graph_incremental
+                        skip_lsp: false, // update_graph_with_scan: LSP runs inline (already incremental)
                     },
                     dirty_slugs,
                 ).await.map_err(|e| {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -223,7 +223,8 @@ impl RnaHandler {
                     }
                     build_status.set_ready();
                     tracing::info!(
-                        "Graph pre-warm complete: {} symbols, {} edges in {:.2}s",
+                        "Graph pre-warm complete (tree-sitter + passes): {} symbols, {} edges in {:.2}s \
+                         — LSP enrichment running in background",
                         node_count,
                         edge_count,
                         t0.elapsed().as_secs_f64(),


### PR DESCRIPTION
## Summary

Fixes #574 - cold scan regression from 42s (v0.1.14) to 3+ minutes (v2-rc).

- **Root cause**: The event bus migration moved LSP enrichment from a background task into the synchronous `emit_enrichment_pipeline` call inside `build_full_graph_inner`, blocking until rust-analyzer reaches quiescent
- **Fix**: `build_full_graph_inner(spawn_background=true)` now runs the enrichment pipeline with `skip_lsp=true`, returns tree-sitter + non-LSP pass results immediately, then spawns LSP enrichment in background via `spawn_background_lsp_enrichment()` -- restoring the v0.1.14 pattern
- **Pre-warm** now completes in seconds (tree-sitter only) instead of minutes, so tool calls see results immediately instead of getting "Index building..." for 2-3 minutes

## Key changes

- `BusOptions.skip_lsp`: when true, `LspConsumer` instances are not registered and `AllEnrichmentsGate` forces expected=0
- `spawn_background_lsp_enrichment()`: runs full pipeline with LSP in `tokio::spawn`, recomputes PageRank/subsystems, ArcSwaps enriched graph, re-persists to LanceDB
- CLI path (`spawn_background=false`) unchanged: LSP runs inline as before

## Test plan

- [x] `cargo check --lib` -- clean, no warnings
- [x] `cargo test` -- all 1722 tests pass
- [ ] Manual: verify cold scan returns in <10s with tree-sitter results, LSP enrichment completes in background
- [ ] Manual: verify `list-roots` shows LSP status transitioning from "running" to "complete"