### PR TITLE
fix: address review findings from #621

### DIFF
--- a/src/server/sentinel.rs
+++ b/src/server/sentinel.rs
@@ -101,8 +101,9 @@ pub fn read_lsp_sentinel(repo_root: &Path) -> Option<SentinelData> {
     read_sentinel(&lsp_sentinel_path(repo_root), "lsp")
 }
 
-/// Delete both sentinels. Called when a full rebuild is triggered (schema migration
-/// or explicit `--full` with cache invalidation).
+/// Delete both sentinels. Called when a full rebuild is triggered: schema migration,
+/// explicit `--full` with cache invalidation, or when cached graph enrichment output
+/// is stale/missing (via `cache_needs_enrichment` paths in `enrichment.rs` and `graph.rs`).
 pub fn clear_sentinels(repo_root: &Path) {
     clear_sentinel(&extract_sentinel_path(repo_root), "extract");
     clear_sentinel(&lsp_sentinel_path(repo_root), "lsp");


### PR DESCRIPTION
## Summary

- Fixes stale doc-comments in `src/server/sentinel.rs` that still referenced `extraction_version` semantics after the deprecation removal in #621

## CodeRabbit finding addressed

From PR #621 review (outside-diff comment, Minor severity):

> `read_lsp_sentinel` and `clear_sentinels` docs still mention extraction version, which is no longer part of sentinel validity/migration behavior.

Updated:
- `read_lsp_sentinel`: "schema/extraction version" → "schema version"
- `clear_sentinels`: removed "extraction version bump" from the trigger list; expanded to list all actual trigger cases (schema migration, `--full` cache invalidation, stale/missing enrichment)

## Test plan
- [x] `cargo check --lib` passes (doc-only change)
- [x] No functional behavior change — comments only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified docs: a missing/stale marker means LSP enrichment hasn't completed for the current schema version.
  * Expanded docs on when sentinel markers are cleared to include schema migrations, full cache invalidation, and cases where cached enrichment output is stale or missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->