### PR TITLE
Add dead-code detection skill

### DIFF
--- a/plugin/skills/dead-code/SKILL.md
+++ b/plugin/skills/dead-code/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: dead-code
+description: Detect potentially dead code using RNA graph data. Finds public functions with zero non-test callers. No code changes needed — queries existing graph edges.
+---
+
+# /dead-code
+
+Find public functions that nothing calls (excluding tests). Uses RNA's graph to identify candidates — not a compiler, so results are heuristic. False positives exist (framework callbacks, trait impls, FFI exports, CLI dispatch targets).
+
+## Arguments
+
+`$ARGUMENTS` should be: `[scope]`
+
+- No arguments: scan the whole repo
+- File path: `src/service.rs` — scan one file
+- Directory: `src/extract/` — scan a subtree
+- Subsystem: `subsystem:code` — scan an RNA-detected subsystem
+
+Examples:
+- `/dead-code`
+- `/dead-code src/embed.rs`
+- `/dead-code src/graph/`
+
+## Procedure
+
+### Step 1: Gather functions
+
+List all functions in scope. Use non-compact mode to see `In:` and `Out:` edge counts separately.
+
+```text
+search(kind="function", file="<scope>", limit=50)
+```
+
+If no `file` scope, omit it to search the whole repo. Increase `limit` if the scope is large.
+
+> **Note:** Compact mode (`compact=true`) saves tokens but merges in/out into a single `edges:` count.
+> Use non-compact for the initial scan so you can see `In: N edge(s)` separately.
+
+From the results, note each function's:
+- **ID** (the stable node ID)
+- **Name** (from the signature)
+- **In-edge count** (`In: N edge(s)`)
+- **Test flag** (`Test: yes` means this IS a test — skip it as a candidate)
+- **Decorators** (framework annotations suggest the function is an entry point)
+
+### Step 2: Filter obvious non-candidates
+
+Remove from consideration:
+- **Test functions** — `Test: yes` or name starts with `test_`
+- **Entry points** — `main`, `run`, `setup`, `__init__`, `__main__`
+- **Framework callbacks** — functions with decorators like `#[tokio::main]`, `@app.route`, `@pytest.fixture`, `#[test]`, `@click.command`, `#[handler]`, `#[endpoint]`, `@celery.task`
+- **Trait/interface implementations** — if the function is inside an `impl Trait for` block or implements an interface method
+- **Functions with high in-edge count** — if `In: 5+ edge(s)`, it's clearly used; skip
+
+Focus on functions where `In: 0-2 edge(s)` — these are the candidates worth checking.
+
+> **Edge count gotcha:** `In: 1` usually means zero callers — the single incoming edge is the
+> `Defines` relationship from the parent module/struct. A function with `In: 1` and only a `Defines`
+> edge has no callers at all. True "has one caller" shows as `In: 2` (one `Defines` + one `Calls`).
+
+### Step 3: Check each candidate's callers
+
+For each remaining candidate, query incoming neighbors:
+
+```text
+search(node="<function-id>", mode="neighbors", direction="incoming", limit=10)
+```
+
+Examine each caller:
+- If the caller has `Test: yes` → it's a test reference, **ignore it**
+- If the caller's file path contains `/test`, `/tests/`, `_test.`, `.test.`, `spec/` → it's a test reference, **ignore it**
+- If the caller is in the same file and is itself a dead candidate → weak signal, still counts but note it
+
+After filtering test callers: if **zero non-test callers remain**, the function is a dead code candidate.
+
+### Step 4: Chase dead chains
+
+When a candidate's only non-test caller is itself a low-in-edge function, check that caller too.
+Dead code often forms chains: `A` → `B` → `C` where `A` is the only caller of `B`, and nothing calls `A`.
+
+```text
+search(node="<caller-id>", mode="neighbors", direction="incoming", limit=10)
+```
+
+If the entire chain has zero external callers, the whole chain is dead — report the root function
+and note the chain members.
+
+### Step 5: Batch efficiency
+
+If there are many candidates (>10), use the `nodes` parameter to batch-retrieve:
+
+```text
+search(nodes=["<id1>", "<id2>", "<id3>"], compact=true)
+```
+
+This gives updated edge counts. Focus detailed neighbor queries (Step 3) on the ones with genuinely low in-edge counts.
+### Step 6: Report
+
+Present results as a table:
+
+| Function | File | Non-test callers | Confidence | Notes |
+|----------|------|-----------------|------------|-------|
+| `unused_helper` | src/utils.rs:42 | 0 | High | No callers at all |
+| `old_format` | src/format.rs:88 | 0 | Medium | Has test callers only |
+| `dispatch_cmd` | src/cli.rs:15 | 0 | Low | Likely CLI dispatch target |
+
+**Confidence levels:**
+- **High** — zero total incoming edges, no decorators, not in a trait impl
+- **Medium** — has callers but all are tests, or low edge count with ambiguous decorators
+- **Low** — zero callers but has characteristics of a framework entry point, trait impl, or exported API
+
+## Limitations
+
+- **LSP enrichment required** — `Calls` and `ReferencedBy` edges come from LSP. If the repo hasn't been LSP-enriched, the graph only has structural edges (defines, contains), and every function will look "dead." Check: if no function has `Calls` edges, warn the user that LSP enrichment hasn't run.
+- **Dynamic dispatch** — trait objects, function pointers, and reflection-based calls won't have graph edges.
+- **Macros** — macro-generated call sites may not be captured by tree-sitter or LSP.
+- **Re-exports** — a function re-exported from a library crate may have zero in-repo callers but be the public API.
+- **Cross-root** — callers in a different workspace root won't show unless both roots are indexed.


