### PR TITLE
Implement ADR validation primitive for RNA and downstream repos

### DIFF
--- a/.oh/adr-validation/001-event-bus-extraction-pipeline.json
+++ b/.oh/adr-validation/001-event-bus-extraction-pipeline.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "001-event-bus-extraction-pipeline",
+  "title": "RNA Event Bus Architecture",
+  "status": "implemented",
+  "source": "docs/ADRs/001-event-bus-extraction-pipeline.md",
+  "validate": {
+    "cargo_tests": [
+      "extract::event_bus::tests::test_follow_on_events_are_routed",
+      "extract::event_bus::tests::test_depth_first_ordering",
+      "extract::event_bus::tests::test_consumer_receives_follow_on_regardless_of_registration_order"
+    ],
+    "audits": [
+      "no_consumer_knows_other_consumers",
+      "static_registration_only",
+      "no_broker_logic_in_core"
+    ],
+    "scripts": [],
+    "smoke": []
+  }
+}

--- a/.oh/adr-validation/002-arcswap-graph-concurrency.json
+++ b/.oh/adr-validation/002-arcswap-graph-concurrency.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "002-arcswap-graph-concurrency",
+  "title": "ArcSwap for Graph Concurrency",
+  "status": "implementing",
+  "source": "docs/ADRs/002-arcswap-graph-concurrency.md",
+  "validate": {
+    "cargo_tests": [
+      "server::tests::test_arcswap_readers_see_consistent_snapshots",
+      "server::tests::test_get_graph_result_outlives_subsequent_mutations"
+    ],
+    "audits": [
+      "graph_state_uses_arcswap"
+    ],
+    "scripts": [],
+    "smoke": []
+  }
+}

--- a/README.md
+++ b/README.md
@@ -190,9 +190,27 @@ CLI and MCP share the same index. Run `scan --full` from the CLI to build the co
 | `scan --repo <dir> --full` | Full pipeline including LSP enrichment. Incremental on repeat runs. |
 | `stats --repo <dir>` | Show repo stats from persisted index (no re-scan) |
 | `test --repo <dir>` | Run 29 pipeline checks end-to-end |
+| `adr compile --repo <dir>` | Compile ADR frontmatter into `.oh/adr-validation/*.json` and refresh `docs/ADRs/README.md` when present |
+| `adr validate --repo <dir>` | Execute compiled ADR validations (cargo tests, audits, smoke, scripts) and fail if an implemented ADR is not honestly backed by passing checks |
+| `adr audit <name> --repo <dir>` | Run one built-in ADR code-shape audit directly |
 | `open --repo <dir>` | Launch an interactive graph visualizer in the browser |
 | `setup --project <dir>` | Bootstrap RNA + OH MCP + skills for a project |
 
+
+### ADR validation primitive
+
+ADRs can declare direct executable references in YAML frontmatter:
+- `validate.cargo_tests` — exact names from `cargo test -- --list`
+- `validate.audits` — built-in code-shape audits run with `adr audit <name>`
+- `validate.smoke` — fixture paths for repo-native delivery checks
+- `validate.scripts` — exact repo-relative script paths as a last resort
+
+Compile declarations into derived manifests and validate them with the real executable surface:
+
+```bash
+repo-native-alignment adr compile --repo .
+repo-native-alignment adr validate --repo . --cargo-arg --no-default-features
+```
 ### Plugin Skills
 
 | Skill | What it does |

--- a/docs/ADRs/001-event-bus-extraction-pipeline.md
+++ b/docs/ADRs/001-event-bus-extraction-pipeline.md
@@ -1,10 +1,21 @@
+---
+id: 001-event-bus-extraction-pipeline
+status: implemented
+validate:
+  cargo_tests:
+    - extract::event_bus::tests::test_follow_on_events_are_routed
+    - extract::event_bus::tests::test_depth_first_ordering
+    - extract::event_bus::tests::test_consumer_receives_follow_on_regardless_of_registration_order
+  audits:
+    - no_consumer_knows_other_consumers
+    - static_registration_only
+    - no_broker_logic_in_core
+---
+
 # RNA Event Bus Architecture
-**Status:** Implemented — Phase 2b complete (v0.1.15)
 **Issues:** #478 (plugin arch — merged), #479 (event bus — merged), #454 (multi-tenant store — deferred to future release)
 **Date:** 2026-03-22
 **Implementation PRs:** #493 (PostExtractionRegistry), #500 (EventBus + ExtractionConsumer trait), #515 (wire build_full_graph_inner to EventBus), #519 (FastAPI router prefix), #526/#533 (content-addressed cache keys), #527 (ScanStatsConsumer), #528 (AllEnrichmentsGate / parallel LSP), #530 (EmbeddingIndexerConsumer + LanceDBConsumer promotion)
-
----
 
 ## Core Principle
 
@@ -192,6 +203,11 @@ After each implementation phase, an audit agent must verify the architectural co
 
 ### Constraint 5: Performance gate
 **Audit:** `time repo-native-alignment scan --repo . --full` must complete in < 120s on the main RNA repo with no active agent worktrees.
+
+## Validation Gaps
+
+- The `all_paths_go_through_event_bus` constraint is intentionally **not** declared in frontmatter yet: `src/server/enrichment.rs` still performs a direct `framework_detection_pass()` check for fast-path gating before the full bus run. Until that code is cut over, this ADR keeps the gap explicit instead of pretending the audit passes.
+- The performance gate (`repo-native-alignment scan --repo . --full` under 120s on the main RNA repo with no active agent worktrees) is still manual today. The architecture is shipped and the structural/event-flow checks above are executable, but the perf proof is not yet automated.
 
 ## References
 

