### PR TITLE
feat: remove deprecated EXTRACTION_VERSION constant

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -12,7 +12,7 @@ Authoritative sources: `src/graph/mod.rs`, `src/graph/store.rs`, `src/server/sto
 
 RNA persists data in LanceDB at `.oh/.cache/lance/` relative to the repository root. The current schema version is tracked in `.oh/.cache/lance/schema_version`. When this file does not match `SCHEMA_VERSION` (currently `18`), the graph tables (`symbols`, `edges`, `pr_merges`, `file_index`) are dropped and rebuilt from scratch. The `artifacts` embedding table is managed separately and is not covered by `SCHEMA_VERSION` — it has its own schema validation at startup (see `artifacts` table section below).
 
-A separate `.oh/.cache/lance/extraction_version` file tracks the global extraction logic version (`EXTRACTION_VERSION`, currently `14`). This integer is **deprecated** as of v0.1.15 (#526) — per-consumer content-addressed cache keys have replaced the single global sentinel (see [Section 6](#6-content-addressed-consumer-cache)). The file is still read for backward-compatible sentinel detection on cold start, but new consumer invalidation is driven by `ExtractionConsumer::version()` return values, not this file.
+The `extraction_version` file that used to live alongside `schema_version` has been removed as of v0.2.x (#620). Per-consumer content-addressed cache keys (see [Section 6](#6-content-addressed-consumer-cache)) replaced the single global sentinel in v0.1.15 (#526). Legacy `extraction_version` files on disk are no longer read or written and will be cleaned up by the next schema migration.
 
 ### `symbols` table
 
@@ -518,7 +518,7 @@ Override to `false` for consumers that:
 - Trigger external side-effects that must run every time (e.g., `LanceDBConsumer`, `EmbeddingIndexerConsumer`).
 - Read filesystem state beyond the event payload (e.g., `ManifestConsumer`, `TreeSitterConsumer`).
 
-**Migration from `EXTRACTION_VERSION`:** The global `EXTRACTION_VERSION` integer (`src/graph/store.rs`) is deprecated and kept only for backward-compatible sentinel reads on cold start. New invalidation is driven exclusively by `ConsumerCacheKey`.
+**Supersedes `EXTRACTION_VERSION`:** The global `EXTRACTION_VERSION` integer was removed in v0.2.x (#620). Invalidation is driven exclusively by `ConsumerCacheKey`.
 
 ---
 

--- a/scripts/test-suite.sh
+++ b/scripts/test-suite.sh
@@ -259,8 +259,6 @@ check "FastapiRouterPrefixPass struct defined (#519)" \
   "grep -r 'FastapiRouterPrefixPass\|fastapi_router_prefix' $RNA_REPO/src/ 2>/dev/null | grep -v test | wc -l" "[1-9]"
 check "FastapiRouterPrefixConsumer registered in build_builtin_bus (#519/#523)" \
   "grep -c 'FastapiRouterPrefixConsumer' $RNA_REPO/src/extract/consumers.rs 2>/dev/null" "[1-9]"
-check "EXTRACTION_VERSION >= 13 for router_var metadata (#519)" \
-  "grep 'EXTRACTION_VERSION' $RNA_REPO/src/graph/store.rs | grep -o '[0-9]*' | tail -1" "1[3-9]\|[2-9][0-9]"
 check "router_var metadata extracted in generic.rs (#519)" \
   "grep -c 'router_var' $RNA_REPO/src/extract/generic.rs 2>/dev/null" "[1-9]"
 
@@ -302,10 +300,8 @@ check "EmbeddingIndexerConsumer::stub defined (#530)" \
 check "All production lance_repo_root opts are None (#530)" \
   "grep -c 'BusOptions\|lance_repo_root.*None\|embed_idx.*None' $RNA_REPO/src/server/graph.rs 2>/dev/null" "[1-9]"
 
-# ── FASTAPI PREFIX IDEMPOTENCY + EXTRACTION_VERSION BUMP (#531) ───────────
-echo "" && echo "--- FastAPI prefix idempotency + EXTRACTION_VERSION bump (#531) ---"
-check "EXTRACTION_VERSION >= 14 for http_path_local field (#531)" \
-  "grep 'EXTRACTION_VERSION' $RNA_REPO/src/graph/store.rs | grep -o '[0-9]*' | tail -1" "1[4-9]\|[2-9][0-9]"
+# ── FASTAPI PREFIX IDEMPOTENCY (#531) ───────────────────────────────────────
+echo "" && echo "--- FastAPI prefix idempotency (#531) ---"
 check "http_path_local stored for idempotency (#531)" \
   "grep -c 'http_path_local' $RNA_REPO/src/extract/fastapi_router_prefix.rs 2>/dev/null" "[1-9]"
 check "FastapiRouterPrefixConsumer present in consumers.rs (#531/#523)" \

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -16,44 +16,6 @@ use arrow_schema::{DataType, Field, Schema};
 /// Also surfaced in the index freshness footer on `search`.
 pub const SCHEMA_VERSION: u32 = 18; // gRPC proto columns: parent_service, rpc_request_type, rpc_response_type
 
-/// Extraction version for source-level extraction logic.
-///
-/// **Deprecated** — replaced by content-addressed per-consumer cache keys (#526).
-///
-/// Each `ExtractionConsumer` now declares `fn version() -> u64`. The cache key for
-/// a consumer+event pair is `(blake3(event.canonical_bytes()), consumer.version())`.
-/// Changing one consumer's `version()` only invalidates that consumer's cache, not all
-/// consumers.
-///
-/// This constant is retained for backward compatibility with the sentinel system
-/// (`SentinelData::extraction_version`) and the `check_and_migrate_extraction_version`
-/// call site in the server pipeline. Both will be removed in a follow-up cleanup.
-///
-/// **Do not bump this constant.** Instead, bump the `version()` of the specific consumer
-/// whose extraction logic changed. Config-driven consumers (`CustomExtractorConsumer`)
-/// derive their version from `blake3(toml_file_contents)` automatically.
-///
-/// Historical bump log (kept for reference, not for future use):
-/// - Bumped to 1 for doc_comment metadata extraction (#401).
-/// - Bumped to 3 for new C, PHP, HTML, Scala, Dart, Elixir extractors (#435).
-/// - Bumped to 4 for Next.js routing pass (#440) and monorepo subdirectory roots (#442).
-/// - Bumped to 5 for subsystem first-class nodes (#470).
-/// - Bumped to 6 for framework detection pass (#469).
-/// - Bumped to 7 for pub/sub + websocket extractors (#464/#467).
-/// - Bumped to 8 for cross-file import-calls pass (#462).
-/// - Bumped to 9 for background scanner post-extraction passes (#471).
-/// - Bumped to 10 for generic extractor-config pass (#467).
-/// - Bumped to 11 for openapi_sdk_link_pass (#465).
-/// - Bumped to 12 for gRPC client calls pass (#466).
-/// - Bumped to 13 for FastAPI router prefix pass (#517).
-/// - Bumped to 14 for idempotent FastAPI prefix rewrite (#528 followup).
-#[deprecated(
-    since = "0.1.8",
-    note = "Use ExtractionConsumer::version() + content-addressed cache keys instead (#526). \
-            Do not bump this constant — bump the specific consumer's version() instead."
-)]
-pub const EXTRACTION_VERSION: u32 = 14;
-
 /// Arrow schema for the `symbols` table.
 ///
 /// Stores code symbols (functions, structs, traits, etc.) with embeddings
@@ -261,21 +223,6 @@ mod tests {
     fn test_schema_version_constant() {
         // SCHEMA_VERSION must be at least 17 (bumped for scan_version column #477)
         assert!(SCHEMA_VERSION >= 17, "SCHEMA_VERSION should be >= 17");
-    }
-
-    /// `EXTRACTION_VERSION` is now deprecated (#526). The global integer is replaced by
-    /// per-consumer content-addressed cache keys: `(blake3(event_payload), consumer.version())`.
-    /// This test verifies the constant still holds its historical value (14) so that the
-    /// sentinel backward-compat path continues to read old sentinel files correctly.
-    /// Do not bump this value — bump the specific consumer's `version()` instead.
-    #[test]
-    #[allow(deprecated)]
-    fn test_extraction_version_is_frozen_at_14() {
-        assert_eq!(
-            EXTRACTION_VERSION, 14,
-            "EXTRACTION_VERSION is frozen at 14 (#526). \
-             Do not bump — use ExtractionConsumer::version() instead."
-        );
     }
 
     #[test]

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -6,9 +6,6 @@
 //! - `scan_roots()` -- resolve workspace roots, detect file changes
 //! - `update_graph()` -- apply changes, run enrichment pipeline
 //! - `persist_deltas()` -- write to LanceDB, commit scanner state
-// EXTRACTION_VERSION is deprecated (#526) but still used for backward-compat migration.
-#![allow(deprecated)]
-
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -18,7 +15,7 @@ use crate::roots::{RootConfig, WorkspaceConfig};
 use crate::scanner::Scanner;
 
 use super::state::GraphState;
-use super::store::{check_and_migrate_extraction_version, persist_graph_to_lance};
+use super::store::persist_graph_to_lance;
 use super::{PipelineResult, RnaHandler};
 
 /// Check if a cached graph is missing enrichment passes output that should exist.
@@ -780,37 +777,6 @@ impl RnaHandler {
             return self
                 .run_pipeline_foreground_full(on_progress, pipeline_start)
                 .await;
-        }
-
-        // Pre-flight: check extraction version. If it changed (e.g., EXTRACTION_VERSION
-        // bumped in a new binary), clear scan-state files and fall back to full rebuild so
-        // all files are re-extracted with the updated extraction logic.
-        // Without this check the incremental path skips build_full_graph_inner (which
-        // contains the extraction-version guard) and reports "incremental, no changes".
-        {
-            let workspace = WorkspaceConfig::load()
-                .with_primary_root(self.repo_root.clone())
-                .with_worktrees(&self.repo_root)
-                .with_claude_memory(&self.repo_root)
-                .with_agent_memories(&self.repo_root)
-                .with_declared_roots(&self.repo_root);
-            let secondary_slugs: Vec<String> = workspace
-                .resolved_roots()
-                .iter()
-                .filter(|r| r.path != self.repo_root)
-                .map(|r| r.slug.clone())
-                .collect();
-            if check_and_migrate_extraction_version(&db_path, &self.repo_root, &secondary_slugs)? {
-                tracing::info!(
-                    "Extraction version migrated during incremental pre-flight -- falling back to full rebuild"
-                );
-                on_progress("Extraction version upgrade detected -- rebuilding from scratch.");
-                // Clear sentinels -- they reference the old extraction version and are now stale.
-                super::sentinel::clear_sentinels(&self.repo_root);
-                return self
-                    .run_pipeline_foreground_full(on_progress, pipeline_start)
-                    .await;
-            }
         }
 
         // Phase 1: Scan to detect changes.

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -1,6 +1,4 @@
 //! Graph lifecycle: building, incremental updates, and state management.
-// EXTRACTION_VERSION is deprecated (#526) but still used for backward-compat migration.
-#![allow(deprecated)]
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -21,9 +19,8 @@ use super::RnaHandler;
 use super::helpers;
 use super::state::GraphState;
 use super::store::{
-    check_and_migrate_extraction_version, check_and_migrate_schema, delete_nodes_for_roots,
-    get_stored_root_ids, graph_lance_path, load_graph_from_lance, persist_graph_incremental,
-    persist_graph_to_lance,
+    check_and_migrate_schema, delete_nodes_for_roots, get_stored_root_ids, graph_lance_path,
+    load_graph_from_lance, persist_graph_incremental, persist_graph_to_lance,
 };
 
 impl RnaHandler {
@@ -714,27 +711,6 @@ impl RnaHandler {
             .with_agent_memories(&self.repo_root)
             .with_declared_roots(&self.repo_root);
         let resolved_roots = workspace.resolved_roots();
-
-        // Check extraction version: if it changed, clear scan-state files for all roots
-        // to force full re-extraction with updated extraction logic (e.g., doc_comment #401).
-        let secondary_slugs: Vec<String> = resolved_roots
-            .iter()
-            .filter(|r| r.path != self.repo_root)
-            .map(|r| r.slug.clone())
-            .collect();
-        match check_and_migrate_extraction_version(&db_path, &self.repo_root, &secondary_slugs) {
-            Ok(true) => {
-                tracing::info!(
-                    "Extraction version migrated to v{} — scan-state cleared, full re-extraction required",
-                    crate::graph::store::EXTRACTION_VERSION
-                );
-                // Scan-state files are cleared; the scanner below will see all files as new.
-            }
-            Ok(false) => {}
-            Err(e) => {
-                tracing::warn!("Extraction version check failed (proceeding): {}", e);
-            }
-        }
 
         // Prune stale roots: compare discovered roots against what LanceDB has stored.
         // Worktrees removed while the server was offline leave orphaned rows that cause

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -1,6 +1,4 @@
 //! Formatting utilities, argument parsing, and display helpers.
-// EXTRACTION_VERSION is deprecated (#526) but still used in the freshness footer.
-#![allow(deprecated)]
 
 use super::state::{EmbeddingStatus, LspEnrichmentStatus};
 use crate::graph;
@@ -73,11 +71,10 @@ pub fn format_freshness_full(
         .unwrap_or_default();
 
     format!(
-        "\n\n*Index: {} symbols · last scan {} · schema v{} · extract v{}{}{}*",
+        "\n\n*Index: {} symbols · last scan {} · schema v{}{}{}*",
         node_count,
         age,
         crate::graph::store::SCHEMA_VERSION,
-        crate::graph::store::EXTRACTION_VERSION,
         embed_part,
         lsp_part,
     )

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,4 @@
 //! MCP server: RnaHandler, graph building, background scanner, and MCP dispatch.
-// EXTRACTION_VERSION is deprecated (#526) but still used in tests and log messages.
-#![allow(deprecated)]
 
 mod bg_scanner;
 mod enrichment;
@@ -769,112 +767,6 @@ mod tests {
         }
     }
 
-    /// Regression test: bumping EXTRACTION_VERSION must force full re-extraction even on
-    /// the foreground incremental path (run_pipeline_foreground with a cached LanceDB graph).
-    ///
-    /// The bug was that run_pipeline_foreground_incremental called check_and_migrate_schema
-    /// but NOT check_and_migrate_extraction_version, so a version bump went undetected and
-    /// the scan reported "incremental, no changes".
-    #[tokio::test]
-    async fn test_extraction_version_bump_forces_full_rebuild_on_incremental_path() {
-        use std::sync::Mutex;
-        use tempfile::TempDir;
-
-        let tmp = TempDir::new().unwrap();
-        let root = tmp.path();
-
-        std::fs::create_dir_all(root.join("src")).unwrap();
-        std::fs::create_dir_all(root.join(".oh/.cache")).unwrap();
-        std::fs::write(root.join("src/lib.rs"), "pub fn stable_function() {}\n").unwrap();
-
-        let handler = RnaHandler {
-            repo_root: root.to_path_buf(),
-            ..Default::default()
-        };
-
-        // First run: full rebuild, writes EXTRACTION_VERSION to the version file.
-        let result1 = handler
-            .run_pipeline_foreground(|_| {})
-            .await
-            .expect("first run should succeed");
-        assert!(
-            result1.node_count > 0,
-            "should have extracted nodes on first run"
-        );
-
-        // Verify the extraction_version file was written.
-        let version_file = root
-            .join(".oh")
-            .join(".cache")
-            .join("lance")
-            .join("extraction_version");
-        assert!(
-            version_file.exists(),
-            "extraction_version file should exist after first run"
-        );
-
-        // Simulate a version bump: overwrite the stored version with a stale value.
-        // This mimics what happens when a new binary with a higher EXTRACTION_VERSION
-        // is run against a repo whose cache was built with an older version.
-        std::fs::write(&version_file, "0").unwrap();
-
-        // Second run: should detect the version mismatch and take the full rebuild path.
-        let handler2 = RnaHandler {
-            repo_root: root.to_path_buf(),
-            ..Default::default()
-        };
-
-        let progress2: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-        let p2 = progress2.clone();
-        let result2 = handler2
-            .run_pipeline_foreground(move |msg| {
-                p2.lock().unwrap().push(msg.to_string());
-            })
-            .await
-            .expect("second run should succeed after extraction version migration");
-
-        assert!(
-            result2.node_count > 0,
-            "should have nodes after version bump rebuild"
-        );
-
-        let msgs = progress2.lock().unwrap();
-
-        // The second run must enter the incremental path (LanceDB cache was written by first run).
-        assert!(
-            msgs.iter().any(|m| m.contains("Loaded cached graph")),
-            "second run should start from cached graph (incremental entry). Messages: {:?}",
-            *msgs
-        );
-
-        // Must NOT report "no changes" -- that was the bug.
-        assert!(
-            !msgs.iter().any(|m| m.contains("incremental, no changes")),
-            "should NOT report 'incremental, no changes' after extraction version bump. Messages: {:?}",
-            *msgs
-        );
-
-        // Must report the extraction version upgrade message.
-        assert!(
-            msgs.iter()
-                .any(|m| m.contains("Extraction version upgrade detected")),
-            "should report extraction version upgrade. Messages: {:?}",
-            *msgs
-        );
-
-        // Verify the version file now holds the current EXTRACTION_VERSION.
-        let stored: u32 = std::fs::read_to_string(&version_file)
-            .unwrap()
-            .trim()
-            .parse()
-            .unwrap();
-        assert_eq!(
-            stored,
-            crate::graph::store::EXTRACTION_VERSION,
-            "extraction_version file should be updated to current EXTRACTION_VERSION"
-        );
-    }
-
     /// Regression test: bumping SCHEMA_VERSION must force a full rebuild even on the
     /// foreground incremental path (run_pipeline_foreground with a cached LanceDB graph).
     ///
@@ -883,8 +775,6 @@ mod tests {
     /// LanceDB tables, and fall back to `run_pipeline_foreground_full`.  Without this,
     /// the incremental path loads the now-empty tables and returns a partial graph.
     ///
-    /// Mirrors `test_extraction_version_bump_forces_full_rebuild_on_incremental_path`
-    /// which covers the EXTRACTION_VERSION case (#452).
     #[tokio::test]
     async fn test_schema_version_bump_forces_full_rebuild_on_incremental_path() {
         use std::sync::Mutex;

--- a/src/server/sentinel.rs
+++ b/src/server/sentinel.rs
@@ -1,6 +1,4 @@
 //! Write-ahead log sentinels for scan pipeline phases.
-// EXTRACTION_VERSION is deprecated (#526) but still used for backward-compat sentinel reads.
-#![allow(deprecated)]
 //!
 //! After each major pipeline phase completes and its data is durably persisted,
 //! a sentinel file is written to `.oh/.cache/`. On startup, the server checks
@@ -15,15 +13,15 @@
 //! - `.oh/.cache/lsp_completed.json`     — LSP enrichment + persist done
 //!
 //! ## Schema invalidation
-//! Sentinels embed `schema_version` and `extraction_version`. If either changes
-//! (new binary deployed), the sentinel is treated as absent and the phase re-runs.
+//! Sentinels embed `schema_version`. If it changes (new binary deployed),
+//! the sentinel is treated as absent and the phase re-runs.
 
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-use crate::graph::store::{EXTRACTION_VERSION, SCHEMA_VERSION};
+use crate::graph::store::SCHEMA_VERSION;
 
 /// Data stored in each sentinel file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -32,8 +30,6 @@ pub struct SentinelData {
     pub timestamp: u64,
     /// LanceDB schema version at time of write.
     pub schema_version: u32,
-    /// Extraction logic version at time of write.
-    pub extraction_version: u32,
     /// Node count after the phase completed.
     pub node_count: usize,
     /// Edge count after the phase completed.
@@ -49,15 +45,14 @@ impl SentinelData {
         Self {
             timestamp,
             schema_version: SCHEMA_VERSION,
-            extraction_version: EXTRACTION_VERSION,
             node_count,
             edge_count,
         }
     }
 
-    /// Returns true if this sentinel is valid for the current binary versions.
+    /// Returns true if this sentinel is valid for the current binary version.
     pub fn is_current(&self) -> bool {
-        self.schema_version == SCHEMA_VERSION && self.extraction_version == EXTRACTION_VERSION
+        self.schema_version == SCHEMA_VERSION
     }
 }
 
@@ -185,12 +180,10 @@ fn read_sentinel(path: &Path, name: &str) -> Option<SentinelData> {
                 Some(data)
             } else {
                 tracing::debug!(
-                    "{} sentinel is stale (schema {}/{} vs current {}/{})",
+                    "{} sentinel is stale (schema {} vs current {})",
                     name,
                     data.schema_version,
-                    data.extraction_version,
                     SCHEMA_VERSION,
-                    EXTRACTION_VERSION,
                 );
                 None
             }
@@ -228,7 +221,6 @@ mod tests {
         assert_eq!(sentinel.node_count, 100);
         assert_eq!(sentinel.edge_count, 200);
         assert_eq!(sentinel.schema_version, SCHEMA_VERSION);
-        assert_eq!(sentinel.extraction_version, EXTRACTION_VERSION);
         assert!(sentinel.is_current());
     }
 
@@ -256,7 +248,6 @@ mod tests {
         let stale = SentinelData {
             timestamp: 0,
             schema_version: SCHEMA_VERSION.wrapping_sub(1),
-            extraction_version: EXTRACTION_VERSION,
             node_count: 50,
             edge_count: 80,
         };

--- a/src/server/store/migrate.rs
+++ b/src/server/store/migrate.rs
@@ -1,10 +1,10 @@
-//! Schema and extraction version migration for LanceDB.
+//! Schema migration and version management for LanceDB.
 
 use std::path::Path;
 
 use anyhow::Context;
 
-use crate::graph::store::{EXTRACTION_VERSION, SCHEMA_VERSION};
+use crate::graph::store::SCHEMA_VERSION;
 
 /// Path to the committed scan_version pointer file.
 ///
@@ -91,15 +91,13 @@ pub(crate) async fn check_and_migrate_schema(db_path: &Path) -> anyhow::Result<b
         for entry in entries {
             let entry = entry.context("check_and_migrate_schema: failed to read db_path entry")?;
             let path = entry.path();
-            // Preserve version-tracking files: schema_version is rewritten below;
-            // extraction_version must survive so the next extraction-version bump
-            // still triggers its scan-state reset correctly.
+            // Preserve version-tracking files: schema_version is rewritten below.
             // scan_version is deleted (reset to 0 on next read) since all rows are gone.
             let name = path
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned())
                 .unwrap_or_default();
-            if name == "schema_version" || name == "extraction_version" {
+            if name == "schema_version" {
                 continue;
             }
             if path.is_dir() {
@@ -163,86 +161,6 @@ fn has_lance_data(db_path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// Check the stored extraction version and clear scan-state files if it mismatches.
-///
-/// Returns `true` if scan-state was cleared (re-extraction needed),
-/// `false` if the stored version already matches `EXTRACTION_VERSION` (no-op).
-///
-/// Unlike `check_and_migrate_schema` (which drops LanceDB tables), this only
-/// deletes scanner state files -- forcing the scanner to treat all files as new
-/// on the next build without discarding the LanceDB graph/embedding data.
-///
-/// The version file lives alongside `schema_version` in `db_path`.
-/// Scan-state files are cleared for:
-/// - The primary root: `{repo_root}/.oh/.cache/scan-state.json`
-/// - Secondary roots: `~/.local/share/rna/cache/{slug}/scan-state.json`
-pub(crate) fn check_and_migrate_extraction_version(
-    db_path: &Path,
-    repo_root: &Path,
-    slugs: &[String],
-) -> anyhow::Result<bool> {
-    std::fs::create_dir_all(db_path)?;
-
-    let version_file = db_path.join("extraction_version");
-
-    let stored_version: Option<u32> = std::fs::read_to_string(&version_file)
-        .ok()
-        .and_then(|s| s.trim().parse::<u32>().ok());
-
-    // If version matches, nothing to do.
-    if stored_version == Some(EXTRACTION_VERSION) {
-        return Ok(false);
-    }
-
-    if stored_version.is_some() {
-        tracing::info!(
-            "Extraction version mismatch (stored={:?}, current={}) -- clearing scan-state to force full re-extraction",
-            stored_version,
-            EXTRACTION_VERSION
-        );
-    } else {
-        tracing::debug!(
-            "No stored extraction version; initializing extraction_version to {}",
-            EXTRACTION_VERSION
-        );
-    }
-
-    // Delete scan-state files for all known roots so the scanner treats all
-    // files as new and re-extracts them with the updated extraction logic.
-    if stored_version.is_some() {
-        // Primary root scan-state: {repo_root}/.oh/.cache/scan-state.json
-        let primary_state = repo_root.join(".oh").join(".cache").join("scan-state.json");
-        if primary_state.exists() {
-            match std::fs::remove_file(&primary_state) {
-                Ok(()) => tracing::info!("Cleared primary scan-state (extraction version upgrade)"),
-                Err(e) => tracing::warn!("Failed to clear primary scan-state: {}", e),
-            }
-        }
-
-        // Secondary roots: ~/.local/share/rna/cache/{slug}/scan-state.json
-        for slug in slugs {
-            let state_path = crate::roots::cache_state_path(slug);
-            if state_path.exists() {
-                match std::fs::remove_file(&state_path) {
-                    Ok(()) => tracing::info!(
-                        "Cleared scan-state for root '{}' (extraction version upgrade)",
-                        slug
-                    ),
-                    Err(e) => {
-                        tracing::warn!("Failed to clear scan-state for root '{}': {}", slug, e)
-                    }
-                }
-            }
-        }
-    }
-
-    // Write the current extraction version.
-    std::fs::write(&version_file, EXTRACTION_VERSION.to_string())
-        .context("check_and_migrate_extraction_version: failed to write extraction_version file")?;
-
-    Ok(stored_version.is_some())
-}
-
 /// Drop all LanceDB table directories inside `db_path` and reset the schema_version file.
 ///
 /// Called when a schema mismatch is detected at runtime (Arrow rejection during merge_insert).
@@ -253,12 +171,10 @@ pub(super) fn drop_all_lance_tables(db_path: &Path) {
     if let Ok(entries) = std::fs::read_dir(db_path) {
         for entry in entries.flatten() {
             let path = entry.path();
-            // Preserve both version files: schema_version is rewritten below;
-            // extraction_version must survive so the next extraction-version bump
-            // still triggers its scan-state reset correctly.
+            // Preserve schema_version — it is rewritten below.
             if path
                 .file_name()
-                .map(|n| n == "schema_version" || n == "extraction_version")
+                .map(|n| n == "schema_version")
                 .unwrap_or(false)
             {
                 continue;
@@ -329,108 +245,6 @@ pub(super) fn is_schema_mismatch_error(e: &anyhow::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::graph::store::EXTRACTION_VERSION;
-
-    #[test]
-    fn test_extraction_version_migration_clears_state() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let db_path = dir.path().join("lance");
-        let repo_root = dir.path();
-        std::fs::create_dir_all(&db_path).unwrap();
-
-        // Seed a stale version (0) and create a fake primary scan-state file.
-        std::fs::write(db_path.join("extraction_version"), "0").unwrap();
-        let primary_state = repo_root.join(".oh").join(".cache").join("scan-state.json");
-        std::fs::create_dir_all(primary_state.parent().unwrap()).unwrap();
-        std::fs::write(
-            &primary_state,
-            r#"{"dir_mtimes":{},"file_mtimes":{},"file_content_hashes":{}}"#,
-        )
-        .unwrap();
-
-        // Migration should return true and clear the state file.
-        let migrated = check_and_migrate_extraction_version(&db_path, repo_root, &[])
-            .expect("migration failed");
-        assert!(migrated, "expected migration=true for stale version");
-        assert!(
-            !primary_state.exists(),
-            "scan-state should be cleared after migration"
-        );
-
-        // The version file should now contain EXTRACTION_VERSION.
-        let stored: u32 = std::fs::read_to_string(db_path.join("extraction_version"))
-            .unwrap()
-            .trim()
-            .parse()
-            .unwrap();
-        assert_eq!(stored, EXTRACTION_VERSION);
-
-        // Second call should be a no-op.
-        let migrated2 = check_and_migrate_extraction_version(&db_path, repo_root, &[])
-            .expect("second migration failed");
-        assert!(!migrated2, "expected migration=false when already current");
-    }
-
-    #[test]
-    fn test_extraction_version_fresh_directory_no_clear() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let db_path = dir.path().join("lance");
-        let repo_root = dir.path();
-        std::fs::create_dir_all(&db_path).unwrap();
-
-        let migrated = check_and_migrate_extraction_version(&db_path, repo_root, &[])
-            .expect("migration failed on fresh dir");
-        assert!(!migrated, "expected migration=false for fresh directory");
-
-        let version_file = db_path.join("extraction_version");
-        assert!(
-            version_file.exists(),
-            "extraction_version must be written to lance/ subdir on first run, not found at {}",
-            version_file.display()
-        );
-        let stored: u32 = std::fs::read_to_string(&version_file)
-            .unwrap()
-            .trim()
-            .parse()
-            .unwrap();
-        assert_eq!(
-            stored, EXTRACTION_VERSION,
-            "extraction_version file should contain current EXTRACTION_VERSION"
-        );
-
-        let parent_version_file = dir.path().join("extraction_version");
-        assert!(
-            !parent_version_file.exists(),
-            "extraction_version must NOT be written to the parent .cache/ dir (found at {})",
-            parent_version_file.display()
-        );
-    }
-
-    #[test]
-    fn test_extraction_version_file_path_is_inside_lance_dir() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let db_path = dir.path().join("lance");
-        let repo_root = dir.path();
-        std::fs::create_dir_all(&db_path).unwrap();
-
-        check_and_migrate_extraction_version(&db_path, repo_root, &[])
-            .expect("initial write failed");
-
-        let correct_path = db_path.join("extraction_version");
-        assert!(
-            correct_path.exists(),
-            "extraction_version must be at lance/extraction_version, not found at {}",
-            correct_path.display()
-        );
-
-        let wrong_path = dir.path().join("extraction_version");
-        assert!(
-            !wrong_path.exists(),
-            "extraction_version must NOT be at .cache/extraction_version (found at {}); \
-             write path must match read path in check_and_migrate_extraction_version",
-            wrong_path.display()
-        );
-    }
 
     #[test]
     fn test_is_conflict_error_detection() {
@@ -490,7 +304,6 @@ mod tests {
         std::fs::create_dir_all(db_path.join("symbols.lance")).unwrap();
         std::fs::create_dir_all(db_path.join("edges.lance")).unwrap();
         std::fs::write(db_path.join("schema_version"), "9").unwrap();
-        std::fs::write(db_path.join("extraction_version"), "42").unwrap();
 
         drop_all_lance_tables(&db_path);
 
@@ -505,12 +318,6 @@ mod tests {
 
         let written = std::fs::read_to_string(db_path.join("schema_version")).unwrap();
         assert_eq!(written, SCHEMA_VERSION.to_string());
-
-        let ev = std::fs::read_to_string(db_path.join("extraction_version")).unwrap();
-        assert_eq!(
-            ev, "42",
-            "extraction_version must survive drop_all_lance_tables"
-        );
     }
 
     #[test]
@@ -541,6 +348,8 @@ mod tests {
         std::fs::create_dir_all(&db_path).unwrap();
 
         std::fs::write(db_path.join("schema_version"), "16").unwrap();
+        // extraction_version is a legacy file — no longer written or preserved (#620).
+        // Seed one to verify drop_all_lance_tables cleans it up.
         std::fs::write(db_path.join("extraction_version"), "5").unwrap();
         std::fs::write(db_path.join("scan_version"), "7").unwrap();
         std::fs::create_dir_all(db_path.join("symbols.lance")).unwrap();
@@ -551,9 +360,9 @@ mod tests {
             !db_path.join("scan_version").exists(),
             "scan_version should be removed by drop_all_lance_tables"
         );
-        assert_eq!(
-            std::fs::read_to_string(db_path.join("extraction_version")).unwrap(),
-            "5"
+        assert!(
+            !db_path.join("extraction_version").exists(),
+            "extraction_version is a legacy file and should be removed by drop_all_lance_tables"
         );
     }
 }

--- a/src/server/store/mod.rs
+++ b/src/server/store/mod.rs
@@ -2,12 +2,10 @@
 //!
 //! ## Module structure
 //!
-//! - `migrate` -- schema and extraction version migration, error classification
+//! - `migrate` -- schema migration and error classification
 //! - `batch` -- Arrow RecordBatch builders for symbols and edges tables
 //! - `persist` -- full persist, incremental upsert, compaction, root pruning
 //! - `load` -- graph loading from LanceDB tables
-// EXTRACTION_VERSION is deprecated (#526) but still used for backward-compat sentinel reads.
-#![allow(deprecated)]
 
 mod batch;
 pub(crate) mod load;
@@ -18,10 +16,10 @@ use std::path::{Path, PathBuf};
 
 use crate::graph::{Confidence, EdgeKind, ExtractionSource, NodeId, NodeKind};
 
-// ── Re-exports for backward compatibility ────────────────────────────
+// ── Re-exports ────────────────────────────────────────────────────────
 
 // From migrate
-pub(crate) use migrate::{check_and_migrate_extraction_version, check_and_migrate_schema};
+pub(crate) use migrate::check_and_migrate_schema;
 
 // From persist
 pub(crate) use persist::{


### PR DESCRIPTION
Closes #620

## Problem

`EXTRACTION_VERSION` was frozen at 14 in #526 when per-consumer content-addressed cache keys replaced it. The constant and its associated file (`lance/extraction_version`) are still referenced in ~30 locations across sentinel reads, migration, version file checks, tests, and log messages.

## Solution

Clean removal of `EXTRACTION_VERSION` and all its call sites. Net: -430 lines.

- **`src/graph/store.rs`** — remove const and frozen-at-14 test
- **`src/server/sentinel.rs`** — remove `extraction_version` field from `SentinelData`; `is_current()` now only checks `schema_version` (old sentinels with the field still deserialize via serde ignore-unknown)
- **`src/server/store/migrate.rs`** — remove `check_and_migrate_extraction_version` function and its tests; stop preserving the `extraction_version` file in schema cleanup
- **`src/server/enrichment.rs`** — remove call to `check_and_migrate_extraction_version`
- **`src/server/graph.rs`** — remove call to `check_and_migrate_extraction_version`
- **`src/server/helpers.rs`** — remove `· extract v{}` from freshness footer
- **`src/server/mod.rs`** — remove extraction version regression test
- **`scripts/test-suite.sh`** — remove EXTRACTION_VERSION >= 13/14 checks
- **`docs/data-model.md`** — update to reflect removal

## Backward Compatibility

- Old `lance/extraction_version` files on disk are no longer read or written. They will be cleaned up by the next schema migration (which deletes all non-`schema_version` files in the lance dir). Until then, they sit harmlessly.
- Old sentinel JSON files with an `extraction_version` field still deserialize correctly — serde ignores unknown fields by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect removal of legacy extraction version sentinel tracking from cache management.

* **Refactor**
  * Removed deprecated extraction version invalidation system. Cache validation now exclusively driven by schema version.
  * Legacy extraction version sentinel files are automatically cleaned up during the next schema migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->