### PR DESCRIPTION
## What

Dead-code detection skill + recall improvements for the RNA graph.

## Changes

### 1. Dead-code skill (`plugin/skills/dead-code/SKILL.md`)
Agent skill that detects potentially dead code using RNA graph data. Teaches the query pattern: list functions → filter by in-edge count → check incoming neighbors → ignore test callers → chase dead chains → report.

Includes Step 0 (LSP health check) that warns when LSP enrichment is missing.

### 2. LSP didOpen warmup (`src/extract/lsp/mod.rs`)
After sending `initialized`, RNA now sends `textDocument/didOpen` for a representative source file. This fixes two issues:
- **pyright**: workspace/symbol validation returns 0 symbols because pyright hasnt started indexing (no files opened). didOpen triggers import-graph indexing.
- **tsserver**: throws "No Project" because typescript-language-server needs at least one open file to create a project context.

### 3. Import ReferencedBy edges (`src/extract/import_calls.rs`)
`import_calls_pass` now emits `ReferencedBy` edges for every imported name that resolves to a function in another file, regardless of whether the name appears as a bare call in the body. Catches keyword args, dict dispatch, decorator registration, re-exports.

## Example: applied to this repo

| Function | File | Non-test callers | Confidence |
|----------|------|-----------------|------------|
| `format_pr_merges_markdown` | src/query.rs:173 | 0 | **High** |
| `SourceEnvelope::wrap` | src/graph/mod.rs:311 | 0 | **High** |
| `index_all` | src/embed.rs:681 | 0 | **High** |
| `EventBus::is_empty` | src/extract/event_bus.rs:876 | 0 | **High** |
| `EventBus::cache_len` | src/extract/event_bus.rs:860 | 0 | **Medium** |
| `extract_symbols` → `parse_rust_file` | src/code/mod.rs:11,26 | 0 | **High** |

## Example: applied to Innovation-Connector

Found 1 confirmed dead function (`_generate_context_string`). All other candidates (~30) were false positives from Python dynamic dispatch patterns that RNA's graph misses. Root cause: LSP enrichment produced 0 edges — pyright and tsserver both failed during initialization. The didOpen fix addresses this.

## Testing

- `cargo check --lib` passes (linker issue prevents local test/build — CI should handle this)
- Skill tested manually on RNA repo (6 confirmed dead functions) and Innovation-Connector