--- a/docs/ADRs/002-arcswap-graph-concurrency.md
+++ b/docs/ADRs/002-arcswap-graph-concurrency.md
@@ -1,8 +1,16 @@
-# ArcSwap for Graph Concurrency
-**Status:** Implementing (issue #574)
-**Date:** 2026-03-24
-
 ---
+id: 002-arcswap-graph-concurrency
+status: implementing
+validate:
+  cargo_tests:
+    - server::tests::test_arcswap_readers_see_consistent_snapshots
+    - server::tests::test_get_graph_result_outlives_subsequent_mutations
+  audits:
+    - graph_state_uses_arcswap
+---
+
+# ArcSwap for Graph Concurrency
+**Date:** 2026-03-24
 
 ## Context
 
@@ -36,6 +44,10 @@ The enrichment pipeline takes ownership of nodes/edges via `std::mem::take`, lea
 - Memory doubles briefly during enrichment (old + new graph) — acceptable on modern machines
 - `GraphState` must be wrapped in `Arc` for atomic swapping
 - ArcSwap was previously used in this codebase and proven to work
+
+## Validation Notes
+
+- The current executable coverage proves snapshot consistency and the live ArcSwap graph type. Additional delivery/performance checks can be added before this ADR moves from `implementing` to `implemented`.
 
 ## References
 

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -2,5 +2,5 @@
 
 | ADR | Title | Status |
 |-----|-------|--------|
-| [001](001-event-bus-extraction-pipeline.md) | Event bus extraction pipeline | Implemented (v0.1.15) |
-| [002](002-arcswap-graph-concurrency.md) | ArcSwap for graph concurrency | Implementing (#574) |
+| [001](001-event-bus-extraction-pipeline.md) | RNA Event Bus Architecture | Implemented |
+| [002](002-arcswap-graph-concurrency.md) | ArcSwap for Graph Concurrency | Implementing |

--- a/plugin/skills/adr-sync/SKILL.md
+++ b/plugin/skills/adr-sync/SKILL.md
@@ -99,6 +99,7 @@ For each ADR claim that should be executable but is not yet backed by a real che
 ### Compile / Check
 - `repo-native-alignment adr compile --repo .` → [pass/fail]
 - `repo-native-alignment adr compile --repo . --check` → [pass/fail]
+- `repo-native-alignment adr validate --repo .` → [pass/fail]
 
 ### Missing Real Checks
 - ADR 002: claim "tool calls never block" still needs a dedicated regression test

--- a/plugin/skills/adr-sync/SKILL.md
+++ b/plugin/skills/adr-sync/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: adr-sync
+description: Backfill ADR frontmatter with direct executable validation refs, compile/check ADR validation manifests, and report missing real checks without inventing them.
+---
+
+# ADR Sync
+
+Translate ADR prose into executable validation declarations and verify that ADRs are actually wired to real checks.
+
+## Arguments
+
+`$ARGUMENTS` may be a single ADR path or a directory. Default to `docs/ADRs/` when omitted.
+
+Examples:
+- `/rna-mcp:adr-sync docs/ADRs/001-event-bus-extraction-pipeline.md`
+- `/rna-mcp:adr-sync docs/ADRs`
+
+## Goal
+
+Make ADRs mechanically checkable without introducing a second source of truth.
+
+The ADR markdown stays canonical. This skill:
+- adds or updates thin frontmatter validation declarations
+- points them directly at real repo executables
+- runs the repo-native ADR compile/check path
+- reports gaps where no real executable exists yet
+
+## Valid executable references
+
+Prefer normal test-suite checks first:
+- exact cargo test names as reported by `cargo test -- --list`
+- exact built-in ADR audit names when the claim is a code-shape constraint
+- exact smoke fixture paths only when you need a repo-native delivery scenario
+
+Use exact script paths only as a fallback when a claim genuinely cannot be expressed as a normal test or built-in audit yet.
+
+Do **not** invent opaque evidence IDs or a registry layer in the ADR source.
+Do **not** fabricate validations that do not exist.
+
+## Process
+
+### 1. Inspect the ADR(s)
+- Read the ADR markdown and current frontmatter
+- Extract the concrete claims that should be checkable
+- Look for existing validations already present in the repo:
+  - exact `cargo test -- --list` names
+  - built-in ADR audits via `repo-native-alignment adr audit <name>`
+  - smoke fixtures under `.github/fixtures/` only when a repo-native delivery check is required
+  - scripts under `.github/scripts/` or `scripts/` only if no honest test or audit exists yet
+
+### 2. Add/update frontmatter only where mapping is honest
+Expected shape:
+
+```yaml
+---
+id: 001-event-bus-extraction-pipeline
+status: implemented
+validate:
+  cargo_tests:
+    - exact::cargo::test_name
+  audits:
+    - exact_audit_name
+  smoke:
+    - .github/fixtures/smoke
+```
+
+Rules:
+- Prefer the thinnest schema that points at real checks
+- Prefer `cargo_tests` first, then built-in `audits`, then `smoke`, then `scripts` as the last resort
+- Preserve ADR prose; only add the executable seam
+- If a claim lacks a real check, leave it out and report the gap explicitly
+
+### 3. Compile or check manifests
+Run the repo-native ADR command path when available:
+
+```bash
+repo-native-alignment adr compile --repo .
+repo-native-alignment adr compile --repo . --check
+repo-native-alignment adr validate --repo .
+```
+
+If the command is not available yet, report that as a blocker instead of simulating success.
+
+### 4. Report missing real checks
+For each ADR claim that should be executable but is not yet backed by a real check, report:
+- the missing claim
+- the missing executable type needed (prefer `cargo test`; use script only as a last resort)
+- whether the ADR should remain partially validated for now
+
+## Output
+
+```markdown
+## ADR Sync Result
+
+### Updated ADRs
+- `docs/ADRs/001-...md`: added `validate.cargo_tests`
+- `docs/ADRs/002-...md`: added `validate.cargo_tests`
+
+### Compile / Check
+- `repo-native-alignment adr compile --repo .` → [pass/fail]
+- `repo-native-alignment adr compile --repo . --check` → [pass/fail]
+
+### Missing Real Checks
+- ADR 002: claim "tool calls never block" still needs a dedicated regression test
+
+### Notes
+- No fake validations added
+- No indirect evidence registry introduced
+```
+
+## What NOT to do
+- Do not invent test names or scripts that do not exist
+- Do not mark an ADR fully compliant if required checks are still missing
+- Do not default to `.github/scripts` when a normal test is the honest representation
+- Do not move execution details into prose when frontmatter can carry the direct ref cleanly
+- Do not create a parallel evidence-ID abstraction in ADR source
+
+## Success condition
+The ADR now declares direct executable validation refs, compile/check passes, and any missing real checks are explicitly surfaced instead of papered over.

--- a/plugin/skills/record/SKILL.md
+++ b/plugin/skills/record/SKILL.md
@@ -76,3 +76,44 @@ Edit the existing file at `.oh/outcomes/<slug>.md` — update `status`, `mechani
 - Lowercase, alphanumeric + hyphens only
 - No path separators (`/`, `\`, `..`)
 - Example: `protocol-mismatch-hangs`, `agent-scoping-accuracy`
+
+
+## ADRs (architecture decisions)
+
+When recording an ADR, write to `docs/ADRs/<NNN>-<slug>.md` with YAML frontmatter plus markdown body. Keep the ADR prose canonical, and make executable validation declarations match `plugin/skills/adr-sync/SKILL.md`.
+
+### ADR template
+
+```markdown
+---
+id: <NNN>-<slug>
+status: proposed|implementing|implemented|superseded
+validate:
+  cargo_tests:
+    - <exact cargo test name from `cargo test -- --list`>
+  audits:
+    - <exact built-in audit name if the claim is structural rather than behavioral>
+  smoke:
+    - <fixture path if needed>
+  scripts:
+    - <exact script path only if a normal test or audit cannot honestly express the claim>
+---
+
+# <Decision Title>
+
+## Context
+<why this decision exists>
+
+## Decision
+<what was decided>
+
+## Consequences
+<trade-offs and follow-on effects>
+```
+
+### ADR rules
+- Prefer `cargo_tests` over every other check type whenever the claim can be expressed as a normal test
+- Use built-in `audits` for code-shape constraints that are not honest test cases
+- Use direct executable references only — no opaque evidence IDs
+- If a validation does not exist yet, leave it out and call out the missing check explicitly in the ADR body or follow-up work
+- After creating or updating an ADR, run `/rna-mcp:adr-sync` so frontmatter, compile/check output, and missing-check reporting stay aligned

--- a/src/adr.rs
+++ b/src/adr.rs
@@ -1,0 +1,1287 @@
+use std::collections::{BTreeSet, HashMap};
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use gray_matter::{Matter, ParsedEntity, engine::YAML};
+use serde::{Deserialize, Serialize};
+
+const GENERATED_DIR: &str = ".oh/adr-validation";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdrStatus {
+    Proposed,
+    Implementing,
+    Implemented,
+    Superseded,
+}
+
+impl AdrStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Proposed => "Proposed",
+            Self::Implementing => "Implementing",
+            Self::Implemented => "Implemented",
+            Self::Superseded => "Superseded",
+        }
+    }
+}
+
+impl fmt::Display for AdrStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct AdrValidationRefs {
+    #[serde(default)]
+    pub cargo_tests: Vec<String>,
+    #[serde(default)]
+    pub audits: Vec<String>,
+    #[serde(default)]
+    pub scripts: Vec<String>,
+    #[serde(default)]
+    pub smoke: Vec<String>,
+}
+
+impl AdrValidationRefs {
+    fn total_checks(&self) -> usize {
+        self.cargo_tests.len() + self.audits.len() + self.scripts.len() + self.smoke.len()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdrManifest {
+    pub schema_version: u32,
+    pub id: String,
+    pub title: String,
+    pub status: AdrStatus,
+    pub source: String,
+    pub validate: AdrValidationRefs,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdrFrontmatter {
+    id: String,
+    status: AdrStatus,
+    #[serde(default)]
+    validate: AdrValidationRefs,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedAdr {
+    manifest: AdrManifest,
+    source_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CompileReport {
+    pub check: bool,
+    pub manifests: Vec<String>,
+    pub removed_stale: Vec<String>,
+    pub readme_updated: bool,
+    pub drift: Vec<String>,
+}
+
+impl CompileReport {
+    pub fn ok(&self) -> bool {
+        self.drift.is_empty()
+    }
+
+    pub fn human_summary(&self) -> String {
+        if self.check {
+            if self.ok() {
+                return format!(
+                    "ADR compile check passed: {} manifest(s) and README are in sync.",
+                    self.manifests.len()
+                );
+            }
+            return format!("ADR compile check failed:\n- {}", self.drift.join("\n- "));
+        }
+
+        let mut lines = vec![format!(
+            "Compiled {} ADR manifest(s) into {}.",
+            self.manifests.len(),
+            GENERATED_DIR
+        )];
+        if self.readme_updated {
+            lines.push("Updated docs/ADRs/README.md to match ADR source status.".to_string());
+        }
+        if !self.removed_stale.is_empty() {
+            lines.push(format!(
+                "Removed stale manifests: {}",
+                self.removed_stale.join(", ")
+            ));
+        }
+        lines.join("\n")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ValidationReport {
+    pub manifest_count: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub results: Vec<AdrValidationResult>,
+}
+
+impl ValidationReport {
+    pub fn ok(&self) -> bool {
+        self.failed == 0
+    }
+
+    pub fn human_summary(&self) -> String {
+        let mut lines = vec![format!(
+            "ADR validation: {}/{} passed.",
+            self.passed, self.manifest_count
+        )];
+        for result in &self.results {
+            let verdict = if result.ok { "PASS" } else { "FAIL" };
+            lines.push(format!("- {} [{}] {}", result.id, result.status, verdict));
+            if !result.failures.is_empty() {
+                for failure in &result.failures {
+                    lines.push(format!("  - {}", failure));
+                }
+            }
+        }
+        lines.join("\n")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AdrValidationResult {
+    pub id: String,
+    pub title: String,
+    pub status: AdrStatus,
+    pub ok: bool,
+    pub checks: Vec<CheckExecution>,
+    pub failures: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CheckExecution {
+    pub kind: String,
+    pub target: String,
+    pub ok: bool,
+    pub details: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AuditReport {
+    pub name: String,
+    pub ok: bool,
+    pub details: String,
+}
+
+impl AuditReport {
+    pub fn human_summary(&self) -> String {
+        format!(
+            "ADR audit {}: {}\n{}",
+            self.name,
+            if self.ok { "PASS" } else { "FAIL" },
+            self.details
+        )
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ValidateSelection {
+    pub id: Option<String>,
+    pub source_path: Option<PathBuf>,
+}
+
+pub fn compile(repo_root: &Path, adr_dir: &Path, check: bool) -> Result<CompileReport> {
+    let adrs = load_adrs(repo_root, adr_dir)?;
+    let manifest_dir = repo_root.join(GENERATED_DIR);
+    let mut manifests = Vec::new();
+    let mut drift = Vec::new();
+    let mut removed_stale = Vec::new();
+    let mut readme_updated = false;
+
+    if !check {
+        fs::create_dir_all(&manifest_dir)
+            .with_context(|| format!("creating {}", manifest_dir.display()))?;
+    }
+
+    let mut expected_files = BTreeSet::new();
+    for adr in &adrs {
+        let manifest_path = manifest_dir.join(format!("{}.json", adr.manifest.id));
+        let rel_manifest_path = repo_relative_string(repo_root, &manifest_path)?;
+        expected_files.insert(rel_manifest_path.clone());
+        manifests.push(rel_manifest_path.clone());
+
+        let rendered = render_manifest(&adr.manifest)?;
+        if check {
+            match fs::read_to_string(&manifest_path) {
+                Ok(existing) => {
+                    if existing != rendered {
+                        drift.push(format!("manifest drift: {}", rel_manifest_path));
+                    }
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    drift.push(format!("missing manifest: {}", rel_manifest_path));
+                }
+                Err(err) => {
+                    return Err(err)
+                        .with_context(|| format!("reading {}", manifest_path.display()));
+                }
+            }
+        } else {
+            fs::write(&manifest_path, rendered)
+                .with_context(|| format!("writing {}", manifest_path.display()))?;
+        }
+    }
+
+    if manifest_dir.is_dir() {
+        for entry in fs::read_dir(&manifest_dir)
+            .with_context(|| format!("reading {}", manifest_dir.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let rel = repo_relative_string(repo_root, &path)?;
+            if expected_files.contains(&rel) {
+                continue;
+            }
+            if check {
+                drift.push(format!("stale manifest: {}", rel));
+            } else {
+                fs::remove_file(&path)
+                    .with_context(|| format!("removing stale manifest {}", path.display()))?;
+                removed_stale.push(rel);
+            }
+        }
+    }
+
+    let readme_path = adr_dir.join("README.md");
+    if readme_path.exists() {
+        let rendered = render_readme(&adrs);
+        if check {
+            let existing = fs::read_to_string(&readme_path)
+                .with_context(|| format!("reading {}", readme_path.display()))?;
+            if existing != rendered {
+                drift.push(format!(
+                    "ADR README drift: {}",
+                    repo_relative_string(repo_root, &readme_path)?
+                ));
+            }
+        } else {
+            let existing = fs::read_to_string(&readme_path).unwrap_or_default();
+            if existing != rendered {
+                fs::write(&readme_path, rendered)
+                    .with_context(|| format!("writing {}", readme_path.display()))?;
+                readme_updated = true;
+            }
+        }
+    }
+
+    Ok(CompileReport {
+        check,
+        manifests,
+        removed_stale,
+        readme_updated,
+        drift,
+    })
+}
+
+pub fn validate(
+    repo_root: &Path,
+    selection: &ValidateSelection,
+    cargo_args: &[String],
+) -> Result<ValidationReport> {
+    let manifests = load_manifests(repo_root)?;
+    let source_filter = selection
+        .source_path
+        .as_ref()
+        .map(|path| repo_relative_string(repo_root, path))
+        .transpose()?;
+
+    let selected: Vec<_> = manifests
+        .into_iter()
+        .filter(|manifest| {
+            selection.id.as_ref().is_none_or(|id| manifest.id == *id)
+                && source_filter
+                    .as_ref()
+                    .is_none_or(|path| manifest.source == *path)
+        })
+        .collect();
+
+    if selected.is_empty() {
+        bail!(
+            "no ADR manifests matched the requested selection under {}",
+            repo_root.join(GENERATED_DIR).display()
+        );
+    }
+
+    let requested_cargo_tests: BTreeSet<String> = selected
+        .iter()
+        .flat_map(|manifest| manifest.validate.cargo_tests.iter().cloned())
+        .collect();
+    let available_tests = if requested_cargo_tests.is_empty() {
+        BTreeSet::new()
+    } else {
+        list_cargo_tests(repo_root, cargo_args)?
+    };
+
+    let mut results = Vec::new();
+    for manifest in selected {
+        let mut checks = Vec::new();
+        let mut failures = Vec::new();
+
+        if manifest.status == AdrStatus::Implemented && manifest.validate.total_checks() == 0 {
+            failures.push("implemented ADR declares no executable validations".to_string());
+        }
+
+        for test_name in &manifest.validate.cargo_tests {
+            if !available_tests.contains(test_name) {
+                checks.push(CheckExecution {
+                    kind: "cargo_test".to_string(),
+                    target: test_name.clone(),
+                    ok: false,
+                    details: "not found in `cargo test -- --list` output".to_string(),
+                });
+                failures.push(format!("missing cargo test `{}`", test_name));
+                continue;
+            }
+
+            let output = Command::new("cargo")
+                .arg("test")
+                .args(cargo_args)
+                .arg(test_name)
+                .arg("--")
+                .arg("--exact")
+                .current_dir(repo_root)
+                .output()
+                .with_context(|| format!("running cargo test {}", test_name))?;
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let ran_exact_test =
+                stdout.contains("running 1 test") || stderr.contains("running 1 test");
+            let ok = output.status.success() && ran_exact_test;
+            checks.push(CheckExecution {
+                kind: "cargo_test".to_string(),
+                target: test_name.clone(),
+                ok,
+                details: if ok {
+                    "passed".to_string()
+                } else if output.status.success() {
+                    "command succeeded but did not run exactly one test".to_string()
+                } else {
+                    summarize_command_output(&stdout, &stderr)
+                },
+            });
+            if !ok {
+                failures.push(format!("cargo test `{}` failed", test_name));
+            }
+        }
+
+        for audit_name in &manifest.validate.audits {
+            let audit = run_audit(repo_root, audit_name)?;
+            checks.push(CheckExecution {
+                kind: "audit".to_string(),
+                target: audit_name.clone(),
+                ok: audit.ok,
+                details: audit.details.clone(),
+            });
+            if !audit.ok {
+                failures.push(format!("audit `{}` failed", audit_name));
+            }
+        }
+
+        for script in &manifest.validate.scripts {
+            let script_path = repo_root.join(script);
+            let mut command = if script_path.extension().and_then(|ext| ext.to_str()) == Some("sh")
+            {
+                let mut command = Command::new("bash");
+                command.arg(&script_path);
+                command
+            } else {
+                Command::new(&script_path)
+            };
+            let output = command
+                .current_dir(repo_root)
+                .output()
+                .with_context(|| format!("running script {}", script))?;
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let ok = output.status.success();
+            checks.push(CheckExecution {
+                kind: "script".to_string(),
+                target: script.clone(),
+                ok,
+                details: if ok {
+                    "passed".to_string()
+                } else {
+                    summarize_command_output(&stdout, &stderr)
+                },
+            });
+            if !ok {
+                failures.push(format!("script `{}` failed", script));
+            }
+        }
+
+        for fixture in &manifest.validate.smoke {
+            let binary =
+                std::env::current_exe().context("resolving current executable for smoke run")?;
+            let output = Command::new(&binary)
+                .arg("test")
+                .arg("--repo")
+                .arg(repo_root.join(fixture))
+                .current_dir(repo_root)
+                .output()
+                .with_context(|| format!("running smoke fixture {}", fixture))?;
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let ok = output.status.success();
+            checks.push(CheckExecution {
+                kind: "smoke".to_string(),
+                target: fixture.clone(),
+                ok,
+                details: if ok {
+                    "passed".to_string()
+                } else {
+                    summarize_command_output(&stdout, &stderr)
+                },
+            });
+            if !ok {
+                failures.push(format!("smoke fixture `{}` failed", fixture));
+            }
+        }
+
+        let ok = failures.is_empty();
+        results.push(AdrValidationResult {
+            id: manifest.id,
+            title: manifest.title,
+            status: manifest.status,
+            ok,
+            checks,
+            failures,
+        });
+    }
+
+    let passed = results.iter().filter(|result| result.ok).count();
+    let failed = results.len().saturating_sub(passed);
+    Ok(ValidationReport {
+        manifest_count: results.len(),
+        passed,
+        failed,
+        results,
+    })
+}
+
+pub fn run_audit(repo_root: &Path, name: &str) -> Result<AuditReport> {
+    match name {
+        "no_consumer_knows_other_consumers" => audit_no_consumer_knows_other_consumers(repo_root),
+        "static_registration_only" => audit_static_registration_only(repo_root),
+        "no_broker_logic_in_core" => audit_no_broker_logic_in_core(repo_root),
+        "all_paths_go_through_event_bus" => audit_all_paths_go_through_event_bus(repo_root),
+        "graph_state_uses_arcswap" => audit_graph_state_uses_arcswap(repo_root),
+        other => bail!("unknown ADR audit `{}`", other),
+    }
+}
+
+fn load_adrs(repo_root: &Path, adr_dir: &Path) -> Result<Vec<ParsedAdr>> {
+    let mut files = Vec::new();
+    for entry in fs::read_dir(adr_dir)
+        .with_context(|| format!("reading ADR directory {}", adr_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("md") {
+            continue;
+        }
+        if path.file_name().and_then(|name| name.to_str()) == Some("README.md") {
+            continue;
+        }
+        files.push(path);
+    }
+    files.sort();
+
+    let mut adrs = Vec::new();
+    for path in files {
+        let raw =
+            fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+        adrs.push(parse_adr(repo_root, &path, &raw)?);
+    }
+    Ok(adrs)
+}
+
+fn parse_adr(repo_root: &Path, path: &Path, raw: &str) -> Result<ParsedAdr> {
+    let matter: Matter<YAML> = Matter::new();
+    let parsed: ParsedEntity = matter
+        .parse(raw)
+        .with_context(|| format!("parsing frontmatter in {}", path.display()))?;
+    let has_frontmatter = !parsed.matter.is_empty()
+        || (raw.trim_start().starts_with("---") && parsed.content.len() < raw.len());
+    if !has_frontmatter {
+        bail!("{} is missing YAML frontmatter", path.display());
+    }
+
+    let frontmatter: AdrFrontmatter = serde_yaml::from_str(&parsed.matter)
+        .with_context(|| format!("decoding YAML frontmatter in {}", path.display()))?;
+    let expected_id = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or_default()
+        .to_string();
+    if frontmatter.id != expected_id {
+        bail!(
+            "{} frontmatter id `{}` must match file stem `{}`",
+            path.display(),
+            frontmatter.id,
+            expected_id
+        );
+    }
+
+    let title = extract_title(&parsed.content)
+        .with_context(|| format!("extracting title from {}", path.display()))?;
+
+    let validate = AdrValidationRefs {
+        cargo_tests: dedup_preserve(frontmatter.validate.cargo_tests),
+        audits: dedup_preserve(frontmatter.validate.audits),
+        scripts: normalize_repo_paths(repo_root, &frontmatter.validate.scripts, "script")?,
+        smoke: normalize_repo_paths(repo_root, &frontmatter.validate.smoke, "smoke fixture")?,
+    };
+
+    Ok(ParsedAdr {
+        source_path: path.to_path_buf(),
+        manifest: AdrManifest {
+            schema_version: 1,
+            id: frontmatter.id,
+            title,
+            status: frontmatter.status,
+            source: repo_relative_string(repo_root, path)?,
+            validate,
+        },
+    })
+}
+
+fn load_manifests(repo_root: &Path) -> Result<Vec<AdrManifest>> {
+    let manifest_dir = repo_root.join(GENERATED_DIR);
+    if !manifest_dir.is_dir() {
+        bail!(
+            "{} does not exist; run `repo-native-alignment adr compile --repo {}` first",
+            manifest_dir.display(),
+            repo_root.display()
+        );
+    }
+
+    let mut manifests: Vec<AdrManifest> = Vec::new();
+    for entry in fs::read_dir(&manifest_dir)
+        .with_context(|| format!("reading {}", manifest_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("reading manifest {}", path.display()))?;
+        manifests.push(
+            serde_json::from_str(&raw)
+                .with_context(|| format!("parsing manifest {}", path.display()))?,
+        );
+    }
+    manifests.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(manifests)
+}
+
+fn render_manifest(manifest: &AdrManifest) -> Result<String> {
+    let mut rendered =
+        serde_json::to_string_pretty(manifest).context("serializing ADR manifest")?;
+    rendered.push('\n');
+    Ok(rendered)
+}
+
+fn render_readme(adrs: &[ParsedAdr]) -> String {
+    let mut lines = vec![
+        "# Architecture Decision Records".to_string(),
+        String::new(),
+        "| ADR | Title | Status |".to_string(),
+        "|-----|-------|--------|".to_string(),
+    ];
+    for adr in adrs {
+        let slug = adr
+            .source_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+        let short_id = adr
+            .manifest
+            .id
+            .split('-')
+            .next()
+            .unwrap_or(&adr.manifest.id);
+        lines.push(format!(
+            "| [{}]({}) | {} | {} |",
+            short_id, slug, adr.manifest.title, adr.manifest.status
+        ));
+    }
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+fn list_cargo_tests(repo_root: &Path, cargo_args: &[String]) -> Result<BTreeSet<String>> {
+    let output = Command::new("cargo")
+        .arg("test")
+        .args(cargo_args)
+        .arg("--")
+        .arg("--list")
+        .current_dir(repo_root)
+        .output()
+        .context("listing cargo tests for ADR validation")?;
+
+    if !output.status.success() {
+        bail!(
+            "`cargo test -- --list` failed: {}",
+            summarize_command_output(
+                &String::from_utf8_lossy(&output.stdout),
+                &String::from_utf8_lossy(&output.stderr)
+            )
+        );
+    }
+
+    Ok(parse_cargo_test_list(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
+fn parse_cargo_test_list(stdout: &str) -> BTreeSet<String> {
+    stdout
+        .lines()
+        .filter_map(|line| line.trim().strip_suffix(": test"))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn audit_no_consumer_knows_other_consumers(repo_root: &Path) -> Result<AuditReport> {
+    let extract_dir = repo_root.join("src/extract");
+    let mut hits = Vec::new();
+    for path in collect_rust_files(&extract_dir)? {
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+        if file_name == "event_bus.rs" || file_name == "consumers.rs" {
+            continue;
+        }
+        let content =
+            fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+        for needle in ["EventBus", "run_consumers", "PostExtractionRegistry"] {
+            if content.contains(needle) {
+                hits.push(format!(
+                    "{} contains `{}`",
+                    repo_relative_string(repo_root, &path)?,
+                    needle
+                ));
+            }
+        }
+    }
+
+    Ok(AuditReport {
+        name: "no_consumer_knows_other_consumers".to_string(),
+        ok: hits.is_empty(),
+        details: if hits.is_empty() {
+            "no consumer implementation imports EventBus/run_consumers/PostExtractionRegistry"
+                .to_string()
+        } else {
+            hits.join("; ")
+        },
+    })
+}
+
+fn audit_static_registration_only(repo_root: &Path) -> Result<AuditReport> {
+    let mut hits = Vec::new();
+    for path in collect_rust_files(&repo_root.join("src"))? {
+        let content =
+            fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+        let mut in_on_event = false;
+        let mut depth: i32 = 0;
+        for (idx, raw_line) in content.lines().enumerate() {
+            let line = raw_line.trim();
+            if !in_on_event && line.contains("fn on_event") {
+                in_on_event = true;
+                depth += brace_delta(line);
+                continue;
+            }
+            if !in_on_event {
+                continue;
+            }
+            if !line.starts_with("//")
+                && (line.contains(".register(") || line.contains(".subscribe("))
+            {
+                hits.push(format!(
+                    "{}:{} contains registration inside on_event",
+                    repo_relative_string(repo_root, &path)?,
+                    idx + 1
+                ));
+            }
+            depth += brace_delta(line);
+            if depth <= 0 {
+                in_on_event = false;
+                depth = 0;
+            }
+        }
+    }
+
+    Ok(AuditReport {
+        name: "static_registration_only".to_string(),
+        ok: hits.is_empty(),
+        details: if hits.is_empty() {
+            "no on_event handler performs dynamic registration/subscription".to_string()
+        } else {
+            hits.join("; ")
+        },
+    })
+}
+
+fn audit_no_broker_logic_in_core(repo_root: &Path) -> Result<AuditReport> {
+    let mut hits = Vec::new();
+    for dir in [repo_root.join("src/server"), repo_root.join("src/bus")] {
+        if !dir.exists() {
+            continue;
+        }
+        for path in collect_rust_files(&dir)? {
+            let content =
+                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+            for (idx, raw_line) in content.lines().enumerate() {
+                let line = raw_line.trim();
+                if line.starts_with("//") {
+                    continue;
+                }
+                let lower = line.to_ascii_lowercase();
+                if [
+                    "kafka", "pubsub", "rabbitmq", "rabbit", "celery", "pika", "redis",
+                ]
+                .iter()
+                .any(|needle| lower.contains(needle))
+                {
+                    hits.push(format!(
+                        "{}:{} contains broker-specific core logic",
+                        repo_relative_string(repo_root, &path)?,
+                        idx + 1
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(AuditReport {
+        name: "no_broker_logic_in_core".to_string(),
+        ok: hits.is_empty(),
+        details: if hits.is_empty() {
+            "server/bus core contains no broker-specific logic".to_string()
+        } else {
+            hits.join("; ")
+        },
+    })
+}
+
+fn audit_all_paths_go_through_event_bus(repo_root: &Path) -> Result<AuditReport> {
+    let needles = [
+        "api_link_pass(",
+        "tested_by_pass(",
+        "import_calls_pass(",
+        "directory_module_pass(",
+        "framework_detection_pass(",
+    ];
+    let mut hits = Vec::new();
+    for path in collect_rust_files(&repo_root.join("src/server"))? {
+        let content =
+            fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+        for (idx, raw_line) in content.lines().enumerate() {
+            let line = raw_line.trim();
+            if line.starts_with("//") {
+                continue;
+            }
+            for needle in needles {
+                if line.contains(needle) {
+                    hits.push(format!(
+                        "{}:{} contains direct pass call `{}`",
+                        repo_relative_string(repo_root, &path)?,
+                        idx + 1,
+                        needle.trim_end_matches('(')
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(AuditReport {
+        name: "all_paths_go_through_event_bus".to_string(),
+        ok: hits.is_empty(),
+        details: if hits.is_empty() {
+            "server paths do not call post-extraction passes directly".to_string()
+        } else {
+            hits.join("; ")
+        },
+    })
+}
+
+fn audit_graph_state_uses_arcswap(repo_root: &Path) -> Result<AuditReport> {
+    let path = repo_root.join("src/server/mod.rs");
+    let content =
+        fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let non_comment = content
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let uses_arcswap = non_comment.contains("pub graph: Arc<ArcSwap<Option<Arc<GraphState>>>>");
+    let still_has_rwlock = non_comment.contains("Arc<RwLock<Option<GraphState>>>")
+        || non_comment.contains("RwLock<Option<GraphState>>");
+
+    Ok(AuditReport {
+        name: "graph_state_uses_arcswap".to_string(),
+        ok: uses_arcswap && !still_has_rwlock,
+        details: if uses_arcswap && !still_has_rwlock {
+            "RnaHandler.graph uses ArcSwap and no live RwLock GraphState remains".to_string()
+        } else {
+            "expected ArcSwap-backed graph field and no live RwLock GraphState".to_string()
+        },
+    })
+}
+
+fn collect_rust_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(next) = stack.pop() {
+        for entry in fs::read_dir(&next).with_context(|| format!("reading {}", next.display()))? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn extract_title(body: &str) -> Result<String> {
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("# ") {
+            let title = rest.trim();
+            if !title.is_empty() {
+                return Ok(title.to_string());
+            }
+        }
+    }
+    bail!("ADR body is missing a level-1 heading")
+}
+
+fn normalize_repo_paths(repo_root: &Path, raw_paths: &[String], kind: &str) -> Result<Vec<String>> {
+    let mut normalized = Vec::new();
+    let mut seen = BTreeSet::new();
+    for raw in raw_paths {
+        let path = normalize_repo_relative_path(raw)?;
+        let full_path = repo_root.join(&path);
+        if !full_path.exists() {
+            bail!("{} `{}` does not exist", kind, path.display());
+        }
+        let rel = path_to_slash_string(&path);
+        if seen.insert(rel.clone()) {
+            normalized.push(rel);
+        }
+    }
+    Ok(normalized)
+}
+
+fn normalize_repo_relative_path(raw: &str) -> Result<PathBuf> {
+    let path = Path::new(raw.trim());
+    if raw.trim().is_empty() {
+        bail!("path reference must not be empty");
+    }
+    if path.is_absolute() {
+        bail!("path reference `{}` must be repo-relative", raw);
+    }
+    let normalized = normalize_path(path);
+    if normalized.as_os_str().is_empty() {
+        bail!("path reference `{}` resolves to an empty path", raw);
+    }
+    if normalized.components().any(|component| {
+        matches!(
+            component,
+            std::path::Component::ParentDir
+                | std::path::Component::RootDir
+                | std::path::Component::Prefix(_)
+        )
+    }) {
+        bail!("path reference `{}` escapes the repository root", raw);
+    }
+    Ok(normalized)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if matches!(components.last(), Some(std::path::Component::Normal(_))) {
+                    components.pop();
+                } else {
+                    components.push(component);
+                }
+            }
+            other => components.push(other),
+        }
+    }
+    components.iter().collect()
+}
+
+fn repo_relative_string(repo_root: &Path, path: &Path) -> Result<String> {
+    let relative = path.strip_prefix(repo_root).unwrap_or(path);
+    Ok(path_to_slash_string(relative))
+}
+
+fn path_to_slash_string(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn dedup_preserve(items: Vec<String>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut deduped = Vec::new();
+    for item in items {
+        if seen.insert(item.clone()) {
+            deduped.push(item);
+        }
+    }
+    deduped
+}
+
+fn brace_delta(line: &str) -> i32 {
+    line.chars().fold(0, |acc, ch| match ch {
+        '{' => acc + 1,
+        '}' => acc - 1,
+        _ => acc,
+    })
+}
+
+fn summarize_command_output(stdout: &str, stderr: &str) -> String {
+    let combined = format!("{}\n{}", stdout.trim(), stderr.trim());
+    let summary = combined
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("command failed with no output");
+    summary.to_string()
+}
+
+pub fn adr_edges_from_frontmatter(all_nodes: &[crate::graph::Node]) -> Vec<crate::graph::Edge> {
+    use crate::graph::{Confidence, Edge, EdgeKind, ExtractionSource, Node, NodeKind};
+
+    let mut test_nodes: HashMap<&str, Vec<&Node>> = HashMap::new();
+    for node in all_nodes {
+        if node.id.kind == NodeKind::Function
+            && node.metadata.get("is_test").map(|value| value.as_str()) == Some("true")
+        {
+            test_nodes
+                .entry(node.id.name.as_str())
+                .or_default()
+                .push(node);
+        }
+    }
+
+    let mut file_primary_node: HashMap<&Path, &crate::graph::NodeId> = HashMap::new();
+    let mut file_frontmatter: Vec<&Node> = Vec::new();
+    for node in all_nodes {
+        if node.id.kind != NodeKind::MarkdownSection {
+            continue;
+        }
+        if node
+            .metadata
+            .get("is_frontmatter")
+            .map(|value| value.as_str())
+            == Some("true")
+        {
+            file_frontmatter.push(node);
+            continue;
+        }
+        file_primary_node
+            .entry(node.id.file.as_path())
+            .or_insert(&node.id);
+    }
+
+    let mut edges = Vec::new();
+    let mut seen = BTreeSet::new();
+    for frontmatter in file_frontmatter {
+        let refs: AdrFrontmatter = match serde_yaml::from_str(&frontmatter.body) {
+            Ok(frontmatter) => frontmatter,
+            Err(_) => continue,
+        };
+        let Some(source_id) = file_primary_node
+            .get(frontmatter.id.file.as_path())
+            .copied()
+            .or(Some(&frontmatter.id))
+        else {
+            continue;
+        };
+
+        for cargo_test in refs.validate.cargo_tests {
+            let leaf = cargo_test.rsplit("::").next().unwrap_or(&cargo_test);
+            let Some(targets) = test_nodes.get(leaf) else {
+                continue;
+            };
+            if targets.len() != 1 {
+                continue;
+            }
+            let target = targets[0];
+            let key = format!("{}->{}", source_id.to_stable_id(), target.id.to_stable_id());
+            if !seen.insert(key) {
+                continue;
+            }
+            edges.push(Edge {
+                from: source_id.clone(),
+                to: target.id.clone(),
+                kind: EdgeKind::References,
+                source: ExtractionSource::Markdown,
+                confidence: Confidence::Confirmed,
+            });
+        }
+    }
+    edges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::{ExtractionSource, Node, NodeId, NodeKind};
+    use std::collections::BTreeMap;
+    use tempfile::TempDir;
+
+    fn write_adr(repo: &Path, file: &str, content: &str) {
+        let path = repo.join("docs/ADRs").join(file);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
+    }
+
+    fn sample_adr(id: &str, status: &str, title: &str, validate: &str) -> String {
+        format!(
+            "---\nid: {}\nstatus: {}\nvalidate:\n{}---\n\n# {}\n\nBody.\n",
+            id, status, validate, title
+        )
+    }
+
+    #[test]
+    fn test_compile_writes_manifests_and_readme() {
+        let tmp = TempDir::new().unwrap();
+        write_adr(
+            tmp.path(),
+            "001-event-bus-extraction-pipeline.md",
+            &sample_adr(
+                "001-event-bus-extraction-pipeline",
+                "implemented",
+                "Event bus extraction pipeline",
+                "  cargo_tests:\n    - extract::event_bus::tests::test_depth_first_ordering\n",
+            ),
+        );
+        write_adr(
+            tmp.path(),
+            "002-arcswap-graph-concurrency.md",
+            &sample_adr(
+                "002-arcswap-graph-concurrency",
+                "implementing",
+                "ArcSwap for graph concurrency",
+                "  audits:\n    - graph_state_uses_arcswap\n",
+            ),
+        );
+        fs::write(tmp.path().join("docs/ADRs/README.md"), "stale\n").unwrap();
+
+        let report = compile(tmp.path(), &tmp.path().join("docs/ADRs"), false).unwrap();
+        assert!(report.ok());
+        assert_eq!(report.manifests.len(), 2);
+        assert!(report.readme_updated);
+        assert!(
+            tmp.path()
+                .join(".oh/adr-validation/001-event-bus-extraction-pipeline.json")
+                .exists()
+        );
+        let readme = fs::read_to_string(tmp.path().join("docs/ADRs/README.md")).unwrap();
+        assert!(readme.contains("| [001](001-event-bus-extraction-pipeline.md) | Event bus extraction pipeline | Implemented |"));
+    }
+
+    #[test]
+    fn test_compile_check_detects_manifest_and_readme_drift() {
+        let tmp = TempDir::new().unwrap();
+        write_adr(
+            tmp.path(),
+            "001-event-bus-extraction-pipeline.md",
+            &sample_adr(
+                "001-event-bus-extraction-pipeline",
+                "implemented",
+                "Event bus extraction pipeline",
+                "  audits:\n    - no_consumer_knows_other_consumers\n",
+            ),
+        );
+        fs::write(tmp.path().join("docs/ADRs/README.md"), "wrong\n").unwrap();
+        compile(tmp.path(), &tmp.path().join("docs/ADRs"), false).unwrap();
+        fs::write(
+            tmp.path()
+                .join(".oh/adr-validation/001-event-bus-extraction-pipeline.json"),
+            "{}\n",
+        )
+        .unwrap();
+
+        let report = compile(tmp.path(), &tmp.path().join("docs/ADRs"), true).unwrap();
+        assert!(!report.ok());
+        assert!(
+            report
+                .drift
+                .iter()
+                .any(|entry| entry.contains("manifest drift"))
+        );
+    }
+
+    #[test]
+    fn test_compile_removes_stale_manifest() {
+        let tmp = TempDir::new().unwrap();
+        write_adr(
+            tmp.path(),
+            "001-event-bus-extraction-pipeline.md",
+            &sample_adr(
+                "001-event-bus-extraction-pipeline",
+                "implemented",
+                "Event bus extraction pipeline",
+                "  audits:\n    - no_consumer_knows_other_consumers\n",
+            ),
+        );
+        fs::write(tmp.path().join("docs/ADRs/README.md"), "stale\n").unwrap();
+        fs::create_dir_all(tmp.path().join(".oh/adr-validation")).unwrap();
+        fs::write(tmp.path().join(".oh/adr-validation/stale.json"), "{}\n").unwrap();
+
+        let report = compile(tmp.path(), &tmp.path().join("docs/ADRs"), false).unwrap();
+        assert!(
+            report
+                .removed_stale
+                .iter()
+                .any(|entry| entry == ".oh/adr-validation/stale.json")
+        );
+        assert!(!tmp.path().join(".oh/adr-validation/stale.json").exists());
+    }
+
+    #[test]
+    fn test_parse_adr_requires_matching_id() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp
+            .path()
+            .join("docs/ADRs/001-event-bus-extraction-pipeline.md");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let err = parse_adr(
+            tmp.path(),
+            &path,
+            &sample_adr(
+                "wrong-id",
+                "implemented",
+                "Event bus extraction pipeline",
+                "  audits:\n    - no_consumer_knows_other_consumers\n",
+            ),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("must match file stem"));
+    }
+
+    #[test]
+    fn test_normalize_repo_relative_path_rejects_escape() {
+        let err = normalize_repo_relative_path("../outside.sh").unwrap_err();
+        assert!(err.to_string().contains("escapes the repository root"));
+    }
+
+    #[test]
+    fn test_parse_cargo_test_list_extracts_exact_names() {
+        let tests = parse_cargo_test_list(
+            "server::tests::test_arcswap_readers_see_consistent_snapshots: test\nextract::event_bus::tests::test_depth_first_ordering: test\n",
+        );
+        assert!(tests.contains("server::tests::test_arcswap_readers_see_consistent_snapshots"));
+        assert!(tests.contains("extract::event_bus::tests::test_depth_first_ordering"));
+    }
+
+    #[test]
+    fn test_adr_edges_from_frontmatter_link_to_unique_test_nodes() {
+        let frontmatter = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("docs/ADRs/002-arcswap-graph-concurrency.md"),
+                name: "frontmatter".to_string(),
+                kind: NodeKind::MarkdownSection,
+            },
+            language: "markdown".to_string(),
+            line_start: 1,
+            line_end: 6,
+            signature: "[frontmatter]".to_string(),
+            body: "id: 002-arcswap-graph-concurrency\nstatus: implementing\nvalidate:\n  cargo_tests:\n    - server::tests::test_arcswap_readers_see_consistent_snapshots\n".to_string(),
+            metadata: BTreeMap::from([("is_frontmatter".to_string(), "true".to_string())]),
+            source: ExtractionSource::Markdown,
+        };
+        let adr = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("docs/ADRs/002-arcswap-graph-concurrency.md"),
+                name: "ArcSwap for Graph Concurrency".to_string(),
+                kind: NodeKind::MarkdownSection,
+            },
+            language: "markdown".to_string(),
+            line_start: 8,
+            line_end: 20,
+            signature: "ArcSwap for Graph Concurrency".to_string(),
+            body: "# ArcSwap for Graph Concurrency".to_string(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::Markdown,
+        };
+        let test = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("src/server/mod.rs"),
+                name: "test_arcswap_readers_see_consistent_snapshots".to_string(),
+                kind: NodeKind::Function,
+            },
+            language: "rust".to_string(),
+            line_start: 1,
+            line_end: 10,
+            signature: "async fn test_arcswap_readers_see_consistent_snapshots()".to_string(),
+            body: String::new(),
+            metadata: BTreeMap::from([("is_test".to_string(), "true".to_string())]),
+            source: ExtractionSource::TreeSitter,
+        };
+
+        let edges = adr_edges_from_frontmatter(&[frontmatter, adr.clone(), test.clone()]);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].from, adr.id);
+        assert_eq!(edges[0].to, test.id);
+    }
+
+    #[test]
+    fn test_audit_static_registration_only_detects_dynamic_registration() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("src/sample.rs");
+        fs::create_dir_all(src.parent().unwrap()).unwrap();
+        fs::write(
+            &src,
+            "impl X {\n    async fn on_event(&self) {\n        bus.register(Box::new(Y));\n    }\n}\n",
+        )
+        .unwrap();
+
+        let report = audit_static_registration_only(tmp.path()).unwrap();
+        assert!(!report.ok);
+        assert!(report.details.contains("registration inside on_event"));
+    }
+}

--- a/src/adr.rs
+++ b/src/adr.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -408,19 +408,20 @@ pub fn validate(
             } else {
                 Command::new(&script_path)
             };
-            let output = command
-                .current_dir(repo_root)
-                .output()
+            command.current_dir(repo_root);
+            let output = run_command_with_timeout(&mut command, COMMAND_TIMEOUT)
                 .with_context(|| format!("running script {}", script))?;
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
-            let ok = output.status.success();
+            let ok = output.success;
             checks.push(CheckExecution {
                 kind: "script".to_string(),
                 target: script.clone(),
                 ok,
                 details: if ok {
                     "passed".to_string()
+                } else if output.timed_out {
+                    format!("timed out after {}s", COMMAND_TIMEOUT.as_secs())
                 } else {
                     summarize_command_output(&stdout, &stderr)
                 },
@@ -433,22 +434,25 @@ pub fn validate(
         for fixture in &manifest.validate.smoke {
             let binary =
                 std::env::current_exe().context("resolving current executable for smoke run")?;
-            let output = Command::new(&binary)
+            let mut command = Command::new(&binary);
+            command
                 .arg("test")
                 .arg("--repo")
                 .arg(repo_root.join(fixture))
-                .current_dir(repo_root)
-                .output()
+                .current_dir(repo_root);
+            let output = run_command_with_timeout(&mut command, COMMAND_TIMEOUT)
                 .with_context(|| format!("running smoke fixture {}", fixture))?;
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
-            let ok = output.status.success();
+            let ok = output.success;
             checks.push(CheckExecution {
                 kind: "smoke".to_string(),
                 target: fixture.clone(),
                 ok,
                 details: if ok {
                     "passed".to_string()
+                } else if output.timed_out {
+                    format!("timed out after {}s", COMMAND_TIMEOUT.as_secs())
                 } else {
                     summarize_command_output(&stdout, &stderr)
                 },
@@ -1054,86 +1058,9 @@ fn summarize_command_output(stdout: &str, stderr: &str) -> String {
     summary.to_string()
 }
 
-pub fn adr_edges_from_frontmatter(all_nodes: &[crate::graph::Node]) -> Vec<crate::graph::Edge> {
-    use crate::graph::{Confidence, Edge, EdgeKind, ExtractionSource, Node, NodeKind};
-
-    let mut test_nodes: HashMap<&str, Vec<&Node>> = HashMap::new();
-    for node in all_nodes {
-        if node.id.kind == NodeKind::Function
-            && node.metadata.get("is_test").map(|value| value.as_str()) == Some("true")
-        {
-            test_nodes
-                .entry(node.id.name.as_str())
-                .or_default()
-                .push(node);
-        }
-    }
-
-    let mut file_primary_node: HashMap<&Path, &crate::graph::NodeId> = HashMap::new();
-    let mut file_frontmatter: Vec<&Node> = Vec::new();
-    for node in all_nodes {
-        if node.id.kind != NodeKind::MarkdownSection {
-            continue;
-        }
-        if node
-            .metadata
-            .get("is_frontmatter")
-            .map(|value| value.as_str())
-            == Some("true")
-        {
-            file_frontmatter.push(node);
-            continue;
-        }
-        file_primary_node
-            .entry(node.id.file.as_path())
-            .or_insert(&node.id);
-    }
-
-    let mut edges = Vec::new();
-    let mut seen = BTreeSet::new();
-    for frontmatter in file_frontmatter {
-        let refs: AdrFrontmatter = match serde_yaml::from_str(&frontmatter.body) {
-            Ok(frontmatter) => frontmatter,
-            Err(_) => continue,
-        };
-        let Some(source_id) = file_primary_node
-            .get(frontmatter.id.file.as_path())
-            .copied()
-            .or(Some(&frontmatter.id))
-        else {
-            continue;
-        };
-
-        for cargo_test in refs.validate.cargo_tests {
-            let leaf = cargo_test.rsplit("::").next().unwrap_or(&cargo_test);
-            let Some(targets) = test_nodes.get(leaf) else {
-                continue;
-            };
-            if targets.len() != 1 {
-                continue;
-            }
-            let target = targets[0];
-            let key = format!("{}->{}", source_id.to_stable_id(), target.id.to_stable_id());
-            if !seen.insert(key) {
-                continue;
-            }
-            edges.push(Edge {
-                from: source_id.clone(),
-                to: target.id.clone(),
-                kind: EdgeKind::References,
-                source: ExtractionSource::Markdown,
-                confidence: Confidence::Confirmed,
-            });
-        }
-    }
-    edges
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::graph::{ExtractionSource, Node, NodeId, NodeKind};
-    use std::collections::BTreeMap;
     use tempfile::TempDir;
 
     fn write_adr(repo: &Path, file: &str, content: &str) {
@@ -1280,60 +1207,6 @@ mod tests {
         );
         assert!(tests.contains("server::tests::test_arcswap_readers_see_consistent_snapshots"));
         assert!(tests.contains("extract::event_bus::tests::test_depth_first_ordering"));
-    }
-
-    #[test]
-    fn test_adr_edges_from_frontmatter_link_to_unique_test_nodes() {
-        let frontmatter = Node {
-            id: NodeId {
-                root: String::new(),
-                file: PathBuf::from("docs/ADRs/002-arcswap-graph-concurrency.md"),
-                name: "frontmatter".to_string(),
-                kind: NodeKind::MarkdownSection,
-            },
-            language: "markdown".to_string(),
-            line_start: 1,
-            line_end: 6,
-            signature: "[frontmatter]".to_string(),
-            body: "id: 002-arcswap-graph-concurrency\nstatus: implementing\nvalidate:\n  cargo_tests:\n    - server::tests::test_arcswap_readers_see_consistent_snapshots\n".to_string(),
-            metadata: BTreeMap::from([("is_frontmatter".to_string(), "true".to_string())]),
-            source: ExtractionSource::Markdown,
-        };
-        let adr = Node {
-            id: NodeId {
-                root: String::new(),
-                file: PathBuf::from("docs/ADRs/002-arcswap-graph-concurrency.md"),
-                name: "ArcSwap for Graph Concurrency".to_string(),
-                kind: NodeKind::MarkdownSection,
-            },
-            language: "markdown".to_string(),
-            line_start: 8,
-            line_end: 20,
-            signature: "ArcSwap for Graph Concurrency".to_string(),
-            body: "# ArcSwap for Graph Concurrency".to_string(),
-            metadata: BTreeMap::new(),
-            source: ExtractionSource::Markdown,
-        };
-        let test = Node {
-            id: NodeId {
-                root: String::new(),
-                file: PathBuf::from("src/server/mod.rs"),
-                name: "test_arcswap_readers_see_consistent_snapshots".to_string(),
-                kind: NodeKind::Function,
-            },
-            language: "rust".to_string(),
-            line_start: 1,
-            line_end: 10,
-            signature: "async fn test_arcswap_readers_see_consistent_snapshots()".to_string(),
-            body: String::new(),
-            metadata: BTreeMap::from([("is_test".to_string(), "true".to_string())]),
-            source: ExtractionSource::TreeSitter,
-        };
-
-        let edges = adr_edges_from_frontmatter(&[frontmatter, adr.clone(), test.clone()]);
-        assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].from, adr.id);
-        assert_eq!(edges[0].to, test.id);
     }
 
     #[test]

--- a/src/adr.rs
+++ b/src/adr.rs
@@ -2,12 +2,13 @@ use std::collections::{BTreeSet, HashMap};
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
 use gray_matter::{Matter, ParsedEntity, engine::YAML};
 use serde::{Deserialize, Serialize};
 
+const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 const GENERATED_DIR: &str = ".oh/adr-validation";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -350,27 +351,30 @@ pub fn validate(
                 continue;
             }
 
-            let output = Command::new("cargo")
+            let mut command = Command::new("cargo");
+            command
                 .arg("test")
                 .args(cargo_args)
                 .arg(test_name)
                 .arg("--")
                 .arg("--exact")
-                .current_dir(repo_root)
-                .output()
+                .current_dir(repo_root);
+            let output = run_command_with_timeout(&mut command, COMMAND_TIMEOUT)
                 .with_context(|| format!("running cargo test {}", test_name))?;
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
             let ran_exact_test =
                 stdout.contains("running 1 test") || stderr.contains("running 1 test");
-            let ok = output.status.success() && ran_exact_test;
+            let ok = output.success && ran_exact_test;
             checks.push(CheckExecution {
                 kind: "cargo_test".to_string(),
                 target: test_name.clone(),
                 ok,
                 details: if ok {
                     "passed".to_string()
-                } else if output.status.success() {
+                } else if output.timed_out {
+                    format!("timed out after {}s", COMMAND_TIMEOUT.as_secs())
+                } else if output.success {
                     "command succeeded but did not run exactly one test".to_string()
                 } else {
                     summarize_command_output(&stdout, &stderr)
@@ -473,6 +477,62 @@ pub fn validate(
         failed,
         results,
     })
+}
+
+#[derive(Debug)]
+struct TimedCommandOutput {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    success: bool,
+    timed_out: bool,
+}
+
+fn run_command_with_timeout(
+    command: &mut Command,
+    timeout: std::time::Duration,
+) -> Result<TimedCommandOutput> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawning child process")?;
+    let start = std::time::Instant::now();
+
+    loop {
+        if child.try_wait().context("polling child process")?.is_some() {
+            let output = child
+                .wait_with_output()
+                .context("collecting child process output")?;
+            return Ok(TimedCommandOutput {
+                stdout: output.stdout,
+                stderr: output.stderr,
+                success: output.status.success(),
+                timed_out: false,
+            });
+        }
+
+        if start.elapsed() >= timeout {
+            let _ = child.kill();
+            let output = child
+                .wait_with_output()
+                .context("collecting timed-out child output")?;
+            let mut stderr = output.stderr;
+            if !stderr.is_empty() && !stderr.ends_with(b"\n") {
+                stderr.push(b'\n');
+            }
+            stderr.extend_from_slice(
+                format!("command timed out after {}s", timeout.as_secs()).as_bytes(),
+            );
+            return Ok(TimedCommandOutput {
+                stdout: output.stdout,
+                stderr,
+                success: false,
+                timed_out: true,
+            });
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
 }
 
 pub fn run_audit(repo_root: &Path, name: &str) -> Result<AuditReport> {
@@ -834,9 +894,16 @@ fn audit_graph_state_uses_arcswap(repo_root: &Path) -> Result<AuditReport> {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let uses_arcswap = non_comment.contains("pub graph: Arc<ArcSwap<Option<Arc<GraphState>>>>");
-    let still_has_rwlock = non_comment.contains("Arc<RwLock<Option<GraphState>>>")
-        || non_comment.contains("RwLock<Option<GraphState>>");
+    let uses_arcswap = regex::Regex::new(
+        r"pub\s+graph\s*:\s*Arc\s*<\s*ArcSwap\s*<\s*Option\s*<\s*Arc\s*<\s*GraphState\s*>\s*>\s*>\s*>",
+    )
+    .unwrap()
+    .is_match(&non_comment);
+    let still_has_rwlock = regex::Regex::new(
+        r"Arc\s*<\s*RwLock\s*<\s*Option\s*<\s*GraphState\s*>\s*>\s*>|RwLock\s*<\s*Option\s*<\s*GraphState\s*>\s*>",
+    )
+    .unwrap()
+    .is_match(&non_comment);
 
     Ok(AuditReport {
         name: "graph_state_uses_arcswap".to_string(),

--- a/src/code/minify.rs
+++ b/src/code/minify.rs
@@ -399,7 +399,7 @@ fn minify_with_ast(
     collect_references(body_node, source, &locals, &mut rename_ranges, config);
 
     // Sort descending by start, deduplicate
-    rename_ranges.sort_by(|a, b| b.0.cmp(&a.0));
+    rename_ranges.sort_by_key(|range| std::cmp::Reverse(range.0));
     rename_ranges.dedup_by_key(|r| r.0);
 
     let mut result = source_text.clone();
@@ -1075,7 +1075,10 @@ fn collect_gdscript_locals(
     }
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32) {
-            if child.kind() == "function_definition" || child.kind() == "class_definition" || child.kind() == "lambda" {
+            if child.kind() == "function_definition"
+                || child.kind() == "class_definition"
+                || child.kind() == "lambda"
+            {
                 continue;
             }
             collect_gdscript_locals(child, source, locals, ranges, used);
@@ -1111,10 +1114,7 @@ fn minify_text(body: &str, language: &str) -> String {
         }
 
         // String-aware block comment removal: skip `/* */` inside string literals.
-        loop {
-            let Some(start) = find_outside_strings(&line, "/*") else {
-                break;
-            };
+        while let Some(start) = find_outside_strings(&line, "/*") {
             if let Some(rel_end) = line[start..].find("*/") {
                 line = format!("{}{}", &line[..start], &line[start + rel_end + 2..]);
             } else {
@@ -1372,8 +1372,15 @@ mod tests {
             "userCount should be renamed: {}",
             code
         );
-        let legend = result.lines().find(|l| l.starts_with("// ")).expect("should have legend");
-        assert!(legend.contains("userCount"), "legend should mention userCount: {}", legend);
+        let legend = result
+            .lines()
+            .find(|l| l.starts_with("// "))
+            .expect("should have legend");
+        assert!(
+            legend.contains("userCount"),
+            "legend should mention userCount: {}",
+            legend
+        );
     }
 
     #[test]
@@ -1387,14 +1394,22 @@ mod tests {
     fn test_csharp_preserves_member_access() {
         let input = "var result = obj.PropertyName;\nreturn result;";
         let result = minify_body(input, "csharp");
-        assert!(result.contains("PropertyName"), "property should be preserved: {}", result);
+        assert!(
+            result.contains("PropertyName"),
+            "property should be preserved: {}",
+            result
+        );
     }
 
     #[test]
     fn test_csharp_preserves_method_calls() {
         let input = "var data = FetchUserById(id);\nreturn data;";
         let result = minify_body(input, "csharp");
-        assert!(result.contains("FetchUserById"), "method name should be preserved: {}", result);
+        assert!(
+            result.contains("FetchUserById"),
+            "method name should be preserved: {}",
+            result
+        );
     }
 
     #[test]
@@ -1402,7 +1417,11 @@ mod tests {
         let input = "var longVariable = 42;\nConsole.WriteLine(longVariable);";
         let result = minify_body(input, "cs");
         let legend = result.lines().find(|l| l.starts_with("// "));
-        assert!(legend.is_some(), "cs alias should produce legend: {}", result);
+        assert!(
+            legend.is_some(),
+            "cs alias should produce legend: {}",
+            result
+        );
     }
 
     #[test]
@@ -1410,8 +1429,16 @@ mod tests {
         // Regression: minify_text must recognize '#' as gdscript comment prefix
         let input = "var x = 1  # set x\nvar y = 2";
         let result = minify_body(input, "gdscript");
-        assert!(!result.contains("set x"), "gdscript # comments should be stripped: {}", result);
-        assert!(result.contains("= 1"), "code should be preserved: {}", result);
+        assert!(
+            !result.contains("set x"),
+            "gdscript # comments should be stripped: {}",
+            result
+        );
+        assert!(
+            result.contains("= 1"),
+            "code should be preserved: {}",
+            result
+        );
     }
 
     #[test]
@@ -1421,7 +1448,11 @@ mod tests {
         let result = minify_body(input, "gdscript");
         // The output should not contain artificial wrapper-introduced tabs
         // (original code may have tabs, but wrapper shouldn't add new ones)
-        assert!(!result.starts_with('\t'), "output should not start with tab: {}", result);
+        assert!(
+            !result.starts_with('\t'),
+            "output should not start with tab: {}",
+            result
+        );
     }
 
     #[test]

--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -672,10 +672,12 @@ impl EnrichmentFinalizer {
             }
         }
 
-        // Step 9: ADR validation links — ADR frontmatter points directly at exact
-        // cargo test names, which resolve here to extracted test function nodes.
+        // Step 9: ADR validation links.
+        // - ADR frontmatter points directly at exact Rust cargo test names.
+        // - extracted test functions can reference ADRs back via doc comments.
         {
-            let new_edges = crate::extract::markdown::adr_validation_pass(&all_nodes);
+            let mut new_edges = crate::extract::markdown::adr_validation_pass(&all_nodes);
+            new_edges.extend(crate::extract::markdown::adr_backreference_pass(&all_nodes));
             if !new_edges.is_empty() {
                 all_edges.extend(new_edges);
             }

--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -499,9 +499,10 @@ impl ExtractionConsumer for SdkPathInferenceConsumer {
 /// 6. `openapi_sdk_link_pass` — links SDK functions to OpenAPI spec operations
 /// 7. `manifest_pass` — package.json / Cargo.toml dependency nodes
 /// 8. `tested_by_pass` — naming-convention test edges
-/// 9. `import_calls_pass` — resolves bare function calls via import nodes
-/// 10. `directory_module_pass` — directory-level module nodes
-/// 11. Framework-gated passes: `pubsub_pass`, `websocket_pass`, `nextjs_routing_pass`,
+/// 9. `adr_validation_pass` — ADR frontmatter -> exact test function edges
+/// 10. `import_calls_pass` — resolves bare function calls via import nodes
+/// 11. `directory_module_pass` — directory-level module nodes
+/// 12. Framework-gated passes: `pubsub_pass`, `websocket_pass`, `nextjs_routing_pass`,
 ///     `grpc_client_calls_pass`, `extractor_config_pass` — gate on detected_frameworks
 ///
 /// **Why passes run here, not in individual consumers:**
@@ -671,7 +672,16 @@ impl EnrichmentFinalizer {
             }
         }
 
-        // Step 9: import_calls — resolves bare function calls via import nodes.
+        // Step 9: ADR validation links — ADR frontmatter points directly at exact
+        // cargo test names, which resolve here to extracted test function nodes.
+        {
+            let new_edges = crate::extract::markdown::adr_validation_pass(&all_nodes);
+            if !new_edges.is_empty() {
+                all_edges.extend(new_edges);
+            }
+        }
+
+        // Step 10: import_calls — resolves bare function calls via import nodes.
         {
             let new_edges = crate::extract::import_calls::import_calls_pass(&all_nodes);
             if !new_edges.is_empty() {
@@ -679,7 +689,7 @@ impl EnrichmentFinalizer {
             }
         }
 
-        // Step 10: directory_module — directory-level module nodes.
+        // Step 11: directory_module — directory-level module nodes.
         {
             let result = crate::extract::directory_module::directory_module_pass(&all_nodes);
             if !result.nodes.is_empty() || !result.edges.is_empty() {
@@ -688,7 +698,7 @@ impl EnrichmentFinalizer {
             }
         }
 
-        // Step 11: framework-gated passes — run only when the relevant framework is detected.
+        // Step 12: framework-gated passes — run only when the relevant framework is detected.
         // pubsub
         if crate::extract::pubsub::should_run(&detected_frameworks) {
             let result = crate::extract::pubsub::pubsub_pass(

--- a/src/extract/event_bus.rs
+++ b/src/extract/event_bus.rs
@@ -993,6 +993,7 @@ mod tests {
         );
     }
 
+    /// ADR-ID: 001-event-bus-extraction-pipeline
     #[tokio::test]
     async fn test_follow_on_events_are_routed() {
         // EmittingConsumer listens for RootDiscovered, emits RootExtracted.
@@ -1025,6 +1026,7 @@ mod tests {
         );
     }
 
+    /// ADR-ID: 001-event-bus-extraction-pipeline
     #[tokio::test]
     async fn test_depth_first_ordering() {
         // Emitter1 listens RootDiscovered → emits [RootExtracted, PassesComplete]
@@ -1150,6 +1152,7 @@ mod tests {
         assert_eq!(count_b.load(Ordering::Relaxed), 1);
     }
 
+    /// ADR-ID: 001-event-bus-extraction-pipeline
     /// Adversarial: a consumer registered BEFORE the emitter for a follow-on event
     /// must still receive that event (the bus routes ALL events including follow-ons).
     #[tokio::test]

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -20,7 +20,7 @@
 //! full 300-line traversal reimplementations.
 
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow::Result;
@@ -451,6 +451,26 @@ fn collect_nodes(
                 }
             }
 
+            let adr_refs = if node_kind == NodeKind::Function
+                && metadata.get("is_test").map(|s| s.as_str()) == Some("true")
+            {
+                let refs = metadata
+                    .get("doc_comment")
+                    .map(|doc| parse_adr_refs(doc))
+                    .unwrap_or_default();
+                if !refs.is_empty() {
+                    let joined = refs
+                        .iter()
+                        .map(|p| p.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    metadata.insert("adr_refs".to_string(), joined);
+                }
+                refs
+            } else {
+                Vec::new()
+            };
+
             // Generic type parameter extraction.
             if let Some(tp_kind) = config.type_param_node_kind {
                 for i in 0..node.child_count() {
@@ -559,13 +579,15 @@ fn collect_nodes(
                 None
             };
 
+            let node_id = NodeId {
+                root: String::new(),
+                file: path.to_path_buf(),
+                name: name.clone(),
+                kind: node_kind.clone(),
+            };
+
             nodes.push(Node {
-                id: NodeId {
-                    root: String::new(),
-                    file: path.to_path_buf(),
-                    name: name.clone(),
-                    kind: node_kind.clone(),
-                },
+                id: node_id.clone(),
                 language: config.language_name.to_string(),
                 line_start,
                 line_end,
@@ -577,6 +599,26 @@ fn collect_nodes(
 
             if let Some(edge) = import_edge {
                 edges.push(edge);
+            }
+
+            for adr_path in &adr_refs {
+                let adr_name = adr_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                edges.push(Edge {
+                    from: node_id.clone(),
+                    to: NodeId {
+                        root: String::new(),
+                        file: adr_path.clone(),
+                        name: adr_name,
+                        kind: NodeKind::MarkdownSection,
+                    },
+                    kind: EdgeKind::References,
+                    source: ExtractionSource::TreeSitter,
+                    confidence: Confidence::Detected,
+                });
             }
 
             // Function parameter/return type DependsOn edges (config-driven).
@@ -1238,6 +1280,68 @@ fn collect_doc_comment(node: tree_sitter::Node, source: &[u8], config: &LangConf
     comment_lines.join(" ")
 }
 
+fn parse_adr_refs(doc_comment: &str) -> Vec<PathBuf> {
+    let mut refs = Vec::new();
+    let tokens: Vec<&str> = doc_comment.split_whitespace().collect();
+
+    for (i, token) in tokens.iter().enumerate() {
+        if let Some(path) = token.strip_prefix("ADR:") {
+            if let Some(parsed) = normalize_adr_ref(path, false) {
+                refs.push(parsed);
+                continue;
+            }
+            if let Some(next) = tokens.get(i + 1)
+                && let Some(parsed) = normalize_adr_ref(next, false)
+            {
+                refs.push(parsed);
+            }
+            continue;
+        }
+
+        if let Some(id) = token.strip_prefix("ADR-ID:") {
+            if let Some(parsed) = normalize_adr_ref(id, true) {
+                refs.push(parsed);
+                continue;
+            }
+            if let Some(next) = tokens.get(i + 1)
+                && let Some(parsed) = normalize_adr_ref(next, true)
+            {
+                refs.push(parsed);
+            }
+        }
+    }
+
+    let mut deduped = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for path in refs {
+        if seen.insert(path.clone()) {
+            deduped.push(path);
+        }
+    }
+    deduped
+}
+
+fn normalize_adr_ref(raw: &str, is_id: bool) -> Option<PathBuf> {
+    let trimmed = raw
+        .trim()
+        .trim_matches(|c: char| matches!(c, '"' | '\'' | '`' | '(' | ')' | '[' | ']'))
+        .trim_end_matches([',', ';', '.']);
+
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if is_id {
+        return Some(PathBuf::from("docs/ADRs").join(format!("{}.md", trimmed)));
+    }
+
+    if !trimmed.ends_with(".md") {
+        return None;
+    }
+
+    Some(PathBuf::from(trimmed))
+}
+
 /// Strip comment markers from a raw comment string.
 ///
 /// Removes `///`, `//!`, `//`, `/**`, `*/`, `*`, `#` (Python/shell),
@@ -1628,11 +1732,7 @@ fn run_route_queries(
                 continue;
             }
 
-            let http_path = capture
-                .get("path")
-                .map(strip_quotes)
-                .unwrap_or_default();
-
+            let http_path = capture.get("path").map(strip_quotes).unwrap_or_default();
             let method = if let Some(m) = capture.get("method") {
                 infer_method_from_name(m, cfg.default_method)
             } else if let Some(n) = capture.get("name") {
@@ -4759,7 +4859,10 @@ pub fn init() {}
         // The //! comment should at minimum not crash and not be silently dropped
         // (It may or may not attach to init() depending on sibling walk direction,
         // but the prefix gate must not reject it)
-        assert!(result.nodes.iter().any(|n| n.id.name == "init"), "should find init function");
+        assert!(
+            result.nodes.iter().any(|n| n.id.name == "init"),
+            "should find init function"
+        );
     }
 
     #[test]
@@ -5170,22 +5273,46 @@ class ItemsController {
 
         // Bare @Get() should have empty http_path
         let get_node = api_nodes.iter().find(|n| {
-            n.metadata.get("http_method").map(|m| m == "GET").unwrap_or(false)
-                && n.metadata.get("http_path").map(|p| p.is_empty()).unwrap_or(false)
+            n.metadata
+                .get("http_method")
+                .map(|m| m == "GET")
+                .unwrap_or(false)
+                && n.metadata
+                    .get("http_path")
+                    .map(|p| p.is_empty())
+                    .unwrap_or(false)
         });
-        assert!(get_node.is_some(), "should have GET endpoint with empty path");
+        assert!(
+            get_node.is_some(),
+            "should have GET endpoint with empty path"
+        );
 
         // Bare @Post() should have empty http_path
         let post_node = api_nodes.iter().find(|n| {
-            n.metadata.get("http_method").map(|m| m == "POST").unwrap_or(false)
-                && n.metadata.get("http_path").map(|p| p.is_empty()).unwrap_or(false)
+            n.metadata
+                .get("http_method")
+                .map(|m| m == "POST")
+                .unwrap_or(false)
+                && n.metadata
+                    .get("http_path")
+                    .map(|p| p.is_empty())
+                    .unwrap_or(false)
         });
-        assert!(post_node.is_some(), "should have POST endpoint with empty path");
+        assert!(
+            post_node.is_some(),
+            "should have POST endpoint with empty path"
+        );
 
         // Explicit @Delete("/items/:id") should still work
         let delete_node = api_nodes.iter().find(|n| {
-            n.metadata.get("http_method").map(|m| m == "DELETE").unwrap_or(false)
-                && n.metadata.get("http_path").map(|p| p == "/items/:id").unwrap_or(false)
+            n.metadata
+                .get("http_method")
+                .map(|m| m == "DELETE")
+                .unwrap_or(false)
+                && n.metadata
+                    .get("http_path")
+                    .map(|p| p == "/items/:id")
+                    .unwrap_or(false)
         });
         assert!(
             delete_node.is_some(),
@@ -5223,7 +5350,10 @@ def create_item():
 
         // Bare @app.get() should have empty http_path
         let bare_node = api_nodes.iter().find(|n| {
-            n.metadata.get("http_path").map(|p| p.is_empty()).unwrap_or(false)
+            n.metadata
+                .get("http_path")
+                .map(|p| p.is_empty())
+                .unwrap_or(false)
         });
         assert!(bare_node.is_some(), "should have endpoint with empty path");
         assert_eq!(
@@ -5270,22 +5400,46 @@ public class ItemController {
 
         // @GetMapping (marker annotation, no parens) should have empty path
         let get_node = api_nodes.iter().find(|n| {
-            n.metadata.get("http_method").map(|m| m == "GET").unwrap_or(false)
-                && n.metadata.get("http_path").map(|p| p.is_empty()).unwrap_or(false)
+            n.metadata
+                .get("http_method")
+                .map(|m| m == "GET")
+                .unwrap_or(false)
+                && n.metadata
+                    .get("http_path")
+                    .map(|p| p.is_empty())
+                    .unwrap_or(false)
         });
-        assert!(get_node.is_some(), "should have GET endpoint with empty path");
+        assert!(
+            get_node.is_some(),
+            "should have GET endpoint with empty path"
+        );
 
         // @PostMapping() (empty args) should have empty path
         let post_node = api_nodes.iter().find(|n| {
-            n.metadata.get("http_method").map(|m| m == "POST").unwrap_or(false)
-                && n.metadata.get("http_path").map(|p| p.is_empty()).unwrap_or(false)
+            n.metadata
+                .get("http_method")
+                .map(|m| m == "POST")
+                .unwrap_or(false)
+                && n.metadata
+                    .get("http_path")
+                    .map(|p| p.is_empty())
+                    .unwrap_or(false)
         });
-        assert!(post_node.is_some(), "should have POST endpoint with empty path");
+        assert!(
+            post_node.is_some(),
+            "should have POST endpoint with empty path"
+        );
 
         // @DeleteMapping("/items/{id}") should still work
         let delete_node = api_nodes.iter().find(|n| {
-            n.metadata.get("http_method").map(|m| m == "DELETE").unwrap_or(false)
-                && n.metadata.get("http_path").map(|p| p == "/items/{id}").unwrap_or(false)
+            n.metadata
+                .get("http_method")
+                .map(|m| m == "DELETE")
+                .unwrap_or(false)
+                && n.metadata
+                    .get("http_path")
+                    .map(|p| p == "/items/{id}")
+                    .unwrap_or(false)
         });
         assert!(
             delete_node.is_some(),
@@ -5322,25 +5476,42 @@ public class UserController {
             api_nodes.len(),
             2,
             "should emit 2 ApiEndpoint nodes, got: {:?}",
-            api_nodes.iter().map(|n| (&n.id.name, n.metadata.get("http_path"))).collect::<Vec<_>>()
+            api_nodes
+                .iter()
+                .map(|n| (&n.id.name, n.metadata.get("http_path")))
+                .collect::<Vec<_>>()
         );
 
         let get_node = api_nodes.iter().find(|n| {
-            n.metadata.get("http_method").map(|m| m == "GET").unwrap_or(false)
+            n.metadata
+                .get("http_method")
+                .map(|m| m == "GET")
+                .unwrap_or(false)
         });
         assert!(get_node.is_some(), "should have GET endpoint");
         assert_eq!(
-            get_node.unwrap().metadata.get("http_path").map(|s| s.as_str()),
+            get_node
+                .unwrap()
+                .metadata
+                .get("http_path")
+                .map(|s| s.as_str()),
             Some("/users"),
             "GET endpoint path should be /users from named arg"
         );
 
         let post_node = api_nodes.iter().find(|n| {
-            n.metadata.get("http_method").map(|m| m == "POST").unwrap_or(false)
+            n.metadata
+                .get("http_method")
+                .map(|m| m == "POST")
+                .unwrap_or(false)
         });
         assert!(post_node.is_some(), "should have POST endpoint");
         assert_eq!(
-            post_node.unwrap().metadata.get("http_path").map(|s| s.as_str()),
+            post_node
+                .unwrap()
+                .metadata
+                .get("http_path")
+                .map(|s| s.as_str()),
             Some("/items"),
             "POST endpoint path should be /items from value= arg"
         );
@@ -5684,6 +5855,98 @@ fn not_a_test() {}
         assert!(
             not_test.metadata.get("is_test").is_none(),
             "production function should NOT have is_test metadata"
+        );
+    }
+
+    #[test]
+    fn test_test_function_doc_comment_references_adr_path() {
+        use crate::extract::rust::RUST_CONFIG;
+        let code = r#"
+/// ADR: docs/ADRs/002-arcswap-graph-concurrency.md
+/// Validates consistent snapshots.
+#[test]
+fn my_test() {}
+"#;
+        let result = GenericExtractor::new(&RUST_CONFIG)
+            .run(Path::new("test.rs"), code)
+            .unwrap();
+
+        let test_fn = result
+            .nodes
+            .iter()
+            .find(|n| n.id.name == "my_test")
+            .unwrap();
+        assert_eq!(
+            test_fn.metadata.get("adr_refs").map(|s| s.as_str()),
+            Some("docs/ADRs/002-arcswap-graph-concurrency.md")
+        );
+
+        let refs: Vec<_> = result
+            .edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::References && e.from.name == "my_test")
+            .collect();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(
+            refs[0].to.file,
+            PathBuf::from("docs/ADRs/002-arcswap-graph-concurrency.md")
+        );
+    }
+
+    #[test]
+    fn test_test_function_doc_comment_references_adr_id() {
+        use crate::extract::rust::RUST_CONFIG;
+        let code = r#"
+/// ADR-ID: 001-event-bus-extraction-pipeline
+#[tokio::test]
+async fn my_async_test() {}
+"#;
+        let result = GenericExtractor::new(&RUST_CONFIG)
+            .run(Path::new("test.rs"), code)
+            .unwrap();
+
+        let refs: Vec<_> = result
+            .edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::References && e.from.name == "my_async_test")
+            .collect();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(
+            refs[0].to.file,
+            PathBuf::from("docs/ADRs/001-event-bus-extraction-pipeline.md")
+        );
+    }
+
+    #[test]
+    fn test_non_test_function_doc_comment_does_not_emit_adr_reference() {
+        use crate::extract::rust::RUST_CONFIG;
+        let code = r#"
+/// ADR: docs/ADRs/002-arcswap-graph-concurrency.md
+fn helper() {}
+"#;
+        let result = GenericExtractor::new(&RUST_CONFIG)
+            .run(Path::new("lib.rs"), code)
+            .unwrap();
+
+        assert!(
+            !result
+                .edges
+                .iter()
+                .any(|e| e.kind == EdgeKind::References && e.from.name == "helper")
+        );
+    }
+
+    #[test]
+    fn test_parse_adr_refs_supports_path_and_id() {
+        let refs = parse_adr_refs(
+            "ADR: docs/ADRs/002-arcswap-graph-concurrency.md ADR-ID: 001-event-bus-extraction-pipeline",
+        );
+        assert_eq!(
+            refs,
+            vec![
+                PathBuf::from("docs/ADRs/002-arcswap-graph-concurrency.md"),
+                PathBuf::from("docs/ADRs/001-event-bus-extraction-pipeline.md"),
+            ]
         );
     }
 

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -451,7 +451,7 @@ fn collect_nodes(
                 }
             }
 
-            let adr_refs = if node_kind == NodeKind::Function
+            if node_kind == NodeKind::Function
                 && metadata.get("is_test").map(|s| s.as_str()) == Some("true")
             {
                 let refs = metadata
@@ -466,10 +466,7 @@ fn collect_nodes(
                         .join(", ");
                     metadata.insert("adr_refs".to_string(), joined);
                 }
-                refs
-            } else {
-                Vec::new()
-            };
+            }
 
             // Generic type parameter extraction.
             if let Some(tp_kind) = config.type_param_node_kind {
@@ -599,26 +596,6 @@ fn collect_nodes(
 
             if let Some(edge) = import_edge {
                 edges.push(edge);
-            }
-
-            for adr_path in &adr_refs {
-                let adr_name = adr_path
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                edges.push(Edge {
-                    from: node_id.clone(),
-                    to: NodeId {
-                        root: String::new(),
-                        file: adr_path.clone(),
-                        name: adr_name,
-                        kind: NodeKind::MarkdownSection,
-                    },
-                    kind: EdgeKind::References,
-                    source: ExtractionSource::TreeSitter,
-                    confidence: Confidence::Detected,
-                });
             }
 
             // Function parameter/return type DependsOn edges (config-driven).
@@ -5880,16 +5857,12 @@ fn my_test() {}
             test_fn.metadata.get("adr_refs").map(|s| s.as_str()),
             Some("docs/ADRs/002-arcswap-graph-concurrency.md")
         );
-
-        let refs: Vec<_> = result
-            .edges
-            .iter()
-            .filter(|e| e.kind == EdgeKind::References && e.from.name == "my_test")
-            .collect();
-        assert_eq!(refs.len(), 1);
-        assert_eq!(
-            refs[0].to.file,
-            PathBuf::from("docs/ADRs/002-arcswap-graph-concurrency.md")
+        assert!(
+            !result
+                .edges
+                .iter()
+                .any(|e| e.kind == EdgeKind::References && e.from.name == "my_test"),
+            "generic extraction should record ADR refs but defer real markdown edges to the markdown pass"
         );
     }
 
@@ -5905,15 +5878,20 @@ async fn my_async_test() {}
             .run(Path::new("test.rs"), code)
             .unwrap();
 
-        let refs: Vec<_> = result
-            .edges
+        let test_fn = result
+            .nodes
             .iter()
-            .filter(|e| e.kind == EdgeKind::References && e.from.name == "my_async_test")
-            .collect();
-        assert_eq!(refs.len(), 1);
+            .find(|n| n.id.name == "my_async_test")
+            .unwrap();
         assert_eq!(
-            refs[0].to.file,
-            PathBuf::from("docs/ADRs/001-event-bus-extraction-pipeline.md")
+            test_fn.metadata.get("adr_refs").map(|s| s.as_str()),
+            Some("docs/ADRs/001-event-bus-extraction-pipeline.md")
+        );
+        assert!(
+            !result
+                .edges
+                .iter()
+                .any(|e| e.kind == EdgeKind::References && e.from.name == "my_async_test")
         );
     }
 

--- a/src/extract/go.rs
+++ b/src/extract/go.rs
@@ -280,7 +280,7 @@ fn extract_go_const_spec(
             vec![None; names.len()]
         };
 
-    for (name_str, value_opt) in names.into_iter().zip(per_name_values.into_iter()) {
+    for (name_str, value_opt) in names.into_iter().zip(per_name_values) {
         let signature = format!("const {}", body.trim());
         let mut metadata = BTreeMap::new();
         if let Some(v) = value_opt {
@@ -358,7 +358,7 @@ fn extract_go_var_spec(node: tree_sitter::Node, path: &Path, source: &[u8], node
             vec![None; names.len()]
         };
 
-    for (name_str, value_opt) in names.into_iter().zip(per_name_values.into_iter()) {
+    for (name_str, value_opt) in names.into_iter().zip(per_name_values) {
         let signature = format!("var {}", body.trim());
         let mut metadata = BTreeMap::new();
         metadata.insert("storage".to_string(), "var".to_string());

--- a/src/extract/markdown.rs
+++ b/src/extract/markdown.rs
@@ -3,10 +3,11 @@
 //! Reuses the existing `pulldown-cmark` parsing from `src/markdown/mod.rs`
 //! but produces graph `Node` types for the unified graph model.
 //!
-//! Emits three kinds of edges:
+//! Emits four kinds of edges:
 //! - **Hierarchy (Defines):** parent heading section -> child heading section
 //! - **Frontmatter refs (DependsOn):** .oh/ artifact -> referenced outcome/signal/guardrail
 //! - **Cross-file links (References):** section containing `[text](path)` -> target file
+//! - **ADR validation links (References):** ADR section -> exact test function declared in frontmatter
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -350,6 +351,89 @@ fn emit_link_edges(
     }
 }
 
+/// Emit `References` edges from ADR markdown to exact test functions declared in
+/// ADR frontmatter (`validate.cargo_tests`).
+///
+/// The frontmatter stores exact `cargo test -- --list` names, which include module
+/// paths. Extracted test nodes only store the leaf function name, so resolution uses
+/// the final `::segment` and only links when that leaf resolves unambiguously to a
+/// single test function node.
+pub fn adr_validation_pass(all_nodes: &[Node]) -> Vec<Edge> {
+    let mut test_nodes: BTreeMap<&str, Vec<&Node>> = BTreeMap::new();
+    for node in all_nodes {
+        if node.id.kind == NodeKind::Function
+            && node.metadata.get("is_test").map(|value| value.as_str()) == Some("true")
+        {
+            test_nodes
+                .entry(node.id.name.as_str())
+                .or_default()
+                .push(node);
+        }
+    }
+
+    let mut primary_markdown_nodes: BTreeMap<&Path, &NodeId> = BTreeMap::new();
+    let mut frontmatter_nodes = Vec::new();
+    for node in all_nodes {
+        if node.id.kind != NodeKind::MarkdownSection {
+            continue;
+        }
+        if node
+            .metadata
+            .get("is_frontmatter")
+            .map(|value| value.as_str())
+            == Some("true")
+        {
+            frontmatter_nodes.push(node);
+        } else {
+            primary_markdown_nodes
+                .entry(node.id.file.as_path())
+                .or_insert(&node.id);
+        }
+    }
+
+    let mut edges = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for node in frontmatter_nodes {
+        let frontmatter: crate::adr::AdrValidationRefs =
+            match serde_yaml::from_str::<serde_yaml::Value>(&node.body) {
+                Ok(value) => match value.get("validate") {
+                    Some(validate) => serde_yaml::from_value(validate.clone()).unwrap_or_default(),
+                    None => continue,
+                },
+                Err(_) => continue,
+            };
+
+        let source_id = primary_markdown_nodes
+            .get(node.id.file.as_path())
+            .copied()
+            .unwrap_or(&node.id);
+
+        for cargo_test in frontmatter.cargo_tests {
+            let leaf = cargo_test.rsplit("::").next().unwrap_or(&cargo_test);
+            let Some(matches) = test_nodes.get(leaf) else {
+                continue;
+            };
+            if matches.len() != 1 {
+                continue;
+            }
+            let target_id = &matches[0].id;
+            let edge_key = format!("{}->{}", source_id.to_stable_id(), target_id.to_stable_id());
+            if !seen.insert(edge_key) {
+                continue;
+            }
+            edges.push(Edge {
+                from: (*source_id).clone(),
+                to: target_id.clone(),
+                kind: EdgeKind::References,
+                source: ExtractionSource::Markdown,
+                confidence: Confidence::Confirmed,
+            });
+        }
+    }
+
+    edges
+}
+
 /// Normalize a path by resolving `.` and `..` components without filesystem access.
 /// Preserves leading `..` segments when there is nothing left to pop (out-of-repo links).
 /// Never pops past a root directory or prefix component.
@@ -502,6 +586,7 @@ fn parse_markdown_file_from_source(source: &str, path: &Path) -> Vec<crate::type
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::graph::{ExtractionSource, Node, NodeId, NodeKind};
     use std::path::Path;
 
     #[test]
@@ -1240,6 +1325,130 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_adr_validation_pass_links_frontmatter_to_exact_test() {
+        let adr_frontmatter = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("docs/ADRs/002-arcswap-graph-concurrency.md"),
+                name: "frontmatter".to_string(),
+                kind: NodeKind::MarkdownSection,
+            },
+            language: "markdown".to_string(),
+            line_start: 1,
+            line_end: 6,
+            signature: "[frontmatter]".to_string(),
+            body: "id: 002-arcswap-graph-concurrency\nstatus: implementing\nvalidate:\n  cargo_tests:\n    - server::tests::test_arcswap_readers_see_consistent_snapshots\n".to_string(),
+            metadata: BTreeMap::from([("is_frontmatter".to_string(), "true".to_string())]),
+            source: ExtractionSource::Markdown,
+        };
+        let adr_section = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("docs/ADRs/002-arcswap-graph-concurrency.md"),
+                name: "ArcSwap for graph concurrency".to_string(),
+                kind: NodeKind::MarkdownSection,
+            },
+            language: "markdown".to_string(),
+            line_start: 8,
+            line_end: 20,
+            signature: "ArcSwap for graph concurrency".to_string(),
+            body: "# ArcSwap for graph concurrency".to_string(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::Markdown,
+        };
+        let test_fn = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("src/server/mod.rs"),
+                name: "test_arcswap_readers_see_consistent_snapshots".to_string(),
+                kind: NodeKind::Function,
+            },
+            language: "rust".to_string(),
+            line_start: 1,
+            line_end: 10,
+            signature: "async fn test_arcswap_readers_see_consistent_snapshots()".to_string(),
+            body: String::new(),
+            metadata: BTreeMap::from([("is_test".to_string(), "true".to_string())]),
+            source: ExtractionSource::TreeSitter,
+        };
+
+        let edges = adr_validation_pass(&[adr_frontmatter, adr_section.clone(), test_fn.clone()]);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].from, adr_section.id);
+        assert_eq!(edges[0].to, test_fn.id);
+        assert_eq!(edges[0].kind, EdgeKind::References);
+    }
+
+    #[test]
+    fn test_adr_validation_pass_skips_ambiguous_test_leaf_names() {
+        let adr_frontmatter = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("docs/ADRs/001-event-bus-extraction-pipeline.md"),
+                name: "frontmatter".to_string(),
+                kind: NodeKind::MarkdownSection,
+            },
+            language: "markdown".to_string(),
+            line_start: 1,
+            line_end: 6,
+            signature: "[frontmatter]".to_string(),
+            body: "id: 001-event-bus-extraction-pipeline\nstatus: implemented\nvalidate:\n  cargo_tests:\n    - pkg::tests::duplicate_name\n".to_string(),
+            metadata: BTreeMap::from([("is_frontmatter".to_string(), "true".to_string())]),
+            source: ExtractionSource::Markdown,
+        };
+        let adr_section = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("docs/ADRs/001-event-bus-extraction-pipeline.md"),
+                name: "RNA Event Bus Architecture".to_string(),
+                kind: NodeKind::MarkdownSection,
+            },
+            language: "markdown".to_string(),
+            line_start: 8,
+            line_end: 20,
+            signature: "RNA Event Bus Architecture".to_string(),
+            body: "# RNA Event Bus Architecture".to_string(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::Markdown,
+        };
+        let test_a = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("src/a.rs"),
+                name: "duplicate_name".to_string(),
+                kind: NodeKind::Function,
+            },
+            language: "rust".to_string(),
+            line_start: 1,
+            line_end: 10,
+            signature: "fn duplicate_name()".to_string(),
+            body: String::new(),
+            metadata: BTreeMap::from([("is_test".to_string(), "true".to_string())]),
+            source: ExtractionSource::TreeSitter,
+        };
+        let test_b = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("src/b.rs"),
+                name: "duplicate_name".to_string(),
+                kind: NodeKind::Function,
+            },
+            language: "rust".to_string(),
+            line_start: 1,
+            line_end: 10,
+            signature: "fn duplicate_name()".to_string(),
+            body: String::new(),
+            metadata: BTreeMap::from([("is_test".to_string(), "true".to_string())]),
+            source: ExtractionSource::TreeSitter,
+        };
+
+        let edges = adr_validation_pass(&[adr_frontmatter, adr_section, test_a, test_b]);
+        assert!(
+            edges.is_empty(),
+            "ambiguous cargo test leaf names must not link"
+        );
+    }
     // --- Adversarial: agent memory detection boundary conditions ---
 
     #[test]

