### PR TITLE
refactor: consolidate oh_kind branching in embed.rs into unified helpers

### DIFF
--- a/src/embed.rs
+++ b/src/embed.rs
@@ -328,8 +328,9 @@ fn node_embedding_title(node: &crate::graph::Node) -> String {
 /// Scalar filter columns for a graph node.
 ///
 /// Returns `(file_path, language, subsystem, cyclomatic)`.
-/// Artifacts and other non-code nodes return `(None, None, None, None)`
-/// because they don't participate in subsystem/language/path filtering.
+/// Artifact nodes (those with `oh_kind` metadata) return `(None, None, None, None)`.
+/// Non-artifact nodes include `file_path` and `language`; `subsystem` and
+/// `cyclomatic` are populated when present in metadata.
 fn node_scalar_filters(node: &crate::graph::Node) -> (Option<String>, Option<String>, Option<String>, Option<i32>) {
     if node.metadata.contains_key("oh_kind") {
         (None, None, None, None)


### PR DESCRIPTION
## Summary

Closes #599.

- Extracts four unified helper functions (`node_embedding_text`, `node_embedding_kind`, `node_embedding_title`, `node_scalar_filters`) that consolidate the `oh_kind` branching previously scattered across `reindex_nodes()` and `index_all_inner()`
- Both indexing loops now call the helpers uniformly instead of testing `oh_kind` at 4 separate branch points each
- No behavior change: the underlying `build_artifact_embedding_text` and `build_code_embedding_text` functions are unchanged

## Test plan

- [x] All 70 existing embed tests pass
- [x] 10 new tests verify the unified helpers match the original per-type builders
- [x] `cargo check --lib --tests` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced code maintainability by centralizing embedding computation and filter logic into shared helper functions, eliminating duplicate branching logic across indexing operations.

* **Tests**
  * Expanded test coverage with new test cases for embedding selection behavior, scalar filter population, and text truncation handling across different content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->