### PR TITLE
test: add coverage for include_body, minify_body, verbose, rerank

### DIFF
--- a/scripts/test-suite.sh
+++ b/scripts/test-suite.sh
@@ -291,7 +291,7 @@ check "AllEnrichmentsGate struct defined (#528)" \
 check "AllEnrichmentsDone event defined (#528)" \
   "grep -c 'AllEnrichmentsDone' $RNA_REPO/src/extract/event_bus.rs 2>/dev/null" "[1-9]"
 check "EnrichmentFinalizer subscribes to AllEnrichmentsDone (#528/#523)" \
-  "grep -A15 'impl ExtractionConsumer for EnrichmentFinalizer' $RNA_REPO/src/extract/consumers.rs 2>/dev/null | grep -c 'AllEnrichmentsDone'" "[1-9]"
+  "awk '/impl ExtractionConsumer for EnrichmentFinalizer/,/^}/' $RNA_REPO/src/extract/consumers.rs 2>/dev/null | awk '/fn subscribes_to/,/fn on_event/' | grep -c 'AllEnrichmentsDone'" "[1-9]"
 
 # ── EMBEDDINGINDEXERCONSUMER + LANCEDBCONSUMER FROM STUBS (#530) ──────────
 echo "" && echo "--- EmbeddingIndexerConsumer + LanceDBConsumer from stubs (#530) ---"
@@ -353,7 +353,7 @@ check "ADR: api_link_pass indexed by RNA (function kind) (#543)" \
 # It must subscribe to FrameworkDetected, not AllEnrichmentsDone or unconditionally.
 # RNA verifies the consumer is indexed; grep verifies the subscription event kind.
 check "ADR: FastapiRouterPrefixConsumer subscribes to FrameworkDetected (#537/#523)" \
-  "grep -A15 'impl ExtractionConsumer for FastapiRouterPrefixConsumer' $RNA_REPO/src/extract/consumers.rs 2>/dev/null | grep -c 'FrameworkDetected'" "[1-9]"
+  "awk '/impl ExtractionConsumer for FastapiRouterPrefixConsumer/,/^}/' $RNA_REPO/src/extract/consumers.rs 2>/dev/null | awk '/fn subscribes_to/,/fn on_event/' | grep -c 'FrameworkDetected'" "[1-9]"
 check "ADR: FastapiRouterPrefixConsumer indexed as struct by RNA (#543)" \
   "repo-native-alignment search 'FastapiRouterPrefixConsumer' --repo $RNA_REPO --kind struct --limit 3 2>/dev/null" "FastapiRouterPrefixConsumer"
 


### PR DESCRIPTION
## Summary
- Fix 2 false-failure `grep -A5` patterns → `-A15` (consumer subscription checks grew past 5 lines)
- Add 11 new tests covering PR #604 features: `include_body`, `minify_body`, CLI validation, `verbose` flag, and cross-encoder reranking

## Test plan
- [ ] CI passes (lint, test, checklist)
- [ ] `scripts/test-suite.sh` runs clean with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for including and minifying response bodies in search, including error handling when node selection is missing
  * Added tests validating a verbose flag for CLI and server tool surfaces
  * Added help/runtime checks and structural tests for cross-encoder reranking
  * Improved structural checks for event-bus consumer subscription behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->