--- a/src/extract/markdown.rs
+++ b/src/extract/markdown.rs
@@ -9,7 +9,7 @@
 //! - **Cross-file links (References):** section containing `[text](path)` -> target file
 //! - **ADR validation links (References):** ADR section -> exact test function declared in frontmatter
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -358,8 +358,8 @@ fn emit_link_edges(
 /// against Rust test nodes via `metadata["test_path"]`. No leaf-name fallback: if
 /// the exact Rust test path is not present, no edge is emitted.
 pub fn adr_validation_pass(all_nodes: &[Node]) -> Vec<Edge> {
-    let mut rust_tests: BTreeMap<&str, Vec<&Node>> = BTreeMap::new();
-    let mut primary_markdown_nodes: BTreeMap<&Path, &NodeId> = BTreeMap::new();
+    let mut rust_tests: HashMap<&str, Vec<&Node>> = HashMap::new();
+    let mut primary_markdown_nodes: HashMap<&Path, &NodeId> = HashMap::new();
     let mut frontmatter_nodes = Vec::new();
 
     for node in all_nodes {
@@ -433,7 +433,7 @@ pub fn adr_validation_pass(all_nodes: &[Node]) -> Vec<Edge> {
 /// Emit `References` edges from extracted test functions back to ADR markdown nodes
 /// using `metadata["adr_refs"]` captured during code extraction.
 pub fn adr_backreference_pass(all_nodes: &[Node]) -> Vec<Edge> {
-    let mut primary_markdown_nodes: BTreeMap<&Path, &NodeId> = BTreeMap::new();
+    let mut primary_markdown_nodes: HashMap<&Path, &NodeId> = HashMap::new();
     for node in all_nodes {
         if node.id.kind == NodeKind::MarkdownSection
             && node

--- a/src/extract/markdown.rs
+++ b/src/extract/markdown.rs
@@ -351,29 +351,26 @@ fn emit_link_edges(
     }
 }
 
-/// Emit `References` edges from ADR markdown to exact test functions declared in
+/// Emit `References` edges from ADR markdown to exact Rust test functions declared in
 /// ADR frontmatter (`validate.cargo_tests`).
 ///
-/// The frontmatter stores exact `cargo test -- --list` names, which include module
-/// paths. Extracted test nodes only store the leaf function name, so resolution uses
-/// the final `::segment` and only links when that leaf resolves unambiguously to a
-/// single test function node.
+/// The frontmatter stores exact `cargo test -- --list` names, which we resolve
+/// against Rust test nodes via `metadata["test_path"]`. No leaf-name fallback: if
+/// the exact Rust test path is not present, no edge is emitted.
 pub fn adr_validation_pass(all_nodes: &[Node]) -> Vec<Edge> {
-    let mut test_nodes: BTreeMap<&str, Vec<&Node>> = BTreeMap::new();
-    for node in all_nodes {
-        if node.id.kind == NodeKind::Function
-            && node.metadata.get("is_test").map(|value| value.as_str()) == Some("true")
-        {
-            test_nodes
-                .entry(node.id.name.as_str())
-                .or_default()
-                .push(node);
-        }
-    }
-
+    let mut rust_tests: BTreeMap<&str, Vec<&Node>> = BTreeMap::new();
     let mut primary_markdown_nodes: BTreeMap<&Path, &NodeId> = BTreeMap::new();
     let mut frontmatter_nodes = Vec::new();
+
     for node in all_nodes {
+        if node.id.kind == NodeKind::Function
+            && node.language == "rust"
+            && node.metadata.get("is_test").map(|value| value.as_str()) == Some("true")
+            && let Some(test_path) = node.metadata.get("test_path")
+        {
+            rust_tests.entry(test_path.as_str()).or_default().push(node);
+        }
+
         if node.id.kind != NodeKind::MarkdownSection {
             continue;
         }
@@ -409,8 +406,7 @@ pub fn adr_validation_pass(all_nodes: &[Node]) -> Vec<Edge> {
             .unwrap_or(&node.id);
 
         for cargo_test in frontmatter.cargo_tests {
-            let leaf = cargo_test.rsplit("::").next().unwrap_or(&cargo_test);
-            let Some(matches) = test_nodes.get(leaf) else {
+            let Some(matches) = rust_tests.get(cargo_test.as_str()) else {
                 continue;
             };
             if matches.len() != 1 {
@@ -427,6 +423,61 @@ pub fn adr_validation_pass(all_nodes: &[Node]) -> Vec<Edge> {
                 kind: EdgeKind::References,
                 source: ExtractionSource::Markdown,
                 confidence: Confidence::Confirmed,
+            });
+        }
+    }
+
+    edges
+}
+
+/// Emit `References` edges from extracted test functions back to ADR markdown nodes
+/// using `metadata["adr_refs"]` captured during code extraction.
+pub fn adr_backreference_pass(all_nodes: &[Node]) -> Vec<Edge> {
+    let mut primary_markdown_nodes: BTreeMap<&Path, &NodeId> = BTreeMap::new();
+    for node in all_nodes {
+        if node.id.kind == NodeKind::MarkdownSection
+            && node
+                .metadata
+                .get("is_frontmatter")
+                .map(|value| value.as_str())
+                != Some("true")
+        {
+            primary_markdown_nodes
+                .entry(node.id.file.as_path())
+                .or_insert(&node.id);
+        }
+    }
+
+    let mut edges = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for node in all_nodes {
+        if node.id.kind != NodeKind::Function
+            || node.metadata.get("is_test").map(|value| value.as_str()) != Some("true")
+        {
+            continue;
+        }
+        let Some(raw_refs) = node.metadata.get("adr_refs") else {
+            continue;
+        };
+
+        for adr_path in raw_refs
+            .split(',')
+            .map(|value| PathBuf::from(value.trim()))
+            .filter(|p| !p.as_os_str().is_empty())
+        {
+            let Some(target_id) = primary_markdown_nodes.get(adr_path.as_path()) else {
+                continue;
+            };
+            let edge_key = format!("{}->{}", node.id.to_stable_id(), target_id.to_stable_id());
+            if !seen.insert(edge_key) {
+                continue;
+            }
+            edges.push(Edge {
+                from: node.id.clone(),
+                to: (*target_id).clone(),
+                kind: EdgeKind::References,
+                source: ExtractionSource::TreeSitter,
+                confidence: Confidence::Detected,
             });
         }
     }
@@ -1326,7 +1377,7 @@ mod tests {
     }
 
     #[test]
-    fn test_adr_validation_pass_links_frontmatter_to_exact_test() {
+    fn test_adr_validation_pass_links_frontmatter_to_exact_rust_test_path() {
         let adr_frontmatter = Node {
             id: NodeId {
                 root: String::new(),
@@ -1357,7 +1408,7 @@ mod tests {
             metadata: BTreeMap::new(),
             source: ExtractionSource::Markdown,
         };
-        let test_fn = Node {
+        let rust_test = Node {
             id: NodeId {
                 root: String::new(),
                 file: PathBuf::from("src/server/mod.rs"),
@@ -1369,19 +1420,45 @@ mod tests {
             line_end: 10,
             signature: "async fn test_arcswap_readers_see_consistent_snapshots()".to_string(),
             body: String::new(),
+            metadata: BTreeMap::from([
+                ("is_test".to_string(), "true".to_string()),
+                (
+                    "test_path".to_string(),
+                    "server::tests::test_arcswap_readers_see_consistent_snapshots".to_string(),
+                ),
+            ]),
+            source: ExtractionSource::TreeSitter,
+        };
+        let python_test_same_leaf = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("tests/test_server.py"),
+                name: "test_arcswap_readers_see_consistent_snapshots".to_string(),
+                kind: NodeKind::Function,
+            },
+            language: "python".to_string(),
+            line_start: 1,
+            line_end: 5,
+            signature: "def test_arcswap_readers_see_consistent_snapshots()".to_string(),
+            body: String::new(),
             metadata: BTreeMap::from([("is_test".to_string(), "true".to_string())]),
             source: ExtractionSource::TreeSitter,
         };
 
-        let edges = adr_validation_pass(&[adr_frontmatter, adr_section.clone(), test_fn.clone()]);
+        let edges = adr_validation_pass(&[
+            adr_frontmatter,
+            adr_section.clone(),
+            rust_test.clone(),
+            python_test_same_leaf,
+        ]);
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].from, adr_section.id);
-        assert_eq!(edges[0].to, test_fn.id);
+        assert_eq!(edges[0].to, rust_test.id);
         assert_eq!(edges[0].kind, EdgeKind::References);
     }
 
     #[test]
-    fn test_adr_validation_pass_skips_ambiguous_test_leaf_names() {
+    fn test_adr_validation_pass_skips_when_exact_test_path_missing() {
         let adr_frontmatter = Node {
             id: NodeId {
                 root: String::new(),
@@ -1393,7 +1470,7 @@ mod tests {
             line_start: 1,
             line_end: 6,
             signature: "[frontmatter]".to_string(),
-            body: "id: 001-event-bus-extraction-pipeline\nstatus: implemented\nvalidate:\n  cargo_tests:\n    - pkg::tests::duplicate_name\n".to_string(),
+            body: "id: 001-event-bus-extraction-pipeline\nstatus: implemented\nvalidate:\n  cargo_tests:\n    - extract::event_bus::tests::test_depth_first_ordering\n".to_string(),
             metadata: BTreeMap::from([("is_frontmatter".to_string(), "true".to_string())]),
             source: ExtractionSource::Markdown,
         };
@@ -1412,41 +1489,171 @@ mod tests {
             metadata: BTreeMap::new(),
             source: ExtractionSource::Markdown,
         };
-        let test_a = Node {
+        let rust_test_wrong_path = Node {
             id: NodeId {
                 root: String::new(),
-                file: PathBuf::from("src/a.rs"),
-                name: "duplicate_name".to_string(),
+                file: PathBuf::from("src/extract/event_bus.rs"),
+                name: "test_depth_first_ordering".to_string(),
                 kind: NodeKind::Function,
             },
             language: "rust".to_string(),
             line_start: 1,
             line_end: 10,
-            signature: "fn duplicate_name()".to_string(),
+            signature: "async fn test_depth_first_ordering()".to_string(),
             body: String::new(),
-            metadata: BTreeMap::from([("is_test".to_string(), "true".to_string())]),
-            source: ExtractionSource::TreeSitter,
-        };
-        let test_b = Node {
-            id: NodeId {
-                root: String::new(),
-                file: PathBuf::from("src/b.rs"),
-                name: "duplicate_name".to_string(),
-                kind: NodeKind::Function,
-            },
-            language: "rust".to_string(),
-            line_start: 1,
-            line_end: 10,
-            signature: "fn duplicate_name()".to_string(),
-            body: String::new(),
-            metadata: BTreeMap::from([("is_test".to_string(), "true".to_string())]),
+            metadata: BTreeMap::from([
+                ("is_test".to_string(), "true".to_string()),
+                (
+                    "test_path".to_string(),
+                    "other::tests::test_depth_first_ordering".to_string(),
+                ),
+            ]),
             source: ExtractionSource::TreeSitter,
         };
 
-        let edges = adr_validation_pass(&[adr_frontmatter, adr_section, test_a, test_b]);
+        let edges = adr_validation_pass(&[adr_frontmatter, adr_section, rust_test_wrong_path]);
         assert!(
             edges.is_empty(),
-            "ambiguous cargo test leaf names must not link"
+            "exact cargo test path must match test_path metadata"
+        );
+    }
+
+    #[test]
+    fn test_adr_backreference_pass_links_test_to_real_markdown_node() {
+        let adr_section = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("docs/ADRs/002-arcswap-graph-concurrency.md"),
+                name: "ArcSwap for graph concurrency".to_string(),
+                kind: NodeKind::MarkdownSection,
+            },
+            language: "markdown".to_string(),
+            line_start: 8,
+            line_end: 20,
+            signature: "ArcSwap for graph concurrency".to_string(),
+            body: "# ArcSwap for graph concurrency".to_string(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::Markdown,
+        };
+        let test_fn = Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("src/server/mod.rs"),
+                name: "test_arcswap_readers_see_consistent_snapshots".to_string(),
+                kind: NodeKind::Function,
+            },
+            language: "rust".to_string(),
+            line_start: 1,
+            line_end: 10,
+            signature: "async fn test_arcswap_readers_see_consistent_snapshots()".to_string(),
+            body: String::new(),
+            metadata: BTreeMap::from([
+                ("is_test".to_string(), "true".to_string()),
+                (
+                    "adr_refs".to_string(),
+                    "docs/ADRs/002-arcswap-graph-concurrency.md".to_string(),
+                ),
+            ]),
+            source: ExtractionSource::TreeSitter,
+        };
+
+        let edges = adr_backreference_pass(&[adr_section.clone(), test_fn.clone()]);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].from, test_fn.id);
+        assert_eq!(edges[0].to, adr_section.id);
+        assert_eq!(edges[0].kind, EdgeKind::References);
+    }
+
+    #[test]
+    fn timing_smoke_adr_passes_100k_nodes() {
+        use std::time::Instant;
+
+        let mut nodes = Vec::new();
+        for i in 0..100_000 {
+            nodes.push(Node {
+                id: NodeId {
+                    root: String::new(),
+                    file: PathBuf::from(format!("src/module_{i}.rs")),
+                    name: format!("symbol_{i}"),
+                    kind: NodeKind::Function,
+                },
+                language: "rust".to_string(),
+                line_start: 1,
+                line_end: 1,
+                signature: String::new(),
+                body: String::new(),
+                metadata: BTreeMap::new(),
+                source: ExtractionSource::TreeSitter,
+            });
+        }
+
+        nodes.push(Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("docs/ADRs/001-event-bus-extraction-pipeline.md"),
+                name: "frontmatter".to_string(),
+                kind: NodeKind::MarkdownSection,
+            },
+            language: "markdown".to_string(),
+            line_start: 1,
+            line_end: 6,
+            signature: "[frontmatter]".to_string(),
+            body: "id: 001-event-bus-extraction-pipeline\nstatus: implemented\nvalidate:\n  cargo_tests:\n    - extract::event_bus::tests::test_depth_first_ordering\n".to_string(),
+            metadata: BTreeMap::from([("is_frontmatter".to_string(), "true".to_string())]),
+            source: ExtractionSource::Markdown,
+        });
+        nodes.push(Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("docs/ADRs/001-event-bus-extraction-pipeline.md"),
+                name: "RNA Event Bus Architecture".to_string(),
+                kind: NodeKind::MarkdownSection,
+            },
+            language: "markdown".to_string(),
+            line_start: 8,
+            line_end: 20,
+            signature: String::new(),
+            body: String::new(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::Markdown,
+        });
+        nodes.push(Node {
+            id: NodeId {
+                root: String::new(),
+                file: PathBuf::from("src/extract/event_bus.rs"),
+                name: "test_depth_first_ordering".to_string(),
+                kind: NodeKind::Function,
+            },
+            language: "rust".to_string(),
+            line_start: 1,
+            line_end: 1,
+            signature: String::new(),
+            body: String::new(),
+            metadata: BTreeMap::from([
+                ("is_test".to_string(), "true".to_string()),
+                (
+                    "test_path".to_string(),
+                    "extract::event_bus::tests::test_depth_first_ordering".to_string(),
+                ),
+                (
+                    "adr_refs".to_string(),
+                    "docs/ADRs/001-event-bus-extraction-pipeline.md".to_string(),
+                ),
+            ]),
+            source: ExtractionSource::TreeSitter,
+        });
+
+        let start = Instant::now();
+        let forward = adr_validation_pass(&nodes);
+        let backward = adr_backreference_pass(&nodes);
+        let elapsed = start.elapsed();
+
+        assert_eq!(forward.len(), 1);
+        assert_eq!(backward.len(), 1);
+        assert!(
+            elapsed.as_secs() < 1,
+            "ADR passes on 100k nodes took {:?} — expected under 1s in debug mode",
+            elapsed
         );
     }
     // --- Adversarial: agent memory detection boundary conditions ---

--- a/src/extract/rust.rs
+++ b/src/extract/rust.rs
@@ -124,6 +124,10 @@ impl Extractor for RustExtractor {
         // Generic pass: function/struct/field/const/import/etc. + string literals.
         let mut result = GenericExtractor::new(&RUST_CONFIG).run(path, content)?;
 
+        // Rust-specific: enrich extracted test functions with exact `cargo test -- --list`
+        // style paths so ADR frontmatter can reference real tests unambiguously.
+        enrich_test_paths(path, &mut result.nodes);
+
         // Rust-specific: topology pattern detection (subprocess, network, async)
         // and static item metadata enrichment.
         let mut parser = tree_sitter::Parser::new();
@@ -140,6 +144,58 @@ impl Extractor for RustExtractor {
 
         Ok(result)
     }
+}
+
+fn enrich_test_paths(path: &Path, nodes: &mut [crate::graph::Node]) {
+    let base_segments = rust_module_segments(path);
+
+    for node in nodes.iter_mut() {
+        if node.id.kind != NodeKind::Function
+            || node.language != "rust"
+            || node.metadata.get("is_test").map(|value| value.as_str()) != Some("true")
+        {
+            continue;
+        }
+
+        let mut segments = base_segments.clone();
+        if let Some(scope) = node.metadata.get("parent_scope") {
+            let scope = scope.trim();
+            if !scope.is_empty()
+                && !scope.contains(" for ")
+                && segments.last().is_none_or(|last| last != scope)
+            {
+                segments.push(scope.to_string());
+            }
+        }
+        segments.push(node.id.name.clone());
+        node.metadata
+            .insert("test_path".to_string(), segments.join("::"));
+    }
+}
+
+fn rust_module_segments(path: &Path) -> Vec<String> {
+    let mut parts: Vec<String> = path
+        .iter()
+        .map(|part| part.to_string_lossy().to_string())
+        .collect();
+
+    if let Some(first) = parts.first()
+        && (first == "src" || first == "tests")
+    {
+        parts.remove(0);
+    }
+
+    if let Some(last) = parts.last_mut()
+        && last.ends_with(".rs")
+    {
+        *last = last.trim_end_matches(".rs").to_string();
+    }
+
+    if parts.last().is_some_and(|last| last == "mod") {
+        parts.pop();
+    }
+
+    parts.into_iter().filter(|part| !part.is_empty()).collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/graph/index.rs
+++ b/src/graph/index.rs
@@ -893,7 +893,7 @@ impl GraphIndex {
         }
 
         // Sort by symbol count descending
-        subsystems.sort_by(|a, b| b.symbol_count.cmp(&a.symbol_count));
+        subsystems.sort_by_key(|subsystem| std::cmp::Reverse(subsystem.symbol_count));
         subsystems
     }
 }
@@ -1278,7 +1278,7 @@ pub fn group_subsystems_by_prefix(subsystems: Vec<Subsystem>) -> Vec<Subsystem> 
     }
 
     // Sort by symbol count descending (matching detect_communities output order)
-    result.sort_by(|a, b| b.symbol_count.cmp(&a.symbol_count));
+    result.sort_by_key(|subsystem| std::cmp::Reverse(subsystem.symbol_count));
     result
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod adr;
 pub mod bootstrap;
 pub mod bus;
 pub mod code;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use rust_mcp_sdk::McpServer;
 use rust_mcp_sdk::ToMcpServerHandler;
 use rust_mcp_sdk::schema::{Implementation, InitializeResult, ServerCapabilities};
 
+use repo_native_alignment::adr::{self, ValidateSelection};
 use repo_native_alignment::roots::WorkspaceConfig;
 use repo_native_alignment::server::{self, RnaHandler};
 use repo_native_alignment::service::{
@@ -47,6 +48,8 @@ enum Commands {
     ListRoots(ListRootsCli),
     /// Show a high-level repository map
     RepoMap(RepoMapCli),
+    /// Compile or validate ADR executable declarations
+    Adr(AdrArgs),
     /// Open an interactive graph visualizer in the browser
     Open(OpenArgs),
 }
@@ -170,6 +173,57 @@ struct RepoMapCli {
     root: Option<String>,
     #[arg(long, default_value = ".")]
     repo: PathBuf,
+}
+
+#[derive(clap::Args, Debug)]
+struct AdrArgs {
+    #[command(subcommand)]
+    command: AdrCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum AdrCommand {
+    /// Compile ADR frontmatter into .oh/adr-validation manifests
+    Compile(AdrCompileArgs),
+    /// Execute compiled ADR validations and enforce status gating
+    Validate(AdrValidateArgs),
+    /// Run one built-in ADR audit by name
+    Audit(AdrAuditArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct AdrCompileArgs {
+    #[arg(long, default_value = ".")]
+    repo: PathBuf,
+    #[arg(long, default_value = "docs/ADRs")]
+    dir: PathBuf,
+    #[arg(long)]
+    check: bool,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+struct AdrValidateArgs {
+    #[arg(long, default_value = ".")]
+    repo: PathBuf,
+    #[arg(long)]
+    id: Option<String>,
+    #[arg(long)]
+    path: Option<PathBuf>,
+    #[arg(long = "cargo-arg", allow_hyphen_values = true)]
+    cargo_args: Vec<String>,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+struct AdrAuditArgs {
+    name: String,
+    #[arg(long, default_value = ".")]
+    repo: PathBuf,
+    #[arg(long)]
+    json: bool,
 }
 
 fn server_details() -> InitializeResult {
@@ -595,6 +649,56 @@ async fn async_main() -> anyhow::Result<()> {
             };
             println!("{}", service::repo_map(&params, &ctx));
             return Ok(());
+        }
+        Some(Commands::Adr(args)) => {
+            init_tracing("warn", log_path.as_deref());
+            match args.command {
+                AdrCommand::Compile(args) => {
+                    let repo_root = args.repo.canonicalize()?;
+                    let adr_dir = if args.dir.is_absolute() {
+                        args.dir.clone()
+                    } else {
+                        repo_root.join(&args.dir)
+                    };
+                    let report = adr::compile(&repo_root, &adr_dir, args.check)?;
+                    if args.json {
+                        println!("{}", serde_json::to_string_pretty(&report)?);
+                    } else {
+                        println!("{}", report.human_summary());
+                    }
+                    std::process::exit(if report.ok() { 0 } else { 2 });
+                }
+                AdrCommand::Validate(args) => {
+                    let repo_root = args.repo.canonicalize()?;
+                    let selection = ValidateSelection {
+                        id: args.id.clone(),
+                        source_path: args.path.clone().map(|path| {
+                            if path.is_absolute() {
+                                path
+                            } else {
+                                repo_root.join(path)
+                            }
+                        }),
+                    };
+                    let report = adr::validate(&repo_root, &selection, &args.cargo_args)?;
+                    if args.json {
+                        println!("{}", serde_json::to_string_pretty(&report)?);
+                    } else {
+                        println!("{}", report.human_summary());
+                    }
+                    std::process::exit(if report.ok() { 0 } else { 3 });
+                }
+                AdrCommand::Audit(args) => {
+                    let repo_root = args.repo.canonicalize()?;
+                    let report = adr::run_audit(&repo_root, &args.name)?;
+                    if args.json {
+                        println!("{}", serde_json::to_string_pretty(&report)?);
+                    } else {
+                        println!("{}", report.human_summary());
+                    }
+                    std::process::exit(if report.ok { 0 } else { 3 });
+                }
+            }
         }
         Some(Commands::Open(args)) => {
             init_tracing("warn", log_path.as_deref());

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -134,11 +134,9 @@ pub fn parse_markdown_source(source: &str, path: &Path) -> Vec<MarkdownChunk> {
                 current_link_text = String::new();
             }
 
-            Event::End(TagEnd::Link) => {
-                if in_link {
-                    current_links.push((current_link_text.clone(), current_link_dest.clone()));
-                    in_link = false;
-                }
+            Event::End(TagEnd::Link) if in_link => {
+                current_links.push((current_link_text.clone(), current_link_dest.clone()));
+                in_link = false;
             }
 
             Event::Text(text) => {
@@ -337,7 +335,7 @@ pub fn search_chunks<'a>(chunks: &'a [MarkdownChunk], query: &str) -> Vec<&'a Ma
         })
         .collect();
 
-    scored.sort_by(|a, b| b.1.cmp(&a.1));
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.1));
     scored.into_iter().map(|(chunk, _)| chunk).collect()
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -65,10 +65,7 @@ pub fn outcome_progress(
     // 4. Deduplicate commits by hash, preserving order (tagged first)
     let mut seen_hashes = HashSet::new();
     let mut commits = Vec::new();
-    for c in tagged_commits
-        .into_iter()
-        .chain(pattern_commits.into_iter())
-    {
+    for c in tagged_commits.into_iter().chain(pattern_commits) {
         if seen_hashes.insert(c.hash.clone()) {
             commits.push(c);
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1754,6 +1754,7 @@ mod tests {
         }
     }
 
+    /// ADR-ID: 002-arcswap-graph-concurrency
     /// Dissent finding: ArcSwap store() is atomic, so readers should always see
     /// a consistent snapshot -- never a partially-mutated state.
     #[tokio::test]
@@ -1824,6 +1825,7 @@ mod tests {
         assert_eq!(new_gs.nodes.len(), 3, "New snapshot should have 3 nodes");
     }
 
+    /// ADR-ID: 002-arcswap-graph-concurrency
     /// Dissent finding: get_graph returns Arc<GraphState> (not a lock guard).
     /// Verify that the returned value outlives any internal state changes.
     #[tokio::test]

--- a/src/service/repomap.rs
+++ b/src/service/repomap.rs
@@ -272,7 +272,7 @@ pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
                 .or_default() += 1;
         }
         let mut sf: Vec<_> = fc.into_iter().collect();
-        sf.sort_by(|a, b| b.1.cmp(&a.1));
+        sf.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         sf.truncate(10);
         let single_root = params.root_filter.is_some();
         if !sf.is_empty() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -328,7 +328,7 @@ impl QueryResult {
 
             // Top 5 files by symbol count, with up to 3 key symbols each
             let mut files_sorted: Vec<(&String, &Vec<&Node>)> = file_symbols.iter().collect();
-            files_sorted.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+            files_sorted.sort_by_key(|entry| std::cmp::Reverse(entry.1.len()));
 
             for (file, symbols) in files_sorted.iter().take(5) {
                 out.push_str(&format!("### {} ({} symbols)\n", file, symbols.len()));


### PR DESCRIPTION
## Summary
- implement ADR declaration compilation, validation runner, and status gating as an RNA primitive for downstream repos
- dogfood the primitive on RNA ADRs, generated manifests, docs, graph extraction, skills/workflow, and README status sync
- add test-to-ADR backreferences so extracted test functions can reference ADRs via `ADR:` and `ADR-ID:` doc comments
- closes #638
- closes #639
- closes #640

## Verification
- [x] targeted tests
- [x] CLI compile/check/validate commands
- [x] CI workflow coverage

### Observed locally
- `cargo check --lib --tests`
- `cargo clippy --no-default-features -- -D warnings`
- `cargo test test_test_function_doc_comment_references_adr_path --lib`
- `cargo test test_test_function_doc_comment_references_adr_id --lib`
- `cargo test test_non_test_function_doc_comment_does_not_emit_adr_reference --lib`
- `cargo test test_parse_adr_refs_supports_path_and_id --lib`
- `cargo run -- adr compile --repo .`
- `cargo run -- adr compile --repo . --check`
- `cargo run -- adr validate --repo .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ADR validation workflow: compile ADRs into manifests and run validations (cargo tests, audits, scripts, smoke) via three new CLI commands: adr compile, adr validate, adr audit.
  * ADR-aware linking: ADRs now link to concrete test functions and smoke fixtures when unambiguous; validation reports show per-ADR pass/fail and missing checks.

* **Documentation**
  * Expanded ADR templates, examples, CLI usage, sync guidance, and docs describing validation primitives and expected outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->