### PR TITLE
fix: LSP didOpen warmup + import ReferencedBy edges

### DIFF
--- a/plugin/skills/dead-code/SKILL.md
+++ b/plugin/skills/dead-code/SKILL.md
@@ -70,12 +70,12 @@ Remove from consideration:
 - **Entry points** — `main`, `run`, `setup`, `__init__`, `__main__`
 - **Framework callbacks** — functions with decorators like `#[tokio::main]`, `@app.route`, `@pytest.fixture`, `#[test]`, `@click.command`, `#[handler]`, `#[endpoint]`, `@celery.task`
 - **Trait/interface implementations** — if the function is inside an `impl Trait for` block or implements an interface method
-- **Method overrides on library base classes** — if a method is defined on a class
-  that inherits from an external library class (e.g., SQLAlchemy `TypeDecorator`,
-  OTEL `SpanProcessor`, Django `Model`, Pydantic `BaseModel`), the library calls
-  the method internally. Check the class definition's parent list — if the parent
-  is imported from an external package, any method override is a framework hook
-  candidate. Common patterns:
+- **Method overrides on library base classes** — if a function has
+  `metadata["framework_hook"]` set, it was identified by an `.oh/extractors/`
+  config as a library hook method. Skip it. If the metadata is NOT set but the
+  method is on a class inheriting from an external library (SQLAlchemy
+  `TypeDecorator`, OTEL `SpanProcessor`, Django `Model`, etc.), it may need an
+  `.oh/extractors/` config with a `[[hooks]]` section. Common framework hooks:
   - SQLAlchemy: `process_bind_param`, `process_result_value`, `column_expression`
   - OTEL: `on_start`, `on_end`, `shutdown`, `force_flush`
   - Django: `save`, `delete`, `clean`, `get_queryset`

--- a/plugin/skills/dead-code/SKILL.md
+++ b/plugin/skills/dead-code/SKILL.md
@@ -23,6 +23,26 @@ Examples:
 
 ## Procedure
 
+### Step 0: Check LSP enrichment health
+
+Before analyzing, verify the graph has call edges from LSP enrichment:
+
+```text
+search(query="Calls", kind="function", file="<scope>", limit=5)
+```
+
+Look for functions with `Calls` edges that have `source: Lsp`. If **no** function
+shows LSP-sourced edges, the LSP enrichment didn't run successfully for this repo.
+
+> ⚠️ **Warning:** Without LSP enrichment, the graph only has structural edges
+> (Defines, Contains) and import-resolution edges. Method calls (`obj.method()`),
+> property access, JSX component usage (`<Component />`), and callback patterns
+> are invisible. Results will have a **high false-positive rate** for Python and
+> TypeScript repos. Rust and Go repos are less affected (static dispatch).
+>
+> To fix: run `repo-native-alignment scan --repo <path> --full` and check the
+> LSP enrichment logs for errors.
+
 ### Step 1: Gather functions
 
 List all functions in scope. Use non-compact mode to see `In:` and `Out:` edge counts separately.

--- a/plugin/skills/dead-code/SKILL.md
+++ b/plugin/skills/dead-code/SKILL.md
@@ -81,6 +81,9 @@ Remove from consideration:
   - Django: `save`, `delete`, `clean`, `get_queryset`
   - Pydantic: `model_post_init`, validators
   - Python ABCs: any method matching a name defined on the abstract parent
+- **Nested/local functions** — if the result shows `Parent: <outer-name> (function)`,
+  this is a function defined inside another function/closure. Skip it for dead-code
+  analysis — it is a local helper, not a top-level candidate. The outer function owns it.
 - **CLI script functions** — functions in `scripts/` directories are typically
   called from `if __name__ == "__main__"` blocks or CLI tools, not imported
 - **Functions with high in-edge count** — if `In: 5+ edge(s)`, it's clearly used; skip

--- a/plugin/skills/dead-code/SKILL.md
+++ b/plugin/skills/dead-code/SKILL.md
@@ -70,14 +70,19 @@ Remove from consideration:
 - **Method overrides on library base classes** — if a function has
   `metadata["framework_hook"]` set, it was identified by an `.oh/extractors/`
   config as a library hook method. Skip it. If the metadata is NOT set but the
-  method is on a class inheriting from an external library (SQLAlchemy
-  `TypeDecorator`, OTEL `SpanProcessor`, Django `Model`, etc.), it may need an
-  `.oh/extractors/` config with a `[[hooks]]` section. Common framework hooks:
+  method looks like it is called by an external framework (SQLAlchemy
+  `TypeDecorator`, OTEL `SpanProcessor`, Django `Model`, Pydantic, etc.), it
+  may need an `.oh/extractors/` config with a `[[hooks]]` section.
+
+  Hook matching is **name-based on the enclosing class**, not inheritance-based:
+  the matcher checks only that the function's immediate `parent_scope` contains
+  `class_contains` and that the function's own name is listed in `method_names`.
+  It does not traverse inherited base classes. Examples of common frameworks you
+  can configure hooks for:
   - SQLAlchemy: `process_bind_param`, `process_result_value`, `column_expression`
   - OTEL: `on_start`, `on_end`, `shutdown`, `force_flush`
   - Django: `save`, `delete`, `clean`, `get_queryset`
   - Pydantic: `model_post_init`, validators
-  - Python ABCs: any method matching a name defined on the abstract parent
 - **Nested/local functions** — if the result shows `Parent: <outer-name> (function)`,
   this is a function defined inside another function/closure. Skip it for dead-code
   analysis — it is a local helper, not a top-level candidate. The outer function owns it.

--- a/plugin/skills/dead-code/SKILL.md
+++ b/plugin/skills/dead-code/SKILL.md
@@ -70,6 +70,19 @@ Remove from consideration:
 - **Entry points** — `main`, `run`, `setup`, `__init__`, `__main__`
 - **Framework callbacks** — functions with decorators like `#[tokio::main]`, `@app.route`, `@pytest.fixture`, `#[test]`, `@click.command`, `#[handler]`, `#[endpoint]`, `@celery.task`
 - **Trait/interface implementations** — if the function is inside an `impl Trait for` block or implements an interface method
+- **Method overrides on library base classes** — if a method is defined on a class
+  that inherits from an external library class (e.g., SQLAlchemy `TypeDecorator`,
+  OTEL `SpanProcessor`, Django `Model`, Pydantic `BaseModel`), the library calls
+  the method internally. Check the class definition's parent list — if the parent
+  is imported from an external package, any method override is a framework hook
+  candidate. Common patterns:
+  - SQLAlchemy: `process_bind_param`, `process_result_value`, `column_expression`
+  - OTEL: `on_start`, `on_end`, `shutdown`, `force_flush`
+  - Django: `save`, `delete`, `clean`, `get_queryset`
+  - Pydantic: `model_post_init`, validators
+  - Python ABCs: any method matching a name defined on the abstract parent
+- **CLI script functions** — functions in `scripts/` directories are typically
+  called from `if __name__ == "__main__"` blocks or CLI tools, not imported
 - **Functions with high in-edge count** — if `In: 5+ edge(s)`, it's clearly used; skip
 
 Focus on functions where `In: 0-2 edge(s)` — these are the candidates worth checking.

--- a/plugin/skills/dead-code/SKILL.md
+++ b/plugin/skills/dead-code/SKILL.md
@@ -25,23 +25,20 @@ Examples:
 
 ### Step 0: Check LSP enrichment health
 
-Before analyzing, verify the graph has call edges from LSP enrichment:
+Before analyzing, verify the repo has completed a full scan with LSP enrichment. Use scan logs — not symbol output — because normal `search` output does not expose edge provenance (`source: Lsp`).
 
 ```text
-search(query="Calls", kind="function", file="<scope>", limit=5)
+repo-native-alignment scan --repo <path> --full
 ```
 
-Look for functions with `Calls` edges that have `source: Lsp`. If **no** function
-shows LSP-sourced edges, the LSP enrichment didn't run successfully for this repo.
+Confirm the logs report LSP completion with non-zero LSP call edges, for example:
 
-> ⚠️ **Warning:** Without LSP enrichment, the graph only has structural edges
-> (Defines, Contains) and import-resolution edges. Method calls (`obj.method()`),
-> property access, JSX component usage (`<Component />`), and callback patterns
-> are invisible. Results will have a **high false-positive rate** for Python and
-> TypeScript repos. Rust and Go repos are less affected (static dispatch).
->
-> To fix: run `repo-native-alignment scan --repo <path> --full` and check the
-> LSP enrichment logs for errors.
+```text
+LSP enrichment complete for python: 1234 edges ...
+[background-lsp] LSP enrichment complete: 2870 LSP call edges, 173056 total LSP edges
+```
+
+If the scan logs show 0 LSP call edges, aborted LSP passes, or missing language servers, expect higher false-positive rates — especially for Python and TypeScript repos where method calls, JSX usage, and framework wiring rely on LSP enrichment.
 
 ### Step 1: Gather functions
 

--- a/plugin/skills/setup/SKILL.md
+++ b/plugin/skills/setup/SKILL.md
@@ -117,13 +117,14 @@ If AGENTS.md does not exist, create it with the tool guidance block as the initi
 Check if the project uses messaging frameworks, event buses, or libraries with hook patterns that RNA should know about. Look at the project's imports:
 
 ```bash
-repo-native-alignment search --repo . "" --kind import --compact 2>&1 | grep -iE 'pubsub|kafka|celery|pika|redis|rabbitmq|sqlalchemy|django|flask|opentelemetry|otel'
+repo-native-alignment search --repo . "" --kind import --compact 2>&1 \
+  | grep -iE 'pubsub|kafka|celery|pika|redis|rabbitmq|sqlalchemy|django|flask|opentelemetry|otel' || true
 ```
 
 If any match, check whether `.oh/extractors/` already has coverage for the detected frameworks by searching extractor contents (listing filenames alone is not sufficient):
 
 ```bash
-grep -RniE 'pubsub|kafka|celery|pika|redis|rabbitmq|sqlalchemy|django|flask|opentelemetry|otel' .oh/extractors/ 2>/dev/null
+grep -RniE 'pubsub|kafka|celery|pika|redis|rabbitmq|sqlalchemy|django|flask|opentelemetry|otel' .oh/extractors/ 2>/dev/null || true
 ```
 
 If the project uses a messaging framework without coverage, create a config file. Example for Google Pub/Sub:

--- a/plugin/skills/setup/SKILL.md
+++ b/plugin/skills/setup/SKILL.md
@@ -120,10 +120,10 @@ Check if the project uses messaging frameworks, event buses, or libraries with h
 repo-native-alignment search --repo . "" --kind import --compact 2>&1 | grep -iE 'pubsub|kafka|celery|pika|redis|rabbitmq|sqlalchemy|django|flask|opentelemetry|otel'
 ```
 
-If any match, check if `.oh/extractors/` already has coverage:
+If any match, check whether `.oh/extractors/` already has coverage for the detected frameworks by searching extractor contents (listing filenames alone is not sufficient):
 
 ```bash
-ls .oh/extractors/ 2>/dev/null
+grep -RniE 'pubsub|kafka|celery|pika|redis|rabbitmq|sqlalchemy|django|flask|opentelemetry|otel' .oh/extractors/ 2>/dev/null
 ```
 
 If the project uses a messaging framework without coverage, create a config file. Example for Google Pub/Sub:

--- a/plugin/skills/setup/SKILL.md
+++ b/plugin/skills/setup/SKILL.md
@@ -112,6 +112,57 @@ If AGENTS.md exists but lacks the marker, append this block:
 
 If AGENTS.md does not exist, create it with the tool guidance block as the initial content.
 
+## Step 5b: Check for framework boundary patterns
+
+Check if the project uses messaging frameworks, event buses, or libraries with hook patterns that RNA should know about. Look at the project's imports:
+
+```bash
+repo-native-alignment search --repo . "" --kind import --compact 2>&1 | grep -iE 'pubsub|kafka|celery|pika|redis|rabbitmq|sqlalchemy|django|flask|opentelemetry|otel'
+```
+
+If any match, check if `.oh/extractors/` already has coverage:
+
+```bash
+ls .oh/extractors/ 2>/dev/null
+```
+
+If the project uses a messaging framework without coverage, create a config file. Example for Google Pub/Sub:
+
+```toml
+# .oh/extractors/google-pubsub.toml
+[meta]
+name = "google-pubsub"
+applies_when = { language = "python", imports_contain = "google.cloud.pubsub" }
+
+[[boundaries]]
+function_pattern = "publisher.publish"
+arg_position = 0
+edge_kind = "Produces"
+
+[[boundaries]]
+function_pattern = "subscribe"
+arg_position = 0
+edge_kind = "Consumes"
+```
+
+If the project uses frameworks with method-override hooks (SQLAlchemy, Django, OTEL), create a hooks config:
+
+```toml
+# .oh/extractors/sqlalchemy-hooks.toml
+[meta]
+name = "sqlalchemy-hooks"
+applies_when = { language = "python", imports_contain = "sqlalchemy" }
+
+[[hooks]]
+class_contains = "TypeDecorator"
+method_names = ["process_bind_param", "process_result_value"]
+```
+
+The `[[boundaries]]` section detects Produces/Consumes edges for message brokers.
+The `[[hooks]]` section marks method overrides on library base classes as framework hooks (so dead-code analysis skips them).
+
+For more details, see `docs/extractors.md` in the RNA repo, or use `/gen-extractor` to generate configs from a natural-language description.
+
 ## Step 6: Inform the user
 
 Tell the user:

--- a/src/extract/configs.rs
+++ b/src/extract/configs.rs
@@ -257,6 +257,9 @@ pub static PYTHON_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: true,
     test_name_prefix: true,
+    lsp_enrichable_kinds: Some(&[NodeKind::Function, NodeKind::Trait]),
+    venv_candidates: Some(&[".venv", "venv", "env"]),
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -318,6 +321,9 @@ pub static TYPESCRIPT_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -368,6 +374,9 @@ pub static JAVASCRIPT_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -416,6 +425,9 @@ pub static GO_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -478,6 +490,9 @@ pub static JAVA_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -531,6 +546,9 @@ pub static KOTLIN_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -593,6 +611,9 @@ pub static CSHARP_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -650,6 +671,9 @@ pub static SWIFT_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -697,6 +721,9 @@ pub static ZIG_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -756,6 +783,9 @@ pub static CPP_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -797,6 +827,9 @@ pub static LUA_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -848,6 +881,9 @@ pub static RUBY_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -891,6 +927,9 @@ pub static BASH_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -941,6 +980,9 @@ pub static C_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -1003,6 +1045,9 @@ pub static PHP_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None, // PHP has no re-export semantics like Rust's `pub use`
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -1060,6 +1105,9 @@ pub static SCALA_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -1115,6 +1163,9 @@ pub static DART_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
 // ── GDScript ─────────────────────────────────────────────────────────────────
@@ -1159,5 +1210,35 @@ pub static GDSCRIPT_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: None,
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: false,
 };
 
+
+/// Look up the LangConfig for a language name. Returns None for languages
+/// not supported by the generic extractor (JSON, Markdown, TOML, etc.).
+pub fn config_for_language(language: &str) -> Option<&'static LangConfig> {
+    match language {
+        "rust" => Some(&super::rust::RUST_CONFIG),
+        "python" => Some(&PYTHON_CONFIG),
+        "typescript" => Some(&TYPESCRIPT_CONFIG),
+        "javascript" => Some(&JAVASCRIPT_CONFIG),
+        "go" => Some(&GO_CONFIG),
+        "java" => Some(&JAVA_CONFIG),
+        "kotlin" => Some(&KOTLIN_CONFIG),
+        "csharp" => Some(&CSHARP_CONFIG),
+        "swift" => Some(&SWIFT_CONFIG),
+        "zig" => Some(&ZIG_CONFIG),
+        "cpp" => Some(&CPP_CONFIG),
+        "lua" => Some(&LUA_CONFIG),
+        "ruby" => Some(&RUBY_CONFIG),
+        "bash" => Some(&BASH_CONFIG),
+        "c" => Some(&C_CONFIG),
+        "php" => Some(&PHP_CONFIG),
+        "scala" => Some(&SCALA_CONFIG),
+        "dart" => Some(&DART_CONFIG),
+        "gdscript" => Some(&GDSCRIPT_CONFIG),
+        _ => None,
+    }
+}

--- a/src/extract/configs.rs
+++ b/src/extract/configs.rs
@@ -228,7 +228,7 @@ pub static PYTHON_CONFIG: LangConfig = LangConfig {
         ("import_from_statement", NodeKind::Import),
         // Python has no keyword for fields; ALL_CAPS consts handled in python.rs
     ],
-    scope_parent_kinds: &["class_definition"],
+    scope_parent_kinds: &["class_definition", "function_definition"],
     const_value_field: None,
     full_text_name_kinds: &["import_statement", "import_from_statement"],
     string_literal_kinds: &[("string", None)],

--- a/src/extract/configs.rs
+++ b/src/extract/configs.rs
@@ -259,6 +259,7 @@ pub static PYTHON_CONFIG: LangConfig = LangConfig {
     test_name_prefix: true,
     lsp_enrichable_kinds: Some(&[NodeKind::Function, NodeKind::Trait]),
     venv_candidates: Some(&[".venv", "venv", "env"]),
+    attribute_access_node: Some(("attribute", "attribute")),
     has_parent_module_request: false,
 };
 
@@ -324,6 +325,7 @@ pub static TYPESCRIPT_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: Some(("member_expression", "property")),
 };
 
 // ---------------------------------------------------------------------------
@@ -377,6 +379,7 @@ pub static JAVASCRIPT_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: Some(("selector_expression", "field")),
 };
 
 // ---------------------------------------------------------------------------
@@ -428,6 +431,7 @@ pub static GO_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: Some(("member_expression", "property")),
 };
 
 // ---------------------------------------------------------------------------
@@ -493,6 +497,7 @@ pub static JAVA_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -549,6 +554,7 @@ pub static KOTLIN_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -614,6 +620,7 @@ pub static CSHARP_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -674,6 +681,7 @@ pub static SWIFT_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -724,6 +732,7 @@ pub static ZIG_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -786,6 +795,7 @@ pub static CPP_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -830,6 +840,7 @@ pub static LUA_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -884,6 +895,7 @@ pub static RUBY_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -930,6 +942,7 @@ pub static BASH_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -983,6 +996,7 @@ pub static C_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -1048,6 +1062,7 @@ pub static PHP_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -1108,6 +1123,7 @@ pub static SCALA_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -1166,6 +1182,7 @@ pub static DART_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 // ── GDScript ─────────────────────────────────────────────────────────────────
@@ -1213,6 +1230,7 @@ pub static GDSCRIPT_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: false,
+    attribute_access_node: None,
 };
 
 

--- a/src/extract/extractor_config.rs
+++ b/src/extract/extractor_config.rs
@@ -464,7 +464,24 @@ pub fn extractor_config_pass_with_configs(
 
     // ---------------------------------------------------------------
     // Process [[hooks]] — mark framework hook methods with metadata.
+    // For each function with a parent_scope, find the class node (Struct) in
+    // the same file and check if its SIGNATURE contains the hook's class_contains
+    // substring. The signature has the full inheritance chain, e.g.,
+    // "class StrEnum(TypeDecorator):" which matches class_contains="TypeDecorator".
     // ---------------------------------------------------------------
+
+    // Pre-index: class signatures by (file, class_name) for O(1) lookup.
+    let mut class_sigs: std::collections::HashMap<(&std::path::Path, &str), &str> =
+        std::collections::HashMap::new();
+    for node in all_nodes {
+        if node.id.kind == NodeKind::Struct {
+            class_sigs.insert(
+                (node.id.file.as_path(), node.id.name.as_str()),
+                node.signature.as_str(),
+            );
+        }
+    }
+
     let mut hook_count = 0usize;
     for config in configs {
         if config.hooks.is_empty() {
@@ -481,18 +498,20 @@ pub fn extractor_config_pass_with_configs(
         };
         for (node, _body_lower) in candidates {
             let parent_scope = match node.metadata.get("parent_scope") {
-                Some(s) => s,
+                Some(s) => s.as_str(),
+                None => continue,
+            };
+            // Look up the class node's signature to check inheritance
+            let class_sig = match class_sigs.get(&(node.id.file.as_path(), parent_scope)) {
+                Some(sig) => *sig,
                 None => continue,
             };
             for hook in &config.hooks {
-                if !parent_scope.contains(&hook.class_contains) {
+                if !class_sig.contains(&hook.class_contains) {
                     continue;
                 }
                 if hook.method_names.iter().any(|m| m == &node.id.name) {
                     hook_count += 1;
-                    // We can't mutate the node directly (it's borrowed from all_nodes),
-                    // so emit a synthetic node with the framework_hook metadata set.
-                    // The graph merge will update the existing node's metadata.
                     let mut metadata = node.metadata.clone();
                     metadata.insert("framework_hook".to_string(), config.meta.name.clone());
                     result_nodes.push(Node {
@@ -501,7 +520,7 @@ pub fn extractor_config_pass_with_configs(
                         line_start: node.line_start,
                         line_end: node.line_end,
                         signature: node.signature.clone(),
-                        body: String::new(), // don't duplicate body
+                        body: String::new(),
                         metadata,
                         source: ExtractionSource::TreeSitter,
                     });

--- a/src/extract/extractor_config.rs
+++ b/src/extract/extractor_config.rs
@@ -63,6 +63,10 @@ pub struct ExtractorConfig {
     pub meta: Meta,
     #[serde(default)]
     pub boundaries: Vec<Boundary>,
+    /// Framework hook declarations. Methods matching these patterns are marked
+    /// with `metadata["framework_hook"]` so dead-code analysis skips them.
+    #[serde(default)]
+    pub hooks: Vec<Hook>,
 }
 
 /// Metadata section of an extractor config.
@@ -112,6 +116,26 @@ impl Boundary {
             _ => None,
         }
     }
+}
+
+/// A framework hook declaration.
+///
+/// When a Function node's `parent_scope` metadata contains `class_contains`,
+/// and the function name is in `method_names`, the function is marked with
+/// `metadata["framework_hook"] = config_name`.
+///
+/// Example:
+/// ```toml
+/// [[hooks]]
+/// class_contains = "TypeDecorator"
+/// method_names = ["process_bind_param", "process_result_value"]
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct Hook {
+    /// Substring that must appear in the class name or parent scope.
+    pub class_contains: String,
+    /// Method names that are framework hooks when defined on a matching class.
+    pub method_names: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -436,19 +460,67 @@ pub fn extractor_config_pass_with_configs(
         }
     }
 
-    let nodes: Vec<Node> = channel_nodes.into_values().collect();
+    let mut result_nodes: Vec<Node> = channel_nodes.into_values().collect();
 
-    if !result_edges.is_empty() {
+    // ---------------------------------------------------------------
+    // Process [[hooks]] — mark framework hook methods with metadata.
+    // ---------------------------------------------------------------
+    let mut hook_count = 0usize;
+    for config in configs {
+        if config.hooks.is_empty() {
+            continue;
+        }
+        let target = config.meta.applies_when.imports_contain.as_str();
+        let import_match = import_texts.iter().any(|text| text.contains(target));
+        if !import_match {
+            continue;
+        }
+        let lang = config.meta.applies_when.language.as_str();
+        let Some(candidates) = by_language.get(lang) else {
+            continue;
+        };
+        for (node, _body_lower) in candidates {
+            let parent_scope = match node.metadata.get("parent_scope") {
+                Some(s) => s,
+                None => continue,
+            };
+            for hook in &config.hooks {
+                if !parent_scope.contains(&hook.class_contains) {
+                    continue;
+                }
+                if hook.method_names.iter().any(|m| m == &node.id.name) {
+                    hook_count += 1;
+                    // We can't mutate the node directly (it's borrowed from all_nodes),
+                    // so emit a synthetic node with the framework_hook metadata set.
+                    // The graph merge will update the existing node's metadata.
+                    let mut metadata = node.metadata.clone();
+                    metadata.insert("framework_hook".to_string(), config.meta.name.clone());
+                    result_nodes.push(Node {
+                        id: node.id.clone(),
+                        language: node.language.clone(),
+                        line_start: node.line_start,
+                        line_end: node.line_end,
+                        signature: node.signature.clone(),
+                        body: String::new(), // don't duplicate body
+                        metadata,
+                        source: ExtractionSource::TreeSitter,
+                    });
+                }
+            }
+        }
+    }
+
+    if !result_edges.is_empty() || hook_count > 0 {
         tracing::info!(
-            "Extractor config pass: {} channel node(s), {} Produces/Consumes edge(s) from {} config(s)",
-            nodes.len(),
+            "Extractor config pass: {} channel node(s), {} boundary edge(s), {} framework hook(s)",
+            result_nodes.len().saturating_sub(hook_count),
             result_edges.len(),
-            configs.len(),
+            hook_count,
         );
     }
 
     ExtractionResult {
-        nodes,
+        nodes: result_nodes,
         edges: result_edges,
     }
 }

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -217,11 +217,16 @@ pub struct LangConfig {
 
 /// Walk a tree-sitter subtree and collect attribute/member access names.
 /// Finds all nodes of kind `attr_kind` and extracts the child field `attr_field`.
+///
+/// Recursion stops at nested function/closure boundaries so that attribute
+/// accesses inside inner defs/closures do not leak into the outer function's
+/// `attr_refs`. Callers pass `stop_kinds` listing nested-scope node kinds.
 fn collect_attribute_names<'a>(
     node: tree_sitter::Node<'a>,
     source: &'a [u8],
     attr_kind: &str,
     attr_field: &str,
+    stop_kinds: &[&str],
     out: &mut Vec<&'a str>,
 ) {
     if node.kind() == attr_kind
@@ -235,7 +240,10 @@ fn collect_attribute_names<'a>(
     }
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32) {
-            collect_attribute_names(child, source, attr_kind, attr_field, out);
+            if stop_kinds.contains(&child.kind()) {
+                continue;
+            }
+            collect_attribute_names(child, source, attr_kind, attr_field, stop_kinds, out);
         }
     }
 }
@@ -583,8 +591,42 @@ fn collect_nodes(
             if node_kind == NodeKind::Function
                 && let Some((attr_kind, attr_field)) = config.attribute_access_node
             {
+                // Avoid leaking member accesses from nested function/closure bodies
+                // into this outer function's attr_refs. Stop recursion at any node
+                // kind configured to map to NodeKind::Function, plus common closure
+                // syntaxes across supported languages.
+                let mut fn_stop_kinds: Vec<&str> = config
+                    .node_kinds
+                    .iter()
+                    .filter(|(_, k)| *k == NodeKind::Function)
+                    .map(|(ts_kind, _)| *ts_kind)
+                    .collect();
+                for extra in [
+                    "arrow_function",
+                    "function_expression",
+                    "lambda",
+                    "closure_expression",
+                ] {
+                    if !fn_stop_kinds.contains(&extra) {
+                        fn_stop_kinds.push(extra);
+                    }
+                }
+                // Walk this function's own children, but stop at any nested
+                // function/closure so attribute accesses inside inner defs
+                // don't contaminate the outer function's attr_refs.
                 let mut attr_names: Vec<&str> = Vec::new();
-                collect_attribute_names(node, source, attr_kind, attr_field, &mut attr_names);
+                for i in 0..node.child_count() {
+                    if let Some(child) = node.child(i as u32) {
+                        collect_attribute_names(
+                            child,
+                            source,
+                            attr_kind,
+                            attr_field,
+                            &fn_stop_kinds,
+                            &mut attr_names,
+                        );
+                    }
+                }
                 if !attr_names.is_empty() {
                     attr_names.sort_unstable();
                     attr_names.dedup();

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -594,7 +594,7 @@ fn collect_nodes(
                 // Avoid leaking member accesses from nested function/closure bodies
                 // into this outer function's attr_refs. Stop recursion at any node
                 // kind configured to map to NodeKind::Function, plus common closure
-                // syntaxes across supported languages.
+                // and inner-function syntaxes across supported languages.
                 let mut fn_stop_kinds: HashSet<&str> = config
                     .node_kinds
                     .iter()
@@ -602,28 +602,49 @@ fn collect_nodes(
                     .map(|(ts_kind, _)| *ts_kind)
                     .collect();
                 for extra in [
+                    // JS / TS
                     "arrow_function",
                     "function_expression",
-                    "lambda",
+                    "function_declaration",
+                    "generator_function",
+                    "generator_function_declaration",
+                    "method_definition",
+                    "method",
+                    // Rust
                     "closure_expression",
+                    "async_block",
+                    // Python
+                    "lambda",
+                    "async_function_definition",
+                    // Go
+                    "func_literal",
                 ] {
                     fn_stop_kinds.insert(extra);
                 }
-                // Walk this function's own children, but stop at any nested
-                // function/closure so attribute accesses inside inner defs
-                // don't contaminate the outer function's attr_refs.
+                // Walk only this function's body subtree so attribute accesses in
+                // parameter defaults, decorators, or return-type annotations do
+                // not contaminate attr_refs. Fall back to the whole node when no
+                // body field is exposed by the grammar.
                 let mut attr_names: Vec<&str> = Vec::new();
-                for i in 0..node.child_count() {
-                    if let Some(child) = node.child(i as u32) {
-                        collect_attribute_names(
-                            child,
-                            source,
-                            attr_kind,
-                            attr_field,
-                            &fn_stop_kinds,
-                            &mut attr_names,
-                        );
-                    }
+                let body_node = node.child_by_field_name("body");
+                let walk_roots: Vec<tree_sitter::Node> = if let Some(body) = body_node {
+                    (0..body.child_count())
+                        .filter_map(|i| body.child(i as u32))
+                        .collect()
+                } else {
+                    (0..node.child_count())
+                        .filter_map(|i| node.child(i as u32))
+                        .collect()
+                };
+                for child in walk_roots {
+                    collect_attribute_names(
+                        child,
+                        source,
+                        attr_kind,
+                        attr_field,
+                        &fn_stop_kinds,
+                        &mut attr_names,
+                    );
                 }
                 if !attr_names.is_empty() {
                     attr_names.sort_unstable();

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -19,7 +19,7 @@
 //! the individual extractor files, but as small focused functions rather than
 //! full 300-line traversal reimplementations.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -226,7 +226,7 @@ fn collect_attribute_names<'a>(
     source: &'a [u8],
     attr_kind: &str,
     attr_field: &str,
-    stop_kinds: &[&str],
+    stop_kinds: &HashSet<&str>,
     out: &mut Vec<&'a str>,
 ) {
     if node.kind() == attr_kind
@@ -234,13 +234,13 @@ fn collect_attribute_names<'a>(
         && let Ok(text) = child.utf8_text(source)
     {
         let text = text.trim();
-        if text.len() >= 4 {
+        if !text.is_empty() {
             out.push(text);
         }
     }
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32) {
-            if stop_kinds.contains(&child.kind()) {
+            if stop_kinds.contains(child.kind()) {
                 continue;
             }
             collect_attribute_names(child, source, attr_kind, attr_field, stop_kinds, out);
@@ -595,7 +595,7 @@ fn collect_nodes(
                 // into this outer function's attr_refs. Stop recursion at any node
                 // kind configured to map to NodeKind::Function, plus common closure
                 // syntaxes across supported languages.
-                let mut fn_stop_kinds: Vec<&str> = config
+                let mut fn_stop_kinds: HashSet<&str> = config
                     .node_kinds
                     .iter()
                     .filter(|(_, k)| *k == NodeKind::Function)
@@ -607,9 +607,7 @@ fn collect_nodes(
                     "lambda",
                     "closure_expression",
                 ] {
-                    if !fn_stop_kinds.contains(&extra) {
-                        fn_stop_kinds.push(extra);
-                    }
+                    fn_stop_kinds.insert(extra);
                 }
                 // Walk this function's own children, but stop at any nested
                 // function/closure so attribute accesses inside inner defs

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -19,9 +19,9 @@
 //! the individual extractor files, but as small focused functions rather than
 //! full 300-line traversal reimplementations.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 use anyhow::Result;
 
@@ -213,6 +213,45 @@ pub struct LangConfig {
     /// - Rust: `Some(("field_expression", "field"))`
     /// - Go: `Some(("selector_expression", "field"))`
     pub attribute_access_node: Option<(&'static str, &'static str)>,
+}
+
+/// Return the cached attr_refs recursion stop-kind set for `config`.
+///
+/// Built once per language from the canonical [`CLOSURE_NODE_KINDS`] list plus
+/// any ts_kinds this [`LangConfig`] maps to [`NodeKind::Function`] (named inner
+/// defs, methods). Per-call rebuilds caused the inline list in `collect_nodes`
+/// to diverge from the canonical closure list used by `count_branches`, which
+/// is exactly what the `no-language-conditionals-in-generic` guardrail is
+/// meant to prevent.
+fn fn_stop_kinds_for(config: &LangConfig) -> &'static HashSet<&'static str> {
+    static CACHE: OnceLock<Mutex<HashMap<&'static str, &'static HashSet<&'static str>>>> =
+        OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    // Fast-path: return already-built set for this language.
+    {
+        let guard = cache.lock().expect("fn_stop_kinds cache poisoned");
+        if let Some(&set) = guard.get(config.language_name) {
+            return set;
+        }
+    }
+    // Build the merged set. Named Function-mapped kinds come from LangConfig;
+    // anonymous closure forms come from the shared constant. Leak into static
+    // memory once per language (count bounded by the number of registered
+    // languages) so the borrow outlives any extraction call.
+    let mut set: HashSet<&'static str> = config
+        .node_kinds
+        .iter()
+        .filter(|(_, k)| *k == NodeKind::Function)
+        .map(|(ts_kind, _)| *ts_kind)
+        .collect();
+    for &k in CLOSURE_NODE_KINDS {
+        set.insert(k);
+    }
+    let leaked: &'static HashSet<&'static str> = Box::leak(Box::new(set));
+    let mut guard = cache.lock().expect("fn_stop_kinds cache poisoned");
+    // Race-safe: another thread may have inserted concurrently; keep the first
+    // winner and drop our leaked copy for that language.
+    guard.entry(config.language_name).or_insert(leaked)
 }
 
 /// Walk a tree-sitter subtree and collect attribute/member access names.
@@ -591,40 +630,16 @@ fn collect_nodes(
             if node_kind == NodeKind::Function
                 && let Some((attr_kind, attr_field)) = config.attribute_access_node
             {
-                // Avoid leaking member accesses from nested function/closure bodies
-                // into this outer function's attr_refs. Stop recursion at any node
-                // kind configured to map to NodeKind::Function, plus common closure
-                // and inner-function syntaxes across supported languages.
-                let mut fn_stop_kinds: HashSet<&str> = config
-                    .node_kinds
-                    .iter()
-                    .filter(|(_, k)| *k == NodeKind::Function)
-                    .map(|(ts_kind, _)| *ts_kind)
-                    .collect();
-                for extra in [
-                    // JS / TS
-                    "arrow_function",
-                    "function_expression",
-                    "function_declaration",
-                    "generator_function",
-                    "generator_function_declaration",
-                    "method_definition",
-                    "method",
-                    // Rust
-                    "closure_expression",
-                    "async_block",
-                    // Python
-                    "lambda",
-                    "async_function_definition",
-                    // Go
-                    "func_literal",
-                ] {
-                    fn_stop_kinds.insert(extra);
-                }
                 // Walk only this function's body subtree so attribute accesses in
                 // parameter defaults, decorators, or return-type annotations do
                 // not contaminate attr_refs. Fall back to the whole node when no
                 // body field is exposed by the grammar.
+                //
+                // Nested-scope stops come from the canonical `CLOSURE_NODE_KINDS`
+                // constant plus any ts_kinds this LangConfig maps to
+                // NodeKind::Function (named inner defs / methods). The combined
+                // set is built once per language via `fn_stop_kinds_for`.
+                let fn_stop_kinds = fn_stop_kinds_for(config);
                 let mut attr_names: Vec<&str> = Vec::new();
                 let body_node = node.child_by_field_name("body");
                 let walk_roots: Vec<tree_sitter::Node> = if let Some(body) = body_node {
@@ -642,7 +657,7 @@ fn collect_nodes(
                         source,
                         attr_kind,
                         attr_field,
-                        &fn_stop_kinds,
+                        fn_stop_kinds,
                         &mut attr_names,
                     );
                 }
@@ -925,6 +940,7 @@ const LOGICAL_OPERATORS: &[&str] = &["&&", "||", "and", "or"];
 /// but branches inside them belong to the closure, not the enclosing function.
 const CLOSURE_NODE_KINDS: &[&str] = &[
     "closure_expression",  // Rust
+    "async_block",         // Rust — anonymous `async { ... }` block
     "lambda",              // Python
     "arrow_function",      // TypeScript, JavaScript
     "function_expression", // JavaScript

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -198,6 +198,52 @@ pub struct LangConfig {
     /// Whether this language's LSP server supports a custom `parentModule`
     /// request for more accurate module hierarchy (e.g., rust-analyzer).
     pub has_parent_module_request: bool,
+    /// Tree-sitter node kind and child field name for attribute/member access.
+    /// Used to extract attribute names from function bodies at parse time.
+    /// The attribute name is the identifier accessed via `.` (e.g., `obj.method` → "method").
+    ///
+    /// Stored as `metadata["attr_refs"]` on function nodes — a comma-separated
+    /// list of attribute names used in the body. Consumed by `import_calls_pass`
+    /// for dead-code detection (any function whose name appears as an attr_ref
+    /// somewhere in the codebase is not dead).
+    ///
+    /// Examples:
+    /// - Python: `Some(("attribute", "attribute"))` — `obj.method` is an `attribute` node
+    /// - TypeScript: `Some(("member_expression", "property"))` — `obj.method` is a `member_expression`
+    /// - Rust: `Some(("field_expression", "field"))`
+    /// - Go: `Some(("selector_expression", "field"))`
+    pub attribute_access_node: Option<(&'static str, &'static str)>,
+}
+
+/// Walk a tree-sitter subtree and collect attribute/member access names.
+/// Finds all nodes of kind `attr_kind` and extracts the child field `attr_field`.
+fn collect_attribute_names<'a>(
+    cursor: &mut tree_sitter::TreeCursor<'a>,
+    source: &'a [u8],
+    attr_kind: &str,
+    attr_field: &str,
+    out: &mut Vec<&'a str>,
+) {
+    loop {
+        let node = cursor.node();
+        if node.kind() == attr_kind {
+            if let Some(child) = node.child_by_field_name(attr_field) {
+                if let Ok(text) = child.utf8_text(source) {
+                    let text = text.trim();
+                    if text.len() >= 4 {
+                        out.push(text);
+                    }
+                }
+            }
+        }
+        if cursor.goto_first_child() {
+            collect_attribute_names(cursor, source, attr_kind, attr_field, out);
+            cursor.goto_parent();
+        }
+        if !cursor.goto_next_sibling() {
+            break;
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -213,6 +259,7 @@ impl GenericExtractor {
     pub fn new(config: &'static LangConfig) -> Self {
         Self { config }
     }
+
 
     /// Run extraction and return the result. Used directly or as a base by
     /// per-language extractors that need custom post-processing.
@@ -530,6 +577,22 @@ fn collect_nodes(
                     }
                 }
                 metadata.insert("synthetic".to_string(), "false".to_string());
+            }
+
+            // Attribute access extraction — capture method/property names
+            // used via dot access in function bodies. Stored as metadata
+            // for import_calls_pass to match against defined function names.
+            if node_kind == NodeKind::Function {
+                if let Some((attr_kind, attr_field)) = config.attribute_access_node {
+                    let mut attr_names: Vec<&str> = Vec::new();
+                    let mut cursor = node.walk();
+                    collect_attribute_names(&mut cursor, source, attr_kind, attr_field, &mut attr_names);
+                    if !attr_names.is_empty() {
+                        attr_names.sort_unstable();
+                        attr_names.dedup();
+                        metadata.insert("attr_refs".to_string(), attr_names.join(","));
+                    }
+                }
             }
 
             // Public API surface detection (#409).

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -218,29 +218,24 @@ pub struct LangConfig {
 /// Walk a tree-sitter subtree and collect attribute/member access names.
 /// Finds all nodes of kind `attr_kind` and extracts the child field `attr_field`.
 fn collect_attribute_names<'a>(
-    cursor: &mut tree_sitter::TreeCursor<'a>,
+    node: tree_sitter::Node<'a>,
     source: &'a [u8],
     attr_kind: &str,
     attr_field: &str,
     out: &mut Vec<&'a str>,
 ) {
-    loop {
-        let node = cursor.node();
-        if node.kind() == attr_kind
-            && let Some(child) = node.child_by_field_name(attr_field)
-            && let Ok(text) = child.utf8_text(source)
-        {
-            let text = text.trim();
-            if text.len() >= 4 {
-                out.push(text);
-            }
+    if node.kind() == attr_kind
+        && let Some(child) = node.child_by_field_name(attr_field)
+        && let Ok(text) = child.utf8_text(source)
+    {
+        let text = text.trim();
+        if text.len() >= 4 {
+            out.push(text);
         }
-        if cursor.goto_first_child() {
-            collect_attribute_names(cursor, source, attr_kind, attr_field, out);
-            cursor.goto_parent();
-        }
-        if !cursor.goto_next_sibling() {
-            break;
+    }
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i as u32) {
+            collect_attribute_names(child, source, attr_kind, attr_field, out);
         }
     }
 }
@@ -589,8 +584,7 @@ fn collect_nodes(
                 && let Some((attr_kind, attr_field)) = config.attribute_access_node
             {
                 let mut attr_names: Vec<&str> = Vec::new();
-                let mut cursor = node.walk();
-                collect_attribute_names(&mut cursor, source, attr_kind, attr_field, &mut attr_names);
+                collect_attribute_names(node, source, attr_kind, attr_field, &mut attr_names);
                 if !attr_names.is_empty() {
                     attr_names.sort_unstable();
                     attr_names.dedup();

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -428,8 +428,12 @@ fn collect_nodes(
             let mut metadata = BTreeMap::new();
 
             // Parent scope.
-            if let Some((scope_name, _)) = parent_scope {
+            if let Some((scope_name, scope_kind)) = parent_scope {
                 metadata.insert("parent_scope".to_string(), scope_name.clone());
+                metadata.insert(
+                    "parent_scope_kind".to_string(),
+                    scope_kind.to_string(),
+                );
             }
 
             // Name column for LSP cursor positioning.

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -199,19 +199,22 @@ pub struct LangConfig {
     /// request for more accurate module hierarchy (e.g., rust-analyzer).
     pub has_parent_module_request: bool,
     /// Tree-sitter node kind and child field name for attribute/member access.
-    /// Used to extract attribute names from function bodies at parse time.
-    /// The attribute name is the identifier accessed via `.` (e.g., `obj.method` → "method").
+    /// Used to extract method call names from function bodies at parse time.
+    /// The attribute name is the identifier accessed via `.` (e.g., `obj.method()` → "method").
+    ///
+    /// Only call-position accesses are collected: the attribute node must be the
+    /// callee (`call_expr_kinds.1` field) of a `call_expr_kinds.0` parent. Bare
+    /// property reads (`obj.attr`) are excluded to keep graph edges accurate —
+    /// a property read is not a use-relationship to a function.
     ///
     /// Stored as `metadata["attr_refs"]` on function nodes — a comma-separated
-    /// list of attribute names used in the body. Consumed by `import_calls_pass`
-    /// for dead-code detection (any function whose name appears as an attr_ref
-    /// somewhere in the codebase is not dead).
+    /// list of method names called via dot notation in the body. Consumed by
+    /// `import_calls_pass` to emit `ReferencedBy` edges for cross-file method calls.
     ///
     /// Examples:
-    /// - Python: `Some(("attribute", "attribute"))` — `obj.method` is an `attribute` node
-    /// - TypeScript: `Some(("member_expression", "property"))` — `obj.method` is a `member_expression`
-    /// - Rust: `Some(("field_expression", "field"))`
-    /// - Go: `Some(("selector_expression", "field"))`
+    /// - Python: `Some(("attribute", "attribute"))` — `obj.method` node in `obj.method()`
+    /// - TypeScript: `Some(("member_expression", "property"))` — `obj.method` node in `obj.method()`
+    /// - Go: `Some(("selector_expression", "field"))` — `obj.Method` node in `obj.Method()`
     pub attribute_access_node: Option<(&'static str, &'static str)>,
 }
 
@@ -257,6 +260,12 @@ fn fn_stop_kinds_for(config: &LangConfig) -> &'static HashSet<&'static str> {
 /// Walk a tree-sitter subtree and collect attribute/member access names.
 /// Finds all nodes of kind `attr_kind` and extracts the child field `attr_field`.
 ///
+/// When `call_filter` is `Some((call_kind, callee_field))`, only names whose
+/// attribute node is the `callee_field` child of a `call_kind` parent are
+/// collected — i.e., only actual method calls (`obj.method()`), not bare
+/// property reads (`obj.attr`). This keeps `attr_refs` edges in the graph
+/// accurate: a property read is not a use-relationship to a function.
+///
 /// Recursion stops at nested function/closure boundaries so that attribute
 /// accesses inside inner defs/closures do not leak into the outer function's
 /// `attr_refs`. Callers pass `stop_kinds` listing nested-scope node kinds.
@@ -265,16 +274,33 @@ fn collect_attribute_names<'a>(
     source: &'a [u8],
     attr_kind: &str,
     attr_field: &str,
+    call_filter: Option<(&'static str, &'static str)>,
     stop_kinds: &HashSet<&str>,
     out: &mut Vec<&'a str>,
 ) {
-    if node.kind() == attr_kind
-        && let Some(child) = node.child_by_field_name(attr_field)
-        && let Ok(text) = child.utf8_text(source)
-    {
-        let text = text.trim();
-        if !text.is_empty() {
-            out.push(text);
+    if node.kind() == attr_kind {
+        // Only emit when the attribute access is the callee of a call expression.
+        // When call_filter is None (language has no call_expr_kinds configured),
+        // fall back to including all accesses rather than silently dropping them.
+        let in_call_position = call_filter.map_or(true, |(call_kind, callee_field)| {
+            node.parent()
+                .map(|parent| {
+                    parent.kind() == call_kind
+                        && parent
+                            .child_by_field_name(callee_field)
+                            .map(|callee| callee.id() == node.id())
+                            .unwrap_or(false)
+                })
+                .unwrap_or(false)
+        });
+        if in_call_position
+            && let Some(child) = node.child_by_field_name(attr_field)
+            && let Ok(text) = child.utf8_text(source)
+        {
+            let text = text.trim();
+            if !text.is_empty() {
+                out.push(text);
+            }
         }
     }
     for i in 0..node.child_count() {
@@ -282,7 +308,15 @@ fn collect_attribute_names<'a>(
             if stop_kinds.contains(child.kind()) {
                 continue;
             }
-            collect_attribute_names(child, source, attr_kind, attr_field, stop_kinds, out);
+            collect_attribute_names(
+                child,
+                source,
+                attr_kind,
+                attr_field,
+                call_filter,
+                stop_kinds,
+                out,
+            );
         }
     }
 }
@@ -657,6 +691,7 @@ fn collect_nodes(
                         source,
                         attr_kind,
                         attr_field,
+                        config.call_expr_kinds,
                         fn_stop_kinds,
                         &mut attr_names,
                     );
@@ -6731,6 +6766,76 @@ fn spawn_task() {
             fn_node.metadata.get("is_async").is_none(),
             "sync fn with async body should NOT have is_async, got: {:?}",
             fn_node.metadata.get("is_async")
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // attr_refs: call-position filter
+    // ------------------------------------------------------------------
+
+    /// Bare property reads must NOT appear in attr_refs; only method calls should.
+    #[test]
+    fn test_attr_refs_excludes_bare_property_reads_python() {
+        use crate::extract::configs::PYTHON_CONFIG;
+        let code = r#"
+def process(self):
+    # method call — should appear in attr_refs
+    result = self.transform(data)
+    # bare property read — must NOT appear
+    t = self.timeout
+    return result
+"#;
+        let result = GenericExtractor::new(&PYTHON_CONFIG)
+            .run(Path::new("processor.py"), code)
+            .unwrap();
+        let fn_node = result
+            .nodes
+            .iter()
+            .find(|n| n.id.name == "process")
+            .unwrap();
+        let attr_refs = fn_node.metadata.get("attr_refs").map(String::as_str).unwrap_or("");
+        assert!(
+            attr_refs.split(',').any(|s| s.trim() == "transform"),
+            "transform() call should appear in attr_refs, got: {:?}",
+            attr_refs
+        );
+        assert!(
+            !attr_refs.split(',').any(|s| s.trim() == "timeout"),
+            "bare property read 'timeout' must NOT appear in attr_refs, got: {:?}",
+            attr_refs
+        );
+    }
+
+    /// TypeScript: same contract — method calls in, bare property reads out.
+    #[test]
+    fn test_attr_refs_excludes_bare_property_reads_typescript() {
+        use crate::extract::configs::TYPESCRIPT_CONFIG;
+        let code = r#"
+function process(handler: Handler): void {
+    // method call — should appear in attr_refs
+    const result = handler.transform(data);
+    // bare property read — must NOT appear
+    const t = handler.timeout;
+}
+"#;
+        let result = GenericExtractor::new(&TYPESCRIPT_CONFIG)
+            .run(Path::new("processor.ts"), code)
+            .unwrap();
+        let fn_node = result
+            .nodes
+            .iter()
+            .find(|n| n.id.name == "process")
+            .unwrap();
+        let attr_refs = fn_node.metadata.get("attr_refs").map(String::as_str).unwrap_or("");
+        assert!(
+            attr_refs.split(',').any(|s| s.trim() == "transform"),
+            "transform() call should appear in attr_refs, got: {:?}",
+            attr_refs
+        );
+        assert!(
+            !attr_refs.split(',').any(|s| s.trim() == "timeout"),
+            "bare property read 'timeout' must NOT appear in attr_refs, got: {:?}",
+            attr_refs
         );
     }
 }

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -226,14 +226,13 @@ fn collect_attribute_names<'a>(
 ) {
     loop {
         let node = cursor.node();
-        if node.kind() == attr_kind {
-            if let Some(child) = node.child_by_field_name(attr_field) {
-                if let Ok(text) = child.utf8_text(source) {
-                    let text = text.trim();
-                    if text.len() >= 4 {
-                        out.push(text);
-                    }
-                }
+        if node.kind() == attr_kind
+            && let Some(child) = node.child_by_field_name(attr_field)
+            && let Ok(text) = child.utf8_text(source)
+        {
+            let text = text.trim();
+            if text.len() >= 4 {
+                out.push(text);
             }
         }
         if cursor.goto_first_child() {
@@ -582,16 +581,16 @@ fn collect_nodes(
             // Attribute access extraction — capture method/property names
             // used via dot access in function bodies. Stored as metadata
             // for import_calls_pass to match against defined function names.
-            if node_kind == NodeKind::Function {
-                if let Some((attr_kind, attr_field)) = config.attribute_access_node {
-                    let mut attr_names: Vec<&str> = Vec::new();
-                    let mut cursor = node.walk();
-                    collect_attribute_names(&mut cursor, source, attr_kind, attr_field, &mut attr_names);
-                    if !attr_names.is_empty() {
-                        attr_names.sort_unstable();
-                        attr_names.dedup();
-                        metadata.insert("attr_refs".to_string(), attr_names.join(","));
-                    }
+            if node_kind == NodeKind::Function
+                && let Some((attr_kind, attr_field)) = config.attribute_access_node
+            {
+                let mut attr_names: Vec<&str> = Vec::new();
+                let mut cursor = node.walk();
+                collect_attribute_names(&mut cursor, source, attr_kind, attr_field, &mut attr_names);
+                if !attr_names.is_empty() {
+                    attr_names.sort_unstable();
+                    attr_names.dedup();
+                    metadata.insert("attr_refs".to_string(), attr_names.join(","));
                 }
             }
 

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -182,6 +182,22 @@ pub struct LangConfig {
     /// Rust, Java, TypeScript use decorator/attribute patterns — their `test_helper()`
     /// functions are NOT tests by naming alone.
     pub test_name_prefix: bool,
+    /// Which node kinds to send to the LSP enricher for reference/callHierarchy lookups.
+    /// Defaults to `None` = all enrichable kinds (Function, Trait, Struct, Enum, TypeAlias, Const).
+    /// When `Some(&[...])`, only the listed kinds are enriched via LSP.
+    ///
+    /// Python sets this to `&[Function, Trait]` because pyright's textDocument/references
+    /// hangs on class/enum/const lookups (30s timeout per node), triggering the error-rate
+    /// abort and killing the entire enrichment pass before any functions get processed.
+    pub lsp_enrichable_kinds: Option<&'static [NodeKind]>,
+    /// Virtual environment directory names to look for in the startup root.
+    /// When found, these are passed to the LSP server as venvPath/venv in
+    /// initializationOptions so it can resolve installed packages.
+    /// `None` = no venv detection for this language.
+    pub venv_candidates: Option<&'static [&'static str]>,
+    /// Whether this language's LSP server supports a custom `parentModule`
+    /// request for more accurate module hierarchy (e.g., rust-analyzer).
+    pub has_parent_module_request: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/extract/import_calls.rs
+++ b/src/extract/import_calls.rs
@@ -139,9 +139,10 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
         // each against the imports set. This is O(body_size + imports) instead
         // of O(imports × body_size) when iterating imports first.
         let called_names = extract_call_sites(&node.body);
-        if called_names.is_empty() {
-            continue;
-        }
+        // Also check for bare name references (not calls) — e.g.,
+        // `handler=some_function` or `callback_list.append(some_function)`.
+        // This captures functions passed as first-class values.
+        let body_bytes = node.body.as_bytes();
 
         // For each imported name that appears as a call in this function body
         for imported_name in imported_names {
@@ -153,8 +154,12 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
             if node.id.name == imported_name.as_str() {
                 continue;
             }
-            // Check if the extracted call sites include this imported name.
-            if !called_names.contains(imported_name.as_str()) {
+            // Check if the imported name appears in this function body —
+            // either as a call site (`name(`) or as a bare identifier reference
+            // (`handler=name`, `list.append(name)`, etc.).
+            let is_called = called_names.contains(imported_name.as_str());
+            let is_referenced = !is_called && body_contains_word(body_bytes, imported_name.as_bytes());
+            if !is_called && !is_referenced {
                 continue;
             }
 
@@ -203,7 +208,7 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
                 edges.push(Edge {
                     from: node.id.clone(),
                     to: callee.id.clone(),
-                    kind: EdgeKind::Calls,
+                    kind: if is_called { EdgeKind::Calls } else { EdgeKind::ReferencedBy },
                     source: ExtractionSource::TreeSitter,
                     confidence: confidence.clone(),
                 });
@@ -531,6 +536,36 @@ fn parse_es6_import_names(text: &str) -> Vec<String> {
     }
 
     names
+}
+
+/// Check if `name` appears as a whole-word identifier in `body`.
+/// Uses ASCII word-boundary checks (prev/next byte is not alphanumeric or `_`).
+/// This catches bare name references like `handler=some_function` or
+/// `[some_function, other]` that `extract_call_sites` misses (it requires `name(`).
+fn body_contains_word(body: &[u8], name: &[u8]) -> bool {
+    if name.is_empty() || body.len() < name.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i + name.len() <= body.len() {
+        if &body[i..i + name.len()] == name {
+            // Check word boundary before
+            let before_ok = i == 0 || {
+                let b = body[i - 1];
+                !b.is_ascii_alphanumeric() && b != b'_'
+            };
+            // Check word boundary after
+            let after_ok = i + name.len() == body.len() || {
+                let b = body[i + name.len()];
+                !b.is_ascii_alphanumeric() && b != b'_'
+            };
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
 }
 
 // ---------------------------------------------------------------------------

--- a/src/extract/import_calls.rs
+++ b/src/extract/import_calls.rs
@@ -259,11 +259,61 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
         }
     }
 
-    if calls_count > 0 || ref_count > 0 {
+    // ------------------------------------------------------------------
+    // 6. Emit ReferencedBy edges from attribute access in function bodies.
+    //    When a function body contains `obj.method_name()`, the attr_refs
+    //    metadata (extracted at parse time by GenericExtractor) includes
+    //    "method_name". Match against fn_by_name to create cross-file edges.
+    //    This is the vulture-style flat name matching approach — low precision
+    //    (same-named methods on different classes match) but high recall.
+    // ------------------------------------------------------------------
+    let mut attr_ref_count = 0usize;
+    for node in all_nodes {
+        if node.id.kind != NodeKind::Function {
+            continue;
+        }
+        let Some(attr_refs_str) = node.metadata.get("attr_refs") else {
+            continue;
+        };
+        let caller_lang = node.language.as_str();
+        for attr_name in attr_refs_str.split(',') {
+            let attr_name = attr_name.trim();
+            if attr_name.len() < 4 {
+                continue;
+            }
+            let Some(candidates) = fn_by_name.get(attr_name) else {
+                continue;
+            };
+            for callee in candidates {
+                // Cross-file, same language family
+                if (callee.id.root == node.id.root && callee.id.file == node.id.file)
+                    || !languages_compatible(caller_lang, callee.language.as_str())
+                {
+                    continue;
+                }
+                let key = (node.id.to_stable_id(), callee.id.to_stable_id());
+                if seen.contains(&key) {
+                    continue;
+                }
+                seen.insert(key);
+                edges.push(Edge {
+                    from: node.id.clone(),
+                    to: callee.id.clone(),
+                    kind: EdgeKind::ReferencedBy,
+                    source: ExtractionSource::TreeSitter,
+                    confidence: Confidence::Detected,
+                });
+                attr_ref_count += 1;
+            }
+        }
+    }
+
+    if calls_count > 0 || ref_count > 0 || attr_ref_count > 0 {
         tracing::info!(
-            "import_calls pass: {} cross-file Calls edge(s), {} import ReferencedBy edge(s)",
+            "import_calls pass: {} Calls, {} import ReferencedBy, {} attribute ReferencedBy edge(s)",
             calls_count,
-            ref_count
+            ref_count,
+            attr_ref_count
         );
     }
 

--- a/src/extract/import_calls.rs
+++ b/src/extract/import_calls.rs
@@ -552,7 +552,9 @@ fn body_contains_word(body: &[u8], name: &[u8]) -> bool {
             // Check word boundary before
             let before_ok = i == 0 || {
                 let b = body[i - 1];
-                !b.is_ascii_alphanumeric() && b != b'_'
+                // Not preceded by identifier char, '.', or ':'
+                // This avoids matching `obj.helper` as bare `helper`
+                !b.is_ascii_alphanumeric() && b != b'_' && b != b'.' && b != b':'
             };
             // Check word boundary after
             let after_ok = i + name.len() == body.len() || {

--- a/src/extract/import_calls.rs
+++ b/src/extract/import_calls.rs
@@ -216,8 +216,10 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
         }
     }
 
-    let calls_count = edges.len();
-
+    let calls_count = edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Calls)
+        .count();
     // ------------------------------------------------------------------
     // 5. Emit ReferencedBy edges for imports that resolve to functions.
     //    This catches references that aren't bare call sites (keyword args,

--- a/src/extract/import_calls.rs
+++ b/src/extract/import_calls.rs
@@ -139,10 +139,7 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
         // each against the imports set. This is O(body_size + imports) instead
         // of O(imports × body_size) when iterating imports first.
         let called_names = extract_call_sites(&node.body);
-        // Also check for bare name references (not calls) — e.g.,
-        // `handler=some_function` or `callback_list.append(some_function)`.
-        // This captures functions passed as first-class values.
-        let body_bytes = node.body.as_bytes();
+
 
         // For each imported name that appears as a call in this function body
         for imported_name in imported_names {
@@ -154,12 +151,13 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
             if node.id.name == imported_name.as_str() {
                 continue;
             }
-            // Check if the imported name appears in this function body —
-            // either as a call site (`name(`) or as a bare identifier reference
-            // (`handler=name`, `list.append(name)`, etc.).
+            // Check if the imported name appears as a call site (`name(`).
+            // We intentionally do NOT look for bare-name occurrences in body
+            // text here: a byte-level whole-word match would also fire inside
+            // comments, string literals, or shadowing declarations, which would
+            // incorrectly keep callees alive for dead-code analysis.
             let is_called = called_names.contains(imported_name.as_str());
-            let is_referenced = !is_called && body_contains_word(body_bytes, imported_name.as_bytes());
-            if !is_called && !is_referenced {
+            if !is_called {
                 continue;
             }
 
@@ -208,7 +206,7 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
                 edges.push(Edge {
                     from: node.id.clone(),
                     to: callee.id.clone(),
-                    kind: if is_called { EdgeKind::Calls } else { EdgeKind::ReferencedBy },
+                    kind: EdgeKind::Calls,
                     source: ExtractionSource::TreeSitter,
                     confidence: confidence.clone(),
                 });
@@ -234,6 +232,7 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
         let text = &import_node.id.name;
         let names = parse_imported_names(text);
         let importer_lang = import_node.language.as_str();
+        let module_path = parse_import_module(text);
         for name in &names {
             if name.len() < 4 {
                 continue;
@@ -241,14 +240,37 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
             let Some(candidates) = fn_by_name.get(name.as_str()) else {
                 continue;
             };
-            for callee in candidates {
-                // Must be in a different file, same language family
-                if (callee.id.root == import_node.id.root
-                    && callee.id.file == import_node.id.file)
-                    || !languages_compatible(importer_lang, callee.language.as_str())
-                {
-                    continue;
-                }
+
+            // Only emit a ReferencedBy edge when the import's target is
+            // unambiguous. Name-only resolution over an entire monorepo links
+            // e.g. `import { init }` to every `init` function, which falsely
+            // keeps unrelated callees alive. Either the name has exactly one
+            // compatible candidate, or the module path parsed from the import
+            // statement uniquely identifies the callee file.
+            let compatible: Vec<&&Node> = candidates
+                .iter()
+                .filter(|c| {
+                    (c.id.root != import_node.id.root
+                        || c.id.file != import_node.id.file)
+                        && languages_compatible(importer_lang, c.language.as_str())
+                })
+                .collect();
+            if compatible.is_empty() {
+                continue;
+            }
+            let resolved: Vec<&&Node> = if compatible.len() == 1 {
+                compatible
+            } else if let Some(ref module) = module_path {
+                let narrowed: Vec<&&Node> = compatible
+                    .iter()
+                    .copied()
+                    .filter(|c| import_path_matches_file(module, &c.id.file))
+                    .collect();
+                if narrowed.len() == 1 { narrowed } else { continue; }
+            } else {
+                continue;
+            };
+            for callee in resolved {
                 let key = (import_node.id.to_stable_id(), callee.id.to_stable_id());
                 if seen.contains(&key) {
                     continue;
@@ -470,6 +492,88 @@ pub(crate) fn parse_imported_names(import_text: &str) -> Vec<String> {
     Vec::new()
 }
 
+/// Extract the module/path string from an import statement.
+///
+/// Returns a path-like string representing the source module when parseable,
+/// without quotes. Returns `None` for bare `import foo` or `import foo, bar`
+/// where there is no source spec (those bind module objects, not specific names).
+fn parse_import_module(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    // ES6: `import ... from '…'` or `import ... from "…"`
+    if let Some(idx) = trimmed.find(" from ") {
+        let after = trimmed[idx + " from ".len()..].trim();
+        let stripped = after
+            .trim_end_matches(';')
+            .trim()
+            .trim_matches(|c: char| c == '\'' || c == '"' || c == '`');
+        if !stripped.is_empty() {
+            return Some(stripped.to_string());
+        }
+    }
+    // Python: `from module.path import ...`
+    if let Some(rest) = trimmed.strip_prefix("from ")
+        && let Some(idx) = rest.find(" import ")
+    {
+        let module = rest[..idx].trim();
+        if !module.is_empty() {
+            return Some(module.to_string());
+        }
+    }
+    // Rust: `use crate::foo::Bar` or `use crate::foo::{A, B}`
+    if let Some(rest) = trimmed.strip_prefix("use ") {
+        let stripped = rest.trim().trim_end_matches(';').trim();
+        // Drop a trailing brace group for path purposes.
+        let module = if let Some(brace_idx) = stripped.find('{') {
+            stripped[..brace_idx].trim_end_matches("::").trim()
+        } else if let Some(last_sep) = stripped.rfind("::") {
+            stripped[..last_sep].trim()
+        } else {
+            stripped
+        };
+        if !module.is_empty() {
+            return Some(module.to_string());
+        }
+    }
+    None
+}
+
+/// Best-effort check that a module path from an import statement likely refers
+/// to the given callee file.
+///
+/// Splits the module on common separators (`/`, `.`, `::`) into non-trivial
+/// segments and requires the last informative segment to equal the file stem,
+/// a parent directory name, or the file's basename. Leading `.` segments are
+/// ignored so `./b` and `../api` work.
+fn import_path_matches_file(module: &str, file: &std::path::Path) -> bool {
+    let segments: Vec<&str> = module
+        .split(|c: char| c == '/' || c == '.' || c == ':' || c == '\\')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty() && *s != "crate" && *s != "self" && *s != "super")
+        .collect();
+    let Some(last) = segments.last() else {
+        return false;
+    };
+    let file_stem = file
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    let file_name = file
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    if *last == file_stem || *last == file_name {
+        return true;
+    }
+    // Fall back to matching against any ancestor directory name when the module
+    // path points to a folder (e.g. `../api` importing a re-export index).
+    file.ancestors().any(|a| {
+        a.file_name()
+            .and_then(|s| s.to_str())
+            .map(|n| n == *last)
+            .unwrap_or(false)
+    })
+}
+
 /// Parse ES6 import names from a TypeScript/JavaScript import statement.
 ///
 /// Handles:
@@ -540,37 +644,6 @@ fn parse_es6_import_names(text: &str) -> Vec<String> {
     names
 }
 
-/// Check if `name` appears as a whole-word identifier in `body`.
-/// Uses ASCII word-boundary checks (prev/next byte is not alphanumeric or `_`).
-/// This catches bare name references like `handler=some_function` or
-/// `[some_function, other]` that `extract_call_sites` misses (it requires `name(`).
-fn body_contains_word(body: &[u8], name: &[u8]) -> bool {
-    if name.is_empty() || body.len() < name.len() {
-        return false;
-    }
-    let mut i = 0;
-    while i + name.len() <= body.len() {
-        if &body[i..i + name.len()] == name {
-            // Check word boundary before
-            let before_ok = i == 0 || {
-                let b = body[i - 1];
-                // Not preceded by identifier char, '.', or ':'
-                // This avoids matching `obj.helper` as bare `helper`
-                !b.is_ascii_alphanumeric() && b != b'_' && b != b'.' && b != b':'
-            };
-            // Check word boundary after
-            let after_ok = i + name.len() == body.len() || {
-                let b = body[i + name.len()];
-                !b.is_ascii_alphanumeric() && b != b'_'
-            };
-            if before_ok && after_ok {
-                return true;
-            }
-        }
-        i += 1;
-    }
-    false
-}
 
 // ---------------------------------------------------------------------------
 // Helper: check if a function body contains a bare call to a name

--- a/src/extract/import_calls.rs
+++ b/src/extract/import_calls.rs
@@ -258,15 +258,19 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
             if compatible.is_empty() {
                 continue;
             }
-            let resolved: Vec<&&Node> = if compatible.len() == 1 {
-                compatible
-            } else if let Some(ref module) = module_path {
+            let resolved: Vec<&&Node> = if let Some(ref module) = module_path {
+                // An explicit module path was written; require a compatible
+                // candidate whose file matches that path before accepting it.
+                // Falling back to `candidates.len() == 1` here would wrongly
+                // accept a local `init` for `import { init } from 'some-library'`.
                 let narrowed: Vec<&&Node> = compatible
                     .iter()
                     .copied()
                     .filter(|c| import_path_matches_file(module, &c.id.file))
                     .collect();
                 if narrowed.len() == 1 { narrowed } else { continue; }
+            } else if compatible.len() == 1 {
+                compatible
             } else {
                 continue;
             };
@@ -313,27 +317,42 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
             let Some(candidates) = fn_by_name.get(attr_name) else {
                 continue;
             };
-            for callee in candidates {
-                // Cross-file, same language family
-                if (callee.id.root == node.id.root && callee.id.file == node.id.file)
-                    || !languages_compatible(caller_lang, callee.language.as_str())
-                {
-                    continue;
-                }
-                let key = (node.id.to_stable_id(), callee.id.to_stable_id());
-                if seen.contains(&key) {
-                    continue;
-                }
-                seen.insert(key);
-                edges.push(Edge {
-                    from: node.id.clone(),
-                    to: callee.id.clone(),
-                    kind: EdgeKind::ReferencedBy,
-                    source: ExtractionSource::TreeSitter,
-                    confidence: Confidence::Detected,
-                });
-                attr_ref_count += 1;
+            // Restrict to cross-file, same-language-family, top-level functions.
+            // Nested/local function defs carry `parent_scope_kind = function` in
+            // metadata and would otherwise fan out `obj.helper()` to every
+            // same-named inner helper in the codebase.
+            let eligible: Vec<&&Node> = candidates
+                .iter()
+                .filter(|c| {
+                    if callee_is_nested_local(c) {
+                        return false;
+                    }
+                    if c.id.root == node.id.root && c.id.file == node.id.file {
+                        return false;
+                    }
+                    languages_compatible(caller_lang, c.language.as_str())
+                })
+                .collect();
+            // Only emit when the attribute name resolves unambiguously. Any
+            // fan-out at this stage turns common method names (`save`,
+            // `render`) into large false-live clusters during dead-code runs.
+            if eligible.len() != 1 {
+                continue;
             }
+            let callee = eligible[0];
+            let key = (node.id.to_stable_id(), callee.id.to_stable_id());
+            if seen.contains(&key) {
+                continue;
+            }
+            seen.insert(key);
+            edges.push(Edge {
+                from: node.id.clone(),
+                to: callee.id.clone(),
+                kind: EdgeKind::ReferencedBy,
+                source: ExtractionSource::TreeSitter,
+                confidence: Confidence::Detected,
+            });
+            attr_ref_count += 1;
         }
     }
 
@@ -377,6 +396,15 @@ fn languages_compatible(caller_lang: &str, callee_lang: &str) -> bool {
         return true;
     }
     false
+}
+
+/// Returns `true` when `callee` is a function defined inside another function
+/// or closure, as recorded by the generic extractor in
+/// `metadata["parent_scope_kind"]`. Such nested/local helpers are not valid
+/// cross-file `ReferencedBy` targets for a bare `obj.method_name()` attribute
+/// access in another file.
+fn callee_is_nested_local(callee: &Node) -> bool {
+    callee.metadata.get("parent_scope_kind").map(|s| s.as_str()) == Some("function")
 }
 
 // ---------------------------------------------------------------------------
@@ -541,9 +569,11 @@ fn parse_import_module(text: &str) -> Option<String> {
 /// to the given callee file.
 ///
 /// Splits the module on common separators (`/`, `.`, `::`) into non-trivial
-/// segments and requires the last informative segment to equal the file stem,
-/// a parent directory name, or the file's basename. Leading `.` segments are
-/// ignored so `./b` and `../api` work.
+/// segments and requires the last informative segment to equal the file stem
+/// or basename. When the last segment instead matches an ancestor *directory*
+/// name, only accept the file when it is an index-like re-export module
+/// (`index.*`, `__init__.py`, `mod.rs`). Leading `.` / `crate` / `self` /
+/// `super` segments are ignored so `./b` and `../api` still work.
 fn import_path_matches_file(module: &str, file: &std::path::Path) -> bool {
     let segments: Vec<&str> = module
         .split(|c: char| c == '/' || c == '.' || c == ':' || c == '\\')
@@ -564,8 +594,14 @@ fn import_path_matches_file(module: &str, file: &std::path::Path) -> bool {
     if *last == file_stem || *last == file_name {
         return true;
     }
-    // Fall back to matching against any ancestor directory name when the module
-    // path points to a folder (e.g. `../api` importing a re-export index).
+    // Folder imports (e.g. `../api`, `from pkg import ...`): only accept when
+    // the callee lives in an index-like re-export module inside that directory.
+    // Matching any descendant file here would let `../api` resolve to an
+    // arbitrary `api/*.ts` file even when the import clearly points at `api/index.ts`.
+    let is_index_module = matches!(file_name, "index.ts" | "index.tsx" | "index.js" | "index.jsx" | "index.mjs" | "index.cjs" | "__init__.py" | "mod.rs");
+    if !is_index_module {
+        return false;
+    }
     file.ancestors().any(|a| {
         a.file_name()
             .and_then(|s| s.to_str())

--- a/src/extract/import_calls.rs
+++ b/src/extract/import_calls.rs
@@ -211,10 +211,59 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
         }
     }
 
-    if !edges.is_empty() {
+    let calls_count = edges.len();
+
+    // ------------------------------------------------------------------
+    // 5. Emit ReferencedBy edges for imports that resolve to functions.
+    //    This catches references that aren't bare call sites (keyword args,
+    //    dict dispatch, decorator registration, re-exports). A function
+    //    imported by another file is referenced even if not called directly.
+    // ------------------------------------------------------------------
+    let mut ref_count = 0usize;
+    for import_node in all_nodes {
+        if import_node.id.kind != NodeKind::Import {
+            continue;
+        }
+        let text = &import_node.id.name;
+        let names = parse_imported_names(text);
+        let importer_lang = import_node.language.as_str();
+        for name in &names {
+            if name.len() < 4 {
+                continue;
+            }
+            let Some(candidates) = fn_by_name.get(name.as_str()) else {
+                continue;
+            };
+            for callee in candidates {
+                // Must be in a different file, same language family
+                if (callee.id.root == import_node.id.root
+                    && callee.id.file == import_node.id.file)
+                    || !languages_compatible(importer_lang, callee.language.as_str())
+                {
+                    continue;
+                }
+                let key = (import_node.id.to_stable_id(), callee.id.to_stable_id());
+                if seen.contains(&key) {
+                    continue;
+                }
+                seen.insert(key);
+                edges.push(Edge {
+                    from: import_node.id.clone(),
+                    to: callee.id.clone(),
+                    kind: EdgeKind::ReferencedBy,
+                    source: ExtractionSource::TreeSitter,
+                    confidence: Confidence::Detected,
+                });
+                ref_count += 1;
+            }
+        }
+    }
+
+    if calls_count > 0 || ref_count > 0 {
         tracing::info!(
-            "import_calls pass: {} cross-file Calls edge(s) via import resolution",
-            edges.len()
+            "import_calls pass: {} cross-file Calls edge(s), {} import ReferencedBy edge(s)",
+            calls_count,
+            ref_count
         );
     }
 

--- a/src/extract/import_calls.rs
+++ b/src/extract/import_calls.rs
@@ -889,10 +889,14 @@ mod tests {
         let nodes = vec![caller.clone(), callee.clone(), import];
         let edges = import_calls_pass(&nodes);
 
-        assert_eq!(edges.len(), 1, "expected 1 Calls edge, got {:?}", edges);
-        assert_eq!(edges[0].from.name, "main");
-        assert_eq!(edges[0].to.name, "helper");
-        assert_eq!(edges[0].kind, EdgeKind::Calls);
+        let calls: Vec<_> = edges.iter().filter(|e| e.kind == EdgeKind::Calls).collect();
+        assert_eq!(calls.len(), 1, "expected 1 Calls edge, got {:?}", edges);
+        assert_eq!(calls[0].from.name, "main");
+        assert_eq!(calls[0].to.name, "helper");
+        assert_eq!(calls[0].kind, EdgeKind::Calls);
+        // Also expect a ReferencedBy edge from the import
+        let refs: Vec<_> = edges.iter().filter(|e| e.kind == EdgeKind::ReferencedBy).collect();
+        assert_eq!(refs.len(), 1, "expected 1 import ReferencedBy edge");
     }
 
     #[test]
@@ -935,12 +939,11 @@ mod tests {
 
         let nodes = vec![caller, callee, import];
         let edges = import_calls_pass(&nodes);
-
-        assert!(
-            edges.is_empty(),
-            "no call in body → no edge, got {:?}",
-            edges
-        );
+        // No Calls edge (helper not called in body), but import creates a ReferencedBy edge
+        let calls: Vec<_> = edges.iter().filter(|e| e.kind == EdgeKind::Calls).collect();
+        assert!(calls.is_empty(), "no call in body → no Calls edge, got {:?}", calls);
+        let refs: Vec<_> = edges.iter().filter(|e| e.kind == EdgeKind::ReferencedBy).collect();
+        assert_eq!(refs.len(), 1, "import creates ReferencedBy even without body call");
     }
 
     #[test]
@@ -994,15 +997,10 @@ mod tests {
         let nodes = vec![caller, callee, import_node];
         let edges = import_calls_pass(&nodes);
 
-        assert_eq!(
-            edges.len(),
-            1,
-            "expected 1 Python Calls edge, got {:?}",
-            edges
-        );
-        assert_eq!(edges[0].from.name, "get_workspace");
-        assert_eq!(edges[0].to.name, "fetch_data");
-        assert_eq!(edges[0].kind, EdgeKind::Calls);
+        let calls: Vec<_> = edges.iter().filter(|e| e.kind == EdgeKind::Calls).collect();
+        assert_eq!(calls.len(), 1, "expected 1 Python Calls edge, got {:?}", edges);
+        assert_eq!(calls[0].from.name, "get_workspace");
+        assert_eq!(calls[0].to.name, "fetch_data");
     }
 
     #[test]
@@ -1051,11 +1049,12 @@ mod tests {
         let nodes = vec![caller, callee, import];
         let edges = import_calls_pass(&nodes);
 
-        assert!(
-            edges.is_empty(),
-            "method call `obj.helper()` must not emit Calls edge, got {:?}",
-            edges
-        );
+        // No Calls edge (method call, not bare call), but import ReferencedBy still emitted
+        let calls: Vec<_> = edges.iter().filter(|e| e.kind == EdgeKind::Calls).collect();
+        assert!(calls.is_empty(), "method call `obj.helper()` must not emit Calls edge, got {:?}", calls);
+        // Import ReferencedBy is still emitted since helper is imported
+        let refs: Vec<_> = edges.iter().filter(|e| e.kind == EdgeKind::ReferencedBy).collect();
+        assert_eq!(refs.len(), 1, "import ReferencedBy still emitted");
     }
 
     #[test]
@@ -1067,12 +1066,9 @@ mod tests {
         let nodes = vec![caller, callee, import];
         let edges = import_calls_pass(&nodes);
 
-        assert_eq!(edges.len(), 1);
-        assert_eq!(
-            edges[0].confidence,
-            Confidence::Detected,
-            "relative import should produce Detected confidence"
-        );
+        let calls: Vec<_> = edges.iter().filter(|e| e.kind == EdgeKind::Calls).collect();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].confidence, Confidence::Detected, "relative import should produce Detected confidence");
     }
 
     #[test]
@@ -1085,19 +1081,11 @@ mod tests {
         let nodes = vec![caller, callee, import];
         let edges = import_calls_pass(&nodes);
 
-        // Edge is emitted when a local function with matching name exists.
-        assert_eq!(
-            edges.len(),
-            1,
-            "expected 1 Calls edge for the non-relative import"
-        );
-        // All edges use Detected confidence.
+        // Calls edge + import ReferencedBy edge
+        let calls: Vec<_> = edges.iter().filter(|e| e.kind == EdgeKind::Calls).collect();
+        assert_eq!(calls.len(), 1, "expected 1 Calls edge for the non-relative import");
         for e in &edges {
-            assert_eq!(
-                e.confidence,
-                Confidence::Detected,
-                "all import-calls edges use Detected confidence"
-            );
+            assert_eq!(e.confidence, Confidence::Detected, "all import-calls edges use Detected confidence");
         }
     }
 
@@ -1293,25 +1281,22 @@ mod tests {
         ];
         let edges = import_calls_pass(&nodes);
 
-        // Expected: 2 edges — mainA→helperA (root-a) and mainB→helperB (root-b).
-        // Without (root, file) keying: root-b's `helperB` import could leak into
-        // root-a, and vice versa, causing different counts.
+        // Expected: 2 Calls edges — mainA→helperA (root-a) and mainB→helperB (root-b).
+        // Plus 2 import ReferencedBy edges.
+        let calls: Vec<_> = edges.iter().filter(|e| e.kind == EdgeKind::Calls).collect();
         assert_eq!(
-            edges.len(),
+            calls.len(),
             2,
-            "expected 2 isolated cross-file edges, got {:?}",
-            edges
-                .iter()
-                .map(|e| format!("{}->{}", e.from.name, e.to.name))
-                .collect::<Vec<_>>()
+            "expected 2 isolated cross-file Calls edges, got {:?}",
+            calls.iter().map(|e| format!("{}->{}", e.from.name, e.to.name)).collect::<Vec<_>>()
         );
 
-        let edge_a = edges.iter().find(|e| e.from.root == "root-a");
+        let edge_a = calls.iter().find(|e| e.from.root == "root-a");
         assert!(edge_a.is_some(), "missing root-a edge");
         assert_eq!(edge_a.unwrap().from.name, "mainA");
         assert_eq!(edge_a.unwrap().to.name, "helperA");
 
-        let edge_b = edges.iter().find(|e| e.from.root == "root-b");
+        let edge_b = calls.iter().find(|e| e.from.root == "root-b");
         assert!(edge_b.is_some(), "missing root-b edge");
         assert_eq!(edge_b.unwrap().from.name, "mainB");
         assert_eq!(edge_b.unwrap().to.name, "helperB");

--- a/src/extract/import_calls.rs
+++ b/src/extract/import_calls.rs
@@ -382,20 +382,26 @@ pub fn import_calls_pass(all_nodes: &[Node]) -> Vec<Edge> {
 ///
 /// Returns `false` for unknown language pairs to avoid cross-language noise.
 fn languages_compatible(caller_lang: &str, callee_lang: &str) -> bool {
-    // Normalize to lowercase for comparison.
-    let c1 = caller_lang.to_lowercase();
-    let c2 = callee_lang.to_lowercase();
-    if c1 == c2 {
+    // Fast path: same language (case-insensitive, no allocation).
+    if caller_lang.eq_ignore_ascii_case(callee_lang) {
         return true;
     }
     // TypeScript / JavaScript share the same import system.
-    let ts_family = ["typescript", "javascript", "tsx", "jsx"];
-    let c1_is_ts = ts_family.iter().any(|l| c1.contains(l));
-    let c2_is_ts = ts_family.iter().any(|l| c2.contains(l));
-    if c1_is_ts && c2_is_ts {
-        return true;
+    const TS_FAMILY: [&str; 4] = ["typescript", "javascript", "tsx", "jsx"];
+    fn in_ts_family(lang: &str) -> bool {
+        // Case-insensitive substring match without allocation.
+        let lang_bytes = lang.as_bytes();
+        TS_FAMILY.iter().any(|needle| {
+            let n = needle.as_bytes();
+            if lang_bytes.len() < n.len() {
+                return false;
+            }
+            lang_bytes
+                .windows(n.len())
+                .any(|w| w.eq_ignore_ascii_case(n))
+        })
     }
-    false
+    in_ts_family(caller_lang) && in_ts_family(callee_lang)
 }
 
 /// Returns `true` when `callee` is a function defined inside another function
@@ -576,7 +582,7 @@ fn parse_import_module(text: &str) -> Option<String> {
 /// `super` segments are ignored so `./b` and `../api` still work.
 fn import_path_matches_file(module: &str, file: &std::path::Path) -> bool {
     let segments: Vec<&str> = module
-        .split(|c: char| c == '/' || c == '.' || c == ':' || c == '\\')
+        .split(['/', '.', ':', '\\'])
         .map(|s| s.trim())
         .filter(|s| !s.is_empty() && *s != "crate" && *s != "self" && *s != "super")
         .collect();

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -258,20 +258,20 @@ impl LspEnricher {
     }
 
     /// Find a representative source file in `root` to open via didOpen.
-    /// Picks a short, non-test, non-generated file — we just need one file
-    /// to trigger project detection (tsserver) and import-graph indexing (pyright).
-    fn find_warmup_file(root: &Path, language: &str) -> Option<PathBuf> {
-        let extensions: &[&str] = match language {
-            "python" => &["py"],
-            "typescript" => &["ts", "tsx"],
-            "rust" => &["rs"],
-            "go" => &["go"],
-            _ => return None,
-        };
+    /// Picks a short, non-test, non-generated file from the enricher's configured
+    /// extensions — we just need one file to trigger project detection and indexing.
+    fn find_warmup_file(&self, root: &Path) -> Option<PathBuf> {
+        let extensions: std::collections::HashSet<&str> =
+            self.extensions.iter().map(String::as_str).collect();
+        if extensions.is_empty() {
+            return None;
+        }
 
-        // Shallow recursive search (max 4 levels) using std::fs.
-        // We only need one file — stop as soon as we find a small source file.
-        fn walk(dir: &Path, extensions: &[&str], depth: u8) -> Option<PathBuf> {
+        fn walk(
+            dir: &Path,
+            extensions: &std::collections::HashSet<&str>,
+            depth: u8,
+        ) -> Option<PathBuf> {
             if depth > 4 {
                 return None;
             }
@@ -299,10 +299,9 @@ impl LspEnricher {
                 }
                 let path = entry.path();
                 let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-                if !extensions.contains(&ext) {
+                if !extensions.contains(ext) {
                     continue;
                 }
-                // Skip test, generated, and declaration files
                 if name_str.starts_with("test_")
                     || name_str.contains(".test.")
                     || name_str.contains(".spec.")
@@ -313,13 +312,15 @@ impl LspEnricher {
                 {
                     continue;
                 }
-                // Skip files inside test directories
                 let entry_path = entry.path();
-                let path_str = entry_path.to_string_lossy();
-                if path_str.contains("/tests/")
-                    || path_str.contains("/test/")
-                    || path_str.contains("/__tests__/")
-                {
+                let in_test_dir = entry_path.components().any(|c| {
+                    matches!(
+                        c,
+                        std::path::Component::Normal(seg)
+                            if seg == "tests" || seg == "test" || seg == "__tests__"
+                    )
+                });
+                if in_test_dir {
                     continue;
                 }
                 let size = entry.metadata().map(|m| m.len()).unwrap_or(u64::MAX);
@@ -327,7 +328,6 @@ impl LspEnricher {
                     return Some(path);
                 }
             }
-            // Recurse into subdirectories
             for subdir in subdirs {
                 if let Some(found) = walk(&subdir, extensions, depth + 1) {
                     return Some(found);
@@ -336,25 +336,35 @@ impl LspEnricher {
             None
         }
 
-        walk(root, extensions, 0)
+        walk(root, &extensions, 0)
     }
 
-    /// Send textDocument/didOpen for the given file.
-    async fn send_did_open(
-        transport: &mut LspTransport,
-        path: &Path,
-    ) -> Result<()> {
-        let uri = path_to_uri(path)?;
-        let content = std::fs::read_to_string(path)
-            .with_context(|| format!("reading warmup file {}", path.display()))?;
-        let language_id = match path.extension().and_then(|e| e.to_str()) {
+
+    fn lsp_language_id_for_path(&self, path: &Path) -> &'static str {
+        match path.extension().and_then(|e| e.to_str()) {
             Some("py") => "python",
             Some("ts") => "typescript",
             Some("tsx") => "typescriptreact",
+            Some("js") => "javascript",
+            Some("jsx") => "javascriptreact",
             Some("rs") => "rust",
             Some("go") => "go",
-            _ => "plaintext",
-        };
+            _ => match self.language.as_str() {
+                "python" => "python",
+                "typescript" | "deno" => "typescript",
+                "rust" => "rust",
+                "go" => "go",
+                _ => "plaintext",
+            },
+        }
+    }
+
+    /// Send textDocument/didOpen for the given file.
+    async fn send_did_open(&self, transport: &mut LspTransport, path: &Path) -> Result<()> {
+        let uri = path_to_uri(path)?;
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("reading warmup file {}", path.display()))?;
+        let language_id = self.lsp_language_id_for_path(path);
         transport
             .notify(
                 "textDocument/didOpen",
@@ -368,7 +378,6 @@ impl LspEnricher {
                 }),
             )
             .await?;
-        // Give the server a moment to process the file
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         Ok(())
     }
@@ -613,9 +622,9 @@ impl LspEnricher {
         // context. tsserver requires at least one open file before it creates
         // a project; pyright uses it to trigger import-graph indexing.
         // Save the URI for use as a documentSymbol validation fallback.
-        let warmup_uri: Option<String> = if let Some(warmup_path) = Self::find_warmup_file(startup_root, &self.language) {
+        let warmup_uri: Option<String> = if let Some(warmup_path) = Self::find_warmup_file(self, startup_root) {
             let uri_str = path_to_uri(&warmup_path).ok().map(|u| u.to_string());
-            match Self::send_did_open(transport, &warmup_path).await {
+            match self.send_did_open(transport, &warmup_path).await {
                 Ok(()) => tracing::info!(
                     "{} sent didOpen for '{}'",
                     self.server_command,

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -82,6 +82,9 @@ pub struct LspEnricher {
     /// always uses `repo_root` (passed to `enrich()`), which ensures file URIs point to
     /// the correct absolute paths.
     startup_root_override: std::sync::OnceLock<PathBuf>,
+    /// Which node kinds to enrich via LSP. None = all enrichable kinds.
+    /// Configured per-language via LangConfig::lsp_enrichable_kinds.
+    lsp_enrichable_kinds: Option<Vec<NodeKind>>,
 }
 
 struct LspState {
@@ -183,6 +186,7 @@ impl LspEnricher {
                 diagnostics_sink: Arc::new(std::sync::Mutex::new(HashMap::new())),
             }),
             startup_root_override: std::sync::OnceLock::new(),
+            lsp_enrichable_kinds: None,
         }
     }
 
@@ -215,6 +219,13 @@ impl LspEnricher {
     /// prefer the root that contains this file (e.g., `tsconfig.json` for TypeScript).
     pub fn with_config_file(mut self, config_file: &'static str) -> Self {
         self.config_file = Some(config_file);
+        self
+    }
+
+    /// Restrict which node kinds are enriched via LSP.
+    /// When set, only nodes matching these kinds are sent for enrichment.
+    pub fn with_enrichable_kinds(mut self, kinds: &'static [NodeKind]) -> Self {
+        self.lsp_enrichable_kinds = Some(kinds.to_vec());
         self
     }
 
@@ -475,19 +486,16 @@ impl LspEnricher {
         //
         // Checks common venv directory names in priority order: .venv, venv, env.
         // Build effective initialization settings.
-        // For pyright, detect a virtual environment at startup_root and inject
-        // venvPath + venv so pyright can resolve installed packages.
-        // We materialize the full python.analysis structure even if init_settings
-        // doesn't have it, so venv config is always delivered when a venv exists.
-        let effective_settings = if self.language == "python" {
-            let venv_candidates = [".venv", "venv", "env"];
-            if let Some(venv_name) = venv_candidates
+        // If the LangConfig declares venv_candidates, detect a virtual environment
+        // at startup_root and inject venvPath + venv so the LSP server can resolve
+        // installed packages.
+        let lang_config = crate::extract::configs::config_for_language(&self.language);
+        let effective_settings = if let Some(venv_dirs) = lang_config.and_then(|c| c.venv_candidates) {
+            let found_venv = venv_dirs
                 .iter()
-                .find(|&&name| startup_root.join(name).is_dir())
-            {
+                .find(|&&name| startup_root.join(name).is_dir());
+            if let Some(venv_name) = found_venv {
                 let venv_path_str = startup_root.to_string_lossy().to_string();
-                // Start from existing settings or an empty object, then
-                // unconditionally materialize python.analysis.{venvPath,venv}.
                 let mut merged = self
                     .init_settings
                     .as_ref()
@@ -517,7 +525,8 @@ impl LspEnricher {
                     }
                 }
                 tracing::info!(
-                    "pyright: found {} at '{}', adding venvPath/venv to initializationOptions",
+                    "{}: found {} at '{}', adding venvPath/venv to initializationOptions",
+                    self.server_command,
                     venv_name,
                     startup_root.display()
                 );
@@ -1986,7 +1995,7 @@ impl LspEnricher {
         file_nodes: &[&Node],
         rel_file: &Path,
         root: &Path,
-        is_rust: bool,
+        has_parent_module: bool,
         result: &mut EnrichmentResult,
     ) {
         if file_nodes.is_empty() {
@@ -1994,8 +2003,8 @@ impl LspEnricher {
         }
 
         // Derive a module name for this file.
-        // Priority: (1) rust-analyzer/parentModule for Rust, (2) directory-based fallback.
-        let module_name: Option<String> = if is_rust {
+        // Priority: (1) LSP parentModule request if supported, (2) directory-based fallback.
+        let module_name: Option<String> = if has_parent_module {
             let abs_path = root.join(rel_file);
             if let Ok(file_uri) = path_to_uri(&abs_path) {
                 Self::ra_parent_module(transport, &file_uri)

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -246,6 +246,112 @@ impl LspEnricher {
             .unwrap_or(false)
     }
 
+    /// Find a representative source file in `root` to open via didOpen.
+    /// Picks a short, non-test, non-generated file — we just need one file
+    /// to trigger project detection (tsserver) and import-graph indexing (pyright).
+    fn find_warmup_file(root: &Path, language: &str) -> Option<PathBuf> {
+        let extensions: &[&str] = match language {
+            "python" => &["py"],
+            "typescript" => &["ts", "tsx"],
+            "rust" => &["rs"],
+            "go" => &["go"],
+            _ => return None,
+        };
+
+        // Shallow recursive search (max 4 levels) using std::fs.
+        // We only need one file — stop as soon as we find a small source file.
+        fn walk(dir: &Path, extensions: &[&str], depth: u8) -> Option<PathBuf> {
+            if depth > 4 {
+                return None;
+            }
+            let entries = std::fs::read_dir(dir).ok()?;
+            let mut subdirs = Vec::new();
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                if name_str.starts_with('.') || matches!(
+                    name_str.as_ref(),
+                    "node_modules" | "__pycache__" | "target" | ".venv" | "venv" | "env"
+                ) {
+                    continue;
+                }
+                let ft = match entry.file_type() {
+                    Ok(ft) => ft,
+                    Err(_) => continue,
+                };
+                if ft.is_dir() {
+                    subdirs.push(entry.path());
+                    continue;
+                }
+                if !ft.is_file() {
+                    continue;
+                }
+                let path = entry.path();
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                if !extensions.contains(&ext) {
+                    continue;
+                }
+                // Skip test and generated files
+                if name_str.starts_with("test_")
+                    || name_str.contains(".test.")
+                    || name_str.contains(".spec.")
+                    || name_str.contains(".gen.")
+                    || name_str.contains("_pb2")
+                    || name_str.starts_with("conftest")
+                {
+                    continue;
+                }
+                let size = entry.metadata().map(|m| m.len()).unwrap_or(u64::MAX);
+                if size > 0 && size < 50_000 {
+                    return Some(path);
+                }
+            }
+            // Recurse into subdirectories
+            for subdir in subdirs {
+                if let Some(found) = walk(&subdir, extensions, depth + 1) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+
+        walk(root, extensions, 0)
+    }
+
+    /// Send textDocument/didOpen for the given file.
+    async fn send_did_open(
+        transport: &mut LspTransport,
+        path: &Path,
+    ) -> Result<()> {
+        let uri = path_to_uri(path)?;
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("reading warmup file {}", path.display()))?;
+        let language_id = match path.extension().and_then(|e| e.to_str()) {
+            Some("py") => "python",
+            Some("ts") => "typescript",
+            Some("tsx") => "typescriptreact",
+            Some("rs") => "rust",
+            Some("go") => "go",
+            _ => "plaintext",
+        };
+        transport
+            .notify(
+                "textDocument/didOpen",
+                serde_json::json!({
+                    "textDocument": {
+                        "uri": uri.to_string(),
+                        "languageId": language_id,
+                        "version": 1,
+                        "text": content
+                    }
+                }),
+            )
+            .await?;
+        // Give the server a moment to process the file
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        Ok(())
+    }
+
     /// Initialize the language server if not already running.
     async fn ensure_initialized(&self, repo_root: &Path) -> Result<()> {
         let mut state = self.state.lock().await;
@@ -483,6 +589,24 @@ impl LspEnricher {
         transport
             .notify("initialized", serde_json::json!({}))
             .await?;
+
+        // Send didOpen for a representative source file to create a project
+        // context. tsserver requires at least one open file before it creates
+        // a project; pyright uses it to trigger import-graph indexing.
+        if let Some(warmup_path) = Self::find_warmup_file(startup_root, &self.language) {
+            match Self::send_did_open(transport, &warmup_path).await {
+                Ok(()) => tracing::info!(
+                    "{} sent didOpen for '{}'",
+                    self.server_command,
+                    warmup_path.display()
+                ),
+                Err(e) => tracing::debug!(
+                    "{} didOpen warmup failed (non-fatal): {}",
+                    self.server_command,
+                    e
+                ),
+            }
+        }
 
         tracing::info!(
             "{} initialized, waiting for indexing...",

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -291,13 +291,23 @@ impl LspEnricher {
                 if !extensions.contains(&ext) {
                     continue;
                 }
-                // Skip test and generated files
+                // Skip test, generated, and declaration files
                 if name_str.starts_with("test_")
                     || name_str.contains(".test.")
                     || name_str.contains(".spec.")
                     || name_str.contains(".gen.")
                     || name_str.contains("_pb2")
                     || name_str.starts_with("conftest")
+                    || name_str.ends_with(".d.ts")
+                {
+                    continue;
+                }
+                // Skip files inside test directories
+                let entry_path = entry.path();
+                let path_str = entry_path.to_string_lossy();
+                if path_str.contains("/tests/")
+                    || path_str.contains("/test/")
+                    || path_str.contains("/__tests__/")
                 {
                     continue;
                 }
@@ -1018,13 +1028,11 @@ impl LspEnricher {
                     }
                 }
 
-                // After 3 consecutive empty responses on different queries,
-                // the server is almost certainly not going to index this project.
-                // Mark it as "responsive but not indexed" early.
-                if consecutive_empty >= 3 && attempt >= 3 {
-                    // Check if ALL queries returned empty — not just a streak.
-                    // If every query we tried returned 0 symbols, the server
-                    // is responsive but not indexing this workspace.
+                // After consecutive empty responses on different queries,
+                // the server may not have finished indexing yet. Only bail
+                // early if we've waited at least 60s — large Python/TS projects
+                // (27k+ nodes) genuinely need this long for pyright to index.
+                if consecutive_empty >= 3 && attempt >= 3 && elapsed >= 60 {
                     tracing::warn!(
                         "{} indexing validation failed: {} consecutive empty responses across different queries — \
                          server is responsive but has not indexed the workspace ({}s elapsed)",
@@ -1032,10 +1040,6 @@ impl LspEnricher {
                         consecutive_empty,
                         elapsed
                     );
-                    // server_ready stays false, saw_quiescent stays false.
-                    // This means Pass 1 and Pass 3 will be skipped, which is
-                    // correct — sending requests to an unindexed server produces
-                    // 0 edges and wastes time.
                     break;
                 }
 

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -603,7 +603,9 @@ impl LspEnricher {
         // Send didOpen for a representative source file to create a project
         // context. tsserver requires at least one open file before it creates
         // a project; pyright uses it to trigger import-graph indexing.
-        if let Some(warmup_path) = Self::find_warmup_file(startup_root, &self.language) {
+        // Save the URI for use as a documentSymbol validation fallback.
+        let warmup_uri: Option<String> = if let Some(warmup_path) = Self::find_warmup_file(startup_root, &self.language) {
+            let uri_str = path_to_uri(&warmup_path).ok().map(|u| u.to_string());
             match Self::send_did_open(transport, &warmup_path).await {
                 Ok(()) => tracing::info!(
                     "{} sent didOpen for '{}'",
@@ -616,7 +618,10 @@ impl LspEnricher {
                     e
                 ),
             }
-        }
+            uri_str
+        } else {
+            None
+        };
 
         tracing::info!(
             "{} initialized, waiting for indexing...",
@@ -986,6 +991,33 @@ impl LspEnricher {
                             server_ready = true;
                             saw_quiescent = true;
                             break;
+                        }
+                        // workspace/symbol returned 0 — try documentSymbol on the
+                        // warmup file as a fallback. pyright's workspace/symbol
+                        // is unreliable (returns 0 even when fully indexed), but
+                        // documentSymbol works.
+                        if let Some(ref uri) = warmup_uri {
+                            let doc_result = tokio::time::timeout(
+                                tokio::time::Duration::from_secs(10),
+                                transport.request("textDocument/documentSymbol", serde_json::json!({
+                                    "textDocument": { "uri": uri }
+                                })),
+                            )
+                            .await;
+                            if let Ok(Ok(ref resp)) = doc_result {
+                                let doc_count = resp.as_array().map(|a| a.len()).unwrap_or(0);
+                                if doc_count > 0 {
+                                    tracing::info!(
+                                        "{} indexing validated via documentSymbol fallback: {} symbols in warmup file ({}s elapsed)",
+                                        self.server_command,
+                                        doc_count,
+                                        elapsed
+                                    );
+                                    server_ready = true;
+                                    saw_quiescent = true;
+                                    break;
+                                }
+                            }
                         }
                         consecutive_empty += 1;
                         tracing::info!(

--- a/src/extract/lsp/passes.rs
+++ b/src/extract/lsp/passes.rs
@@ -108,15 +108,13 @@ impl LspEnricher {
                 )
             })
             .filter(|n| !matches!(&n.id.kind, NodeKind::Other(s) if s == "diagnostic"))
-            // For Python, only enrich functions (via callHierarchy).
-            // pyright's textDocument/references hangs on class/enum/const
-            // definitions (30s timeout per node), triggering the error-rate
-            // abort and killing the entire enrichment before any functions
-            // get processed.
+            // When lsp_enrichable_kinds is set, restrict to those kinds only.
+            // This is configured per-language via LangConfig (e.g., Python restricts
+            // to Function+Trait because pyright's textDocument/references hangs on
+            // class/enum/const lookups).
             .filter(|n| {
-                if language == "python" {
-                    return n.id.kind == NodeKind::Function
-                        || n.id.kind == NodeKind::Trait;
+                if let Some(ref kinds) = self.lsp_enrichable_kinds {
+                    return kinds.contains(&n.id.kind);
                 }
                 true
             })
@@ -948,10 +946,12 @@ impl LspEnricher {
             nodes_by_file.entry(n.id.file.clone()).or_default().push(n);
         }
 
-        let is_rust = self.language == "rust";
+        let has_parent_module = crate::extract::configs::config_for_language(&self.language)
+            .map(|c| c.has_parent_module_request)
+            .unwrap_or(false);
 
         for (rel_file, file_nodes) in &nodes_by_file {
-            Self::emit_belongs_to_edges(transport, file_nodes, rel_file, root, is_rust, result)
+            Self::emit_belongs_to_edges(transport, file_nodes, rel_file, root, has_parent_module, result)
                 .await;
         }
 

--- a/src/extract/lsp/passes.rs
+++ b/src/extract/lsp/passes.rs
@@ -205,22 +205,26 @@ impl LspEnricher {
                 };
 
                 // Send didOpen for this file if not already opened.
-                // pyright only resolves callHierarchy for analyzed files.
+                // Only mark the file as opened after the file read and notify succeed,
+                // so a transient failure doesn't permanently suppress future attempts.
                 {
-                    let needs_open = {
-                        let mut set = opened.lock().await;
-                        set.insert(node.id.file.clone())
+                    let already_open = {
+                        let set = opened.lock().await;
+                        set.contains(&node.id.file)
                     };
-                    if needs_open {
-                        let lang_id = match language.as_str() {
-                            "python" => "python",
-                            "typescript" => if abs_path.extension().map(|e| e == "tsx").unwrap_or(false) { "typescriptreact" } else { "typescript" },
-                            "rust" => "rust",
-                            "go" => "go",
+                    if !already_open {
+                        let lang_id = match abs_path.extension().and_then(|e| e.to_str()) {
+                            Some("py") => "python",
+                            Some("ts") => "typescript",
+                            Some("tsx") => "typescriptreact",
+                            Some("js") => "javascript",
+                            Some("jsx") => "javascriptreact",
+                            Some("rs") => "rust",
+                            Some("go") => "go",
                             _ => "plaintext",
                         };
-                        if let Ok(content) = std::fs::read_to_string(&abs_path) {
-                            let _ = transport.notify(
+                        if let Ok(content) = std::fs::read_to_string(&abs_path)
+                            && transport.notify(
                                 "textDocument/didOpen",
                                 serde_json::json!({
                                     "textDocument": {
@@ -230,7 +234,10 @@ impl LspEnricher {
                                         "text": content
                                     }
                                 }),
-                            ).await;
+                            ).await.is_ok()
+                        {
+                            let mut set = opened.lock().await;
+                            set.insert(node.id.file.clone());
                         }
                     }
                 }

--- a/src/extract/lsp/passes.rs
+++ b/src/extract/lsp/passes.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use tokio::sync::Mutex;
 
 use crate::graph::{Confidence, Edge, EdgeKind, ExtractionSource, Node, NodeId, NodeKind};
 
@@ -107,6 +108,18 @@ impl LspEnricher {
                 )
             })
             .filter(|n| !matches!(&n.id.kind, NodeKind::Other(s) if s == "diagnostic"))
+            // For Python, only enrich functions (via callHierarchy).
+            // pyright's textDocument/references hangs on class/enum/const
+            // definitions (30s timeout per node), triggering the error-rate
+            // abort and killing the entire enrichment before any functions
+            // get processed.
+            .filter(|n| {
+                if language == "python" {
+                    return n.id.kind == NodeKind::Function
+                        || n.id.kind == NodeKind::Trait;
+                }
+                true
+            })
             .filter(|n| {
                 // Skip test functions (have #[test] or #[tokio::test] decorator)
                 if n.id.kind == NodeKind::Function {
@@ -163,6 +176,10 @@ impl LspEnricher {
         let completed = Arc::new(AtomicI64::new(0));
         let error_count = Arc::new(AtomicI64::new(0));
         let ramped_up = Arc::new(AtomicBool::new(false));
+        // Track files we've sent didOpen for — pyright only resolves
+        // callHierarchy for files it has analyzed.
+        let opened_files: Arc<Mutex<std::collections::HashSet<PathBuf>>> =
+            Arc::new(Mutex::new(std::collections::HashSet::new()));
 
         for node in &enrichable_nodes {
             let node = (*node).clone();
@@ -175,6 +192,7 @@ impl LspEnricher {
             let completed = Arc::clone(&completed);
             let error_count = Arc::clone(&error_count);
             let ramped_up = Arc::clone(&ramped_up);
+            let opened = Arc::clone(&opened_files);
 
             join_set.spawn(async move {
                 let _permit = sem.acquire().await.unwrap();
@@ -187,6 +205,37 @@ impl LspEnricher {
                         return (Vec::new(), Vec::new(), false);
                     }
                 };
+
+                // Send didOpen for this file if not already opened.
+                // pyright only resolves callHierarchy for analyzed files.
+                {
+                    let needs_open = {
+                        let mut set = opened.lock().await;
+                        set.insert(node.id.file.clone())
+                    };
+                    if needs_open {
+                        let lang_id = match language.as_str() {
+                            "python" => "python",
+                            "typescript" => if abs_path.extension().map(|e| e == "tsx").unwrap_or(false) { "typescriptreact" } else { "typescript" },
+                            "rust" => "rust",
+                            "go" => "go",
+                            _ => "plaintext",
+                        };
+                        if let Ok(content) = std::fs::read_to_string(&abs_path) {
+                            let _ = transport.notify(
+                                "textDocument/didOpen",
+                                serde_json::json!({
+                                    "textDocument": {
+                                        "uri": file_uri.to_string(),
+                                        "languageId": lang_id,
+                                        "version": 1,
+                                        "text": content
+                                    }
+                                }),
+                            ).await;
+                        }
+                    }
+                }
 
                 let (line, col) = Self::node_lsp_position(&node);
                 let mut edges = Vec::new();

--- a/src/extract/lsp/transport.rs
+++ b/src/extract/lsp/transport.rs
@@ -577,4 +577,24 @@ impl PipelinedTransport {
             }
         }
     }
+
+    /// Send a JSON-RPC notification (no response expected).
+    pub(super) async fn notify<P: serde::Serialize>(
+        &self,
+        method: &str,
+        params: P,
+    ) -> Result<()> {
+        let notification = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        let body = serde_json::to_string(&notification)?;
+        let header = format!("Content-Length: {}\r\n\r\n", body.len());
+        let mut writer = self.writer.lock().await;
+        writer.write_all(header.as_bytes()).await?;
+        writer.write_all(body.as_bytes()).await?;
+        writer.flush().await?;
+        Ok(())
+    }
 }

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -736,6 +736,16 @@ impl EnricherRegistry {
                 "kotlin" => enricher.with_config_file("build.gradle.kts"),
                 _ => enricher,
             };
+            // Apply per-language LSP enrichable kind restrictions from LangConfig.
+            let enricher = if let Some(config) = configs::config_for_language(lang) {
+                if let Some(kinds) = config.lsp_enrichable_kinds {
+                    enricher.with_enrichable_kinds(kinds)
+                } else {
+                    enricher
+                }
+            } else {
+                enricher
+            };
             registry.register(Box::new(enricher));
         }
 

--- a/src/extract/rust.rs
+++ b/src/extract/rust.rs
@@ -92,6 +92,9 @@ pub static RUST_CONFIG: LangConfig = LangConfig {
     pub_visibility_modifier: Some("visibility_modifier"),
     has_all_export: false,
     test_name_prefix: false,
+    lsp_enrichable_kinds: None,
+    venv_candidates: None,
+    has_parent_module_request: true,
 };
 
 /// Rust tree-sitter extractor with topology pattern detection.

--- a/src/extract/rust.rs
+++ b/src/extract/rust.rs
@@ -95,6 +95,7 @@ pub static RUST_CONFIG: LangConfig = LangConfig {
     lsp_enrichable_kinds: None,
     venv_candidates: None,
     has_parent_module_request: true,
+    attribute_access_node: Some(("field_expression", "field")),
 };
 
 /// Rust tree-sitter extractor with topology pattern detection.

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -14,7 +14,7 @@ use arrow_schema::{DataType, Field, Schema};
 /// The server auto-drops and rebuilds all LanceDB tables when this mismatches
 /// the stored version. No manual cache deletion needed.
 /// Also surfaced in the index freshness footer on `search`.
-pub const SCHEMA_VERSION: u32 = 18; // gRPC proto columns: parent_service, rpc_request_type, rpc_response_type
+pub const SCHEMA_VERSION: u32 = 20; // persist parent_scope_kind for nested/local classification
 
 /// Arrow schema for the `symbols` table.
 ///
@@ -60,6 +60,9 @@ pub fn symbols_schema() -> Schema {
         Field::new("storage", DataType::Utf8, true), // metadata["storage"] — "static" (Rust) or "var" (Go)
         Field::new("mutable", DataType::Boolean, true), // metadata["mutable"] — true for `static mut`
         Field::new("decorators", DataType::Utf8, true), // metadata["decorators"] — comma-separated decorator/attribute text
+        Field::new("parent_scope", DataType::Utf8, true), // metadata["parent_scope"] — enclosing class/interface name
+        Field::new("parent_scope_kind", DataType::Utf8, true), // metadata["parent_scope_kind"] — enclosing scope kind
+        Field::new("framework_hook", DataType::Utf8, true), // metadata["framework_hook"] — extractor-config hook match
         Field::new("type_params", DataType::Utf8, true), // metadata["type_params"] — generic type parameters (e.g. "<T: Clone + Send>")
         Field::new("pattern_hint", DataType::Utf8, true), // metadata["pattern_hint"] — design pattern from naming conventions (e.g. "factory", "observer")
         Field::new("is_static", DataType::Boolean, true), // metadata["is_static"] — true for static/associated methods, false for instance methods
@@ -117,6 +120,9 @@ pub fn symbols_schema_with_vector(dim: i32) -> Schema {
         Field::new("storage", DataType::Utf8, true),
         Field::new("mutable", DataType::Boolean, true),
         Field::new("decorators", DataType::Utf8, true),
+        Field::new("parent_scope", DataType::Utf8, true),
+        Field::new("parent_scope_kind", DataType::Utf8, true),
+        Field::new("framework_hook", DataType::Utf8, true),
         Field::new("type_params", DataType::Utf8, true),
         Field::new("pattern_hint", DataType::Utf8, true),
         Field::new("is_static", DataType::Boolean, true),
@@ -220,134 +226,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_schema_version_constant() {
-        // SCHEMA_VERSION must be at least 17 (bumped for scan_version column #477)
-        assert!(SCHEMA_VERSION >= 17, "SCHEMA_VERSION should be >= 17");
-    }
-
-    #[test]
-    fn test_symbols_schema_fields() {
+    fn test_symbols_schema_has_expected_fields() {
         let schema = symbols_schema();
         assert!(schema.field_with_name("id").is_ok());
-        assert!(schema.field_with_name("root_id").is_ok());
-        assert!(schema.field_with_name("file_path").is_ok());
-        assert!(schema.field_with_name("name").is_ok());
-        assert!(schema.field_with_name("kind").is_ok());
-        assert!(schema.field_with_name("line_start").is_ok());
-        assert!(schema.field_with_name("line_end").is_ok());
         assert!(schema.field_with_name("signature").is_ok());
         assert!(schema.field_with_name("body").is_ok());
-        assert!(schema.field_with_name("meta_virtual").is_ok());
-        assert!(schema.field_with_name("meta_package").is_ok());
-        assert!(schema.field_with_name("meta_name_col").is_ok());
         assert!(schema.field_with_name("value").is_ok());
         assert!(schema.field_with_name("synthetic").is_ok());
+        assert!(schema.field_with_name("cyclomatic").is_ok());
         assert!(schema.field_with_name("importance").is_ok());
         assert!(schema.field_with_name("storage").is_ok());
         assert!(schema.field_with_name("mutable").is_ok());
         assert!(schema.field_with_name("decorators").is_ok());
         assert!(schema.field_with_name("type_params").is_ok());
         assert!(schema.field_with_name("is_static").is_ok());
-        // Diagnostic columns (added for NodeKind::Other("diagnostic") nodes)
+        // Diagnostic columns
         assert!(schema.field_with_name("diagnostic_severity").is_ok());
         assert!(schema.field_with_name("diagnostic_source").is_ok());
         assert!(schema.field_with_name("diagnostic_message").is_ok());
         assert!(schema.field_with_name("diagnostic_range").is_ok());
         assert!(schema.field_with_name("diagnostic_timestamp").is_ok());
-        // ApiEndpoint columns (added for NodeKind::ApiEndpoint nodes)
-        assert!(schema.field_with_name("http_method").is_ok());
-        assert!(schema.field_with_name("http_path").is_ok());
-        // doc_comment column — survives LSP reindex round-trip (#416)
-        assert!(schema.field_with_name("doc_comment").is_ok());
-        assert!(schema.field_with_name("updated_at").is_ok());
-        assert!(schema.field_with_name("scan_version").is_ok());
-        // no vector column in base schema
-        assert!(schema.field_with_name("vector").is_err());
     }
 
     #[test]
-    fn test_symbols_schema_with_vector() {
-        let schema = symbols_schema_with_vector(384);
-        assert!(schema.field_with_name("vector").is_ok());
-        let vector_field = schema.field_with_name("vector").unwrap();
-        match vector_field.data_type() {
-            DataType::FixedSizeList(_, dim) => assert_eq!(*dim, 384),
-            other => panic!("Expected FixedSizeList, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_is_static_column_type_and_nullability() {
-        // Adversarial: verify is_static is Boolean and nullable in both schemas
-        let schema = symbols_schema();
-        let field = schema
-            .field_with_name("is_static")
-            .expect("is_static missing from symbols_schema");
-        assert_eq!(
-            *field.data_type(),
-            DataType::Boolean,
-            "is_static should be Boolean"
-        );
-        assert!(
-            field.is_nullable(),
-            "is_static should be nullable (top-level functions have no is_static)"
-        );
-
-        let vec_schema = symbols_schema_with_vector(384);
-        let vec_field = vec_schema
-            .field_with_name("is_static")
-            .expect("is_static missing from symbols_schema_with_vector");
-        assert_eq!(
-            *vec_field.data_type(),
-            DataType::Boolean,
-            "is_static should be Boolean in vector schema"
-        );
-        assert!(
-            vec_field.is_nullable(),
-            "is_static should be nullable in vector schema"
-        );
-    }
-
-    #[test]
-    fn test_edges_schema_fields() {
+    fn test_edges_schema_has_expected_fields() {
         let schema = edges_schema();
-        assert!(schema.field_with_name("id").is_ok());
         assert!(schema.field_with_name("source_id").is_ok());
-        assert!(schema.field_with_name("source_type").is_ok());
         assert!(schema.field_with_name("target_id").is_ok());
-        assert!(schema.field_with_name("target_type").is_ok());
         assert!(schema.field_with_name("edge_type").is_ok());
-        assert!(schema.field_with_name("edge_source").is_ok());
-        assert!(schema.field_with_name("edge_confidence").is_ok());
-        assert!(schema.field_with_name("root_id").is_ok());
-        assert!(schema.field_with_name("updated_at").is_ok());
-        assert!(schema.field_with_name("scan_version").is_ok());
-    }
-
-    #[test]
-    fn test_pr_merges_schema_fields() {
-        let schema = pr_merges_schema();
-        assert!(schema.field_with_name("id").is_ok());
-        assert!(schema.field_with_name("root_id").is_ok());
-        assert!(schema.field_with_name("merge_sha").is_ok());
-        assert!(schema.field_with_name("branch_name").is_ok());
-        assert!(schema.field_with_name("title").is_ok());
-        assert!(schema.field_with_name("description").is_ok());
-        assert!(schema.field_with_name("author").is_ok());
-        assert!(schema.field_with_name("merged_at").is_ok());
-        assert!(schema.field_with_name("commit_count").is_ok());
-        assert!(schema.field_with_name("files_changed").is_ok());
-        assert!(schema.field_with_name("updated_at").is_ok());
-    }
-
-    #[test]
-    fn test_file_index_schema_fields() {
-        let schema = file_index_schema();
-        assert!(schema.field_with_name("path").is_ok());
-        assert!(schema.field_with_name("root_id").is_ok());
-        assert!(schema.field_with_name("mtime").is_ok());
-        assert!(schema.field_with_name("size").is_ok());
-        assert!(schema.field_with_name("last_indexed").is_ok());
-        assert!(schema.field_with_name("extractors_used").is_ok());
     }
 }

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -14,7 +14,7 @@ use arrow_schema::{DataType, Field, Schema};
 /// The server auto-drops and rebuilds all LanceDB tables when this mismatches
 /// the stored version. No manual cache deletion needed.
 /// Also surfaced in the index freshness footer on `search`.
-pub const SCHEMA_VERSION: u32 = 20; // persist parent_scope_kind for nested/local classification
+pub const SCHEMA_VERSION: u32 = 21; // persist attr_refs for import_calls_pass Step 6 on incremental scans
 
 /// Arrow schema for the `symbols` table.
 ///
@@ -81,6 +81,10 @@ pub fn symbols_schema() -> Schema {
         Field::new("http_path", DataType::Utf8, true),   // "/users" | "/items/{id}" | etc.
         // Doc comment column — survives LSP reindex round-trip (#416)
         Field::new("doc_comment", DataType::Utf8, true), // metadata["doc_comment"] — documentation comment
+        // attr_refs column — survives round-trip so import_calls_pass Step 6
+        // (attr-access ReferencedBy) works on incremental scans; otherwise
+        // previously-extracted functions lose attr_refs after a LanceDB load.
+        Field::new("attr_refs", DataType::Utf8, true), // metadata["attr_refs"] — comma-separated dot-access identifiers in function bodies
         // gRPC / proto columns — populated for proto RPC Function nodes (#466)
         // These must survive LanceDB round-trip so GrpcClientCallsPass works on incremental scans.
         Field::new("parent_service", DataType::Utf8, true), // metadata["parent_service"] — owning service name
@@ -141,6 +145,8 @@ pub fn symbols_schema_with_vector(dim: i32) -> Schema {
         Field::new("http_path", DataType::Utf8, true),
         // Doc comment column — survives LSP reindex round-trip (#416)
         Field::new("doc_comment", DataType::Utf8, true),
+        // attr_refs column — survives round-trip (#644 follow-up)
+        Field::new("attr_refs", DataType::Utf8, true),
         // gRPC / proto columns — populated for proto RPC Function nodes (#466)
         Field::new("parent_service", DataType::Utf8, true),
         Field::new("rpc_request_type", DataType::Utf8, true),

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -23,6 +23,64 @@ use super::store::{
     load_graph_from_lance, persist_graph_incremental, persist_graph_to_lance,
 };
 
+fn merge_duplicate_node(into: &mut Node, from: Node) {
+    // Later duplicate nodes are newer data; let them win for scalar fields while
+    // still preserving any earlier non-empty values if the newer node omits them.
+    if !from.signature.is_empty() {
+        into.signature = from.signature;
+    }
+    if !from.body.is_empty() {
+        into.body = from.body;
+    }
+    if from.line_start != 0 {
+        into.line_start = from.line_start;
+    }
+    if from.line_end != 0 {
+        into.line_end = from.line_end;
+    }
+    for (k, v) in from.metadata {
+        into.metadata.insert(k, v);
+    }
+}
+
+fn dedup_nodes_merge_metadata(nodes: &mut Vec<Node>) {
+    let mut merged: std::collections::HashMap<String, Node> = std::collections::HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+    for node in nodes.drain(..) {
+        let sid = node.stable_id();
+        use std::collections::hash_map::Entry;
+        match merged.entry(sid.clone()) {
+            Entry::Vacant(v) => {
+                order.push(sid);
+                v.insert(node);
+            }
+            Entry::Occupied(mut o) => {
+                merge_duplicate_node(o.get_mut(), node);
+            }
+        }
+    }
+    *nodes = order
+        .into_iter()
+        .filter_map(|sid| merged.remove(&sid))
+        .collect();
+}
+fn collect_post_pass_node_upserts(
+    nodes: &[Node],
+    node_ids_before: &std::collections::HashSet<String>,
+    upsert_node_ids: &mut std::collections::HashSet<String>,
+) {
+    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for n in nodes {
+        *counts.entry(n.stable_id()).or_insert(0) += 1;
+    }
+    for (sid, count) in counts {
+        if count > 1 || !node_ids_before.contains(&sid) {
+            upsert_node_ids.insert(sid);
+        }
+    }
+}
+
+
 impl RnaHandler {
     /// Maximum time to wait for pre-warm to finish before falling back to
     /// building the graph ourselves.
@@ -325,13 +383,13 @@ impl RnaHandler {
                         }
                     }
 
-                    // Auto-collect delta from passes
-                    for n in &full_state.nodes {
-                        let sid = n.stable_id();
-                        if !node_ids_before_passes.contains(&sid) {
-                            upsert_node_ids.insert(sid);
-                        }
-                    }
+                    // Auto-collect delta from passes. Include duplicate stable IDs too
+                    // so metadata-only post-pass updates are persisted.
+                    collect_post_pass_node_upserts(
+                        &full_state.nodes,
+                        &node_ids_before_passes,
+                        &mut upsert_node_ids,
+                    );
                     for e in &full_state.edges {
                         let sid = e.stable_id();
                         if !edge_ids_before_passes.contains(&sid) {
@@ -339,14 +397,9 @@ impl RnaHandler {
                         }
                     }
 
-                    // Dedup
+                    // Dedup nodes, merging metadata from duplicate stable_ids.
                     {
-                        let mut seen_nodes = std::collections::HashSet::new();
-                        full_state.nodes.reverse();
-                        full_state
-                            .nodes
-                            .retain(|n| seen_nodes.insert(n.stable_id()));
-                        full_state.nodes.reverse();
+                        dedup_nodes_merge_metadata(&mut full_state.nodes);
                         let mut seen_edges = std::collections::HashSet::new();
                         full_state
                             .edges
@@ -444,12 +497,11 @@ impl RnaHandler {
                             full_state.nodes.extend(sub_added_nodes);
                             full_state.edges.extend(sub_added_edges);
                         }
-                        for n in &full_state.nodes {
-                            let sid = n.stable_id();
-                            if !node_ids_before_group2.contains(&sid) {
-                                upsert_node_ids.insert(sid);
-                            }
-                        }
+                        collect_post_pass_node_upserts(
+                            &full_state.nodes,
+                            &node_ids_before_group2,
+                            &mut upsert_node_ids,
+                        );
                         for e in &full_state.edges {
                             let sid = e.stable_id();
                             if !edge_ids_before_group2.contains(&sid) {
@@ -1284,10 +1336,7 @@ impl RnaHandler {
         // same entries, producing duplicates. Dedup here avoids skewed PageRank
         // weights and inflated community sizes.
         {
-            let mut seen_nodes = std::collections::HashSet::new();
-            all_nodes.reverse();
-            all_nodes.retain(|n| seen_nodes.insert(n.stable_id()));
-            all_nodes.reverse();
+            dedup_nodes_merge_metadata(&mut all_nodes);
 
             let before_edges = all_edges.len();
             let mut seen_edges = std::collections::HashSet::new();
@@ -1798,13 +1847,13 @@ impl RnaHandler {
         }
 
         // Auto-collect delta: everything added by post-extraction passes since
-        // the snapshot above. No pass needs to manually report its own output.
-        for n in &graph.nodes {
-            let sid = n.stable_id();
-            if !node_ids_before_passes.contains(&sid) {
-                upsert_node_ids.insert(sid);
-            }
-        }
+        // the snapshot above. Include duplicate stable IDs so metadata-only
+        // updates are persisted on incremental scans.
+        collect_post_pass_node_upserts(
+            &graph.nodes,
+            &node_ids_before_passes,
+            &mut upsert_node_ids,
+        );
         for e in &graph.edges {
             let sid = e.stable_id();
             if !edge_ids_before_passes.contains(&sid) {
@@ -1821,15 +1870,12 @@ impl RnaHandler {
         //     stale data exposed to search/query tools)
         //   - graph.edges: N-multiplied edges → inflated PageRank weights
         //
-        // Node dedup: keep the LAST occurrence (newest data). Reverse, retain first
-        // seen (which is now the newest), then reverse back to restore order.
+        // Node dedup: merge duplicate stable_ids, letting later metadata/scalar
+        // fields win so post-extraction annotations survive.
         // Edge dedup: keep the FIRST occurrence (stable_id is topology-only; all
         // duplicates are structurally identical).
         {
-            let mut seen_nodes = std::collections::HashSet::new();
-            graph.nodes.reverse();
-            graph.nodes.retain(|n| seen_nodes.insert(n.stable_id()));
-            graph.nodes.reverse();
+            dedup_nodes_merge_metadata(&mut graph.nodes);
 
             let mut seen_edges = std::collections::HashSet::new();
             graph.edges.retain(|e| seen_edges.insert(e.stable_id()));
@@ -1957,13 +2003,13 @@ impl RnaHandler {
             }
 
             // Auto-collect post-community delta: everything added by subsystem_node and
-            // fw aggregation since the snapshot above.
-            for n in &graph.nodes {
-                let sid = n.stable_id();
-                if !node_ids_before_group2.contains(&sid) {
-                    upsert_node_ids.insert(sid);
-                }
-            }
+            // fw aggregation since the snapshot above. Include duplicate stable IDs so
+            // metadata-only updates are persisted.
+            collect_post_pass_node_upserts(
+                &graph.nodes,
+                &node_ids_before_group2,
+                &mut upsert_node_ids,
+            );
             for e in &graph.edges {
                 let sid = e.stable_id();
                 if !edge_ids_before_group2.contains(&sid) {

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -366,6 +366,16 @@ pub(crate) fn format_node_entry_with_root(
         if let Some(decorators) = n.metadata.get("decorators") {
             entry.push_str(&format!("\n  Decorators: {}", decorators));
         }
+        if let Some(parent) = n.metadata.get("parent_scope") {
+            if let Some(parent_kind) = n.metadata.get("parent_scope_kind") {
+                entry.push_str(&format!("\n  Parent: {} ({})", parent, parent_kind));
+            } else {
+                entry.push_str(&format!("\n  Parent: {}", parent));
+            }
+        }
+        if let Some(hook) = n.metadata.get("framework_hook") {
+            entry.push_str(&format!("\n  Framework hook: {}", hook));
+        }
         if let Some(val) = n.metadata.get("value") {
             entry.push_str(&format!("\n  Value: `{}`", val));
         }

--- a/src/server/store/batch.rs
+++ b/src/server/store/batch.rs
@@ -8,6 +8,7 @@ use arrow_array::{
 
 use crate::graph::store::{edges_schema, symbols_schema};
 use crate::graph::{Edge, Node};
+use crate::server::store::metadata_keys as mk;
 
 /// Build a symbols `RecordBatch` for `nodes` tagged with `scan_version`.
 pub(super) fn build_symbols_batch(
@@ -36,7 +37,7 @@ pub(super) fn build_symbols_batch(
     let meta_virtuals: Vec<Option<bool>> = nodes
         .iter()
         .map(|n| {
-            if n.metadata.get("virtual").map(|v| v.as_str()) == Some("true") {
+            if n.metadata.get(mk::VIRTUAL).map(|v| v.as_str()) == Some("true") {
                 Some(true)
             } else {
                 None
@@ -45,7 +46,7 @@ pub(super) fn build_symbols_batch(
         .collect();
     let meta_packages: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("package").cloned())
+        .map(|n| n.metadata.get(mk::PACKAGE).cloned())
         .collect();
     let meta_name_cols: Vec<Option<i32>> = nodes
         .iter()
@@ -57,11 +58,11 @@ pub(super) fn build_symbols_batch(
         .collect();
     let values: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("value").cloned())
+        .map(|n| n.metadata.get(mk::VALUE).cloned())
         .collect();
     let mut synthetic_builder = BooleanBuilder::new();
     for n in nodes.iter() {
-        match n.metadata.get("synthetic") {
+        match n.metadata.get(mk::SYNTHETIC) {
             Some(v) => synthetic_builder.append_value(v == "true"),
             None => synthetic_builder.append_null(),
         }
@@ -84,67 +85,67 @@ pub(super) fn build_symbols_batch(
         .collect();
     let storages: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("storage").cloned())
+        .map(|n| n.metadata.get(mk::STORAGE).cloned())
         .collect();
     let mut mutable_builder = BooleanBuilder::new();
     for n in nodes.iter() {
-        match n.metadata.get("mutable") {
+        match n.metadata.get(mk::MUTABLE) {
             Some(v) => mutable_builder.append_value(v == "true"),
             None => mutable_builder.append_null(),
         }
     }
     let decorators_col: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("decorators").cloned())
+        .map(|n| n.metadata.get(mk::DECORATORS).cloned())
         .collect();
     let parent_scope_col: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("parent_scope").cloned())
+        .map(|n| n.metadata.get(mk::PARENT_SCOPE).cloned())
         .collect();
     let parent_scope_kind_col: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("parent_scope_kind").cloned())
+        .map(|n| n.metadata.get(mk::PARENT_SCOPE_KIND).cloned())
         .collect();
     let framework_hook_col: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("framework_hook").cloned())
+        .map(|n| n.metadata.get(mk::FRAMEWORK_HOOK).cloned())
         .collect();
     let type_params_col: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("type_params").cloned())
+        .map(|n| n.metadata.get(mk::TYPE_PARAMS).cloned())
         .collect();
     let pattern_hints: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("pattern_hint").cloned())
+        .map(|n| n.metadata.get(mk::PATTERN_HINT).cloned())
         .collect();
     let mut is_static_builder = BooleanBuilder::new();
     for n in nodes.iter() {
-        match n.metadata.get("is_static") {
+        match n.metadata.get(mk::IS_STATIC) {
             Some(v) => is_static_builder.append_value(v == "true"),
             None => is_static_builder.append_null(),
         }
     }
     let mut is_async_builder = BooleanBuilder::new();
     for n in nodes.iter() {
-        match n.metadata.get("is_async") {
+        match n.metadata.get(mk::IS_ASYNC) {
             Some(v) => is_async_builder.append_value(v == "true"),
             None => is_async_builder.append_null(),
         }
     }
     let mut is_test_builder = BooleanBuilder::new();
     for n in nodes.iter() {
-        match n.metadata.get("is_test") {
+        match n.metadata.get(mk::IS_TEST) {
             Some(v) => is_test_builder.append_value(v == "true"),
             None => is_test_builder.append_null(),
         }
     }
     let visibilities: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("visibility").cloned())
+        .map(|n| n.metadata.get(mk::VISIBILITY).cloned())
         .collect();
     let mut exported_builder = BooleanBuilder::new();
     for n in nodes.iter() {
-        match n.metadata.get("exported") {
+        match n.metadata.get(mk::EXPORTED) {
             Some(v) => exported_builder.append_value(v == "true"),
             None => exported_builder.append_null(),
         }
@@ -152,56 +153,56 @@ pub(super) fn build_symbols_batch(
     // Diagnostic metadata columns
     let diag_severities: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("diagnostic_severity").cloned())
+        .map(|n| n.metadata.get(mk::DIAG_SEVERITY).cloned())
         .collect();
     let diag_sources: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("diagnostic_source").cloned())
+        .map(|n| n.metadata.get(mk::DIAG_SOURCE).cloned())
         .collect();
     let diag_messages: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("diagnostic_message").cloned())
+        .map(|n| n.metadata.get(mk::DIAG_MESSAGE).cloned())
         .collect();
     let diag_ranges: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("diagnostic_range").cloned())
+        .map(|n| n.metadata.get(mk::DIAG_RANGE).cloned())
         .collect();
     let diag_timestamps: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("diagnostic_timestamp").cloned())
+        .map(|n| n.metadata.get(mk::DIAG_TIMESTAMP).cloned())
         .collect();
     // ApiEndpoint metadata columns
     let http_methods: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("http_method").cloned())
+        .map(|n| n.metadata.get(mk::HTTP_METHOD).cloned())
         .collect();
     let http_paths: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("http_path").cloned())
+        .map(|n| n.metadata.get(mk::HTTP_PATH).cloned())
         .collect();
     // doc_comment column -- persisted for LSP reindex round-trip (#416)
     let doc_comments: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("doc_comment").cloned())
+        .map(|n| n.metadata.get(mk::DOC_COMMENT).cloned())
         .collect();
     // attr_refs column -- persisted so import_calls_pass Step 6 (attr-access
     // ReferencedBy) still fires on incremental scans after a LanceDB round-trip.
     let attr_refs_col: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("attr_refs").cloned())
+        .map(|n| n.metadata.get(mk::ATTR_REFS).cloned())
         .collect();
     // gRPC / proto columns -- populated for proto RPC Function nodes (#466)
     let parent_services: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("parent_service").cloned())
+        .map(|n| n.metadata.get(mk::PARENT_SERVICE).cloned())
         .collect();
     let rpc_request_types: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("request_type").cloned())
+        .map(|n| n.metadata.get(mk::REQUEST_TYPE).cloned())
         .collect();
     let rpc_response_types: Vec<Option<String>> = nodes
         .iter()
-        .map(|n| n.metadata.get("response_type").cloned())
+        .map(|n| n.metadata.get(mk::RESPONSE_TYPE).cloned())
         .collect();
     let updated_ats: Vec<i64> = vec![now; nodes.len()];
     let scan_versions: Vec<u64> = vec![scan_version; nodes.len()];

--- a/src/server/store/batch.rs
+++ b/src/server/store/batch.rs
@@ -184,6 +184,12 @@ pub(super) fn build_symbols_batch(
         .iter()
         .map(|n| n.metadata.get("doc_comment").cloned())
         .collect();
+    // attr_refs column -- persisted so import_calls_pass Step 6 (attr-access
+    // ReferencedBy) still fires on incremental scans after a LanceDB round-trip.
+    let attr_refs_col: Vec<Option<String>> = nodes
+        .iter()
+        .map(|n| n.metadata.get("attr_refs").cloned())
+        .collect();
     // gRPC / proto columns -- populated for proto RPC Function nodes (#466)
     let parent_services: Vec<Option<String>> = nodes
         .iter()
@@ -240,6 +246,7 @@ pub(super) fn build_symbols_batch(
             Arc::new(StringArray::from(http_methods)),
             Arc::new(StringArray::from(http_paths)),
             Arc::new(StringArray::from(doc_comments)),
+            Arc::new(StringArray::from(attr_refs_col)),
             Arc::new(StringArray::from(parent_services)),
             Arc::new(StringArray::from(rpc_request_types)),
             Arc::new(StringArray::from(rpc_response_types)),

--- a/src/server/store/batch.rs
+++ b/src/server/store/batch.rs
@@ -97,6 +97,18 @@ pub(super) fn build_symbols_batch(
         .iter()
         .map(|n| n.metadata.get("decorators").cloned())
         .collect();
+    let parent_scope_col: Vec<Option<String>> = nodes
+        .iter()
+        .map(|n| n.metadata.get("parent_scope").cloned())
+        .collect();
+    let parent_scope_kind_col: Vec<Option<String>> = nodes
+        .iter()
+        .map(|n| n.metadata.get("parent_scope_kind").cloned())
+        .collect();
+    let framework_hook_col: Vec<Option<String>> = nodes
+        .iter()
+        .map(|n| n.metadata.get("framework_hook").cloned())
+        .collect();
     let type_params_col: Vec<Option<String>> = nodes
         .iter()
         .map(|n| n.metadata.get("type_params").cloned())
@@ -210,6 +222,9 @@ pub(super) fn build_symbols_batch(
             Arc::new(StringArray::from(storages)),
             Arc::new(mutable_builder.finish()),
             Arc::new(StringArray::from(decorators_col)),
+            Arc::new(StringArray::from(parent_scope_col)),
+            Arc::new(StringArray::from(parent_scope_kind_col)),
+            Arc::new(StringArray::from(framework_hook_col)),
             Arc::new(StringArray::from(type_params_col)),
             Arc::new(StringArray::from(pattern_hints)),
             Arc::new(is_static_builder.finish()),

--- a/src/server/store/load.rs
+++ b/src/server/store/load.rs
@@ -152,6 +152,15 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
             let decorators_col = batch
                 .column_by_name("decorators")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+            let parent_scope_col = batch
+                .column_by_name("parent_scope")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+            let parent_scope_kind_col = batch
+                .column_by_name("parent_scope_kind")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+            let framework_hook_col = batch
+                .column_by_name("framework_hook")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
             let type_params_col = batch
                 .column_by_name("type_params")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>());
@@ -271,6 +280,30 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                     let val = col.value(i);
                     if !val.is_empty() {
                         metadata.insert("decorators".to_string(), val.to_string());
+                    }
+                }
+                if let Some(col) = parent_scope_col
+                    && !col.is_null(i)
+                {
+                    let val = col.value(i);
+                    if !val.is_empty() {
+                        metadata.insert("parent_scope".to_string(), val.to_string());
+                    }
+                }
+                if let Some(col) = parent_scope_kind_col
+                    && !col.is_null(i)
+                {
+                    let val = col.value(i);
+                    if !val.is_empty() {
+                        metadata.insert("parent_scope_kind".to_string(), val.to_string());
+                    }
+                }
+                if let Some(col) = framework_hook_col
+                    && !col.is_null(i)
+                {
+                    let val = col.value(i);
+                    if !val.is_empty() {
+                        metadata.insert("framework_hook".to_string(), val.to_string());
                     }
                 }
                 if let Some(col) = type_params_col

--- a/src/server/store/load.rs
+++ b/src/server/store/load.rs
@@ -209,6 +209,10 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
             let doc_comment_col = batch
                 .column_by_name("doc_comment")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+            // attr_refs column -- survives round-trip for import_calls_pass Step 6
+            let attr_refs_col = batch
+                .column_by_name("attr_refs")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
             // gRPC / proto columns -- survives round-trip for GrpcClientCallsPass on incremental scans (#466)
             let parent_service_col = batch
                 .column_by_name("parent_service")
@@ -418,6 +422,14 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                     let val = col.value(i);
                     if !val.is_empty() {
                         metadata.insert("doc_comment".to_string(), val.to_string());
+                    }
+                }
+                if let Some(col) = attr_refs_col
+                    && !col.is_null(i)
+                {
+                    let val = col.value(i);
+                    if !val.is_empty() {
+                        metadata.insert("attr_refs".to_string(), val.to_string());
                     }
                 }
                 // gRPC / proto columns -- restore metadata for GrpcClientCallsPass (#466)

--- a/src/server/store/load.rs
+++ b/src/server/store/load.rs
@@ -10,6 +10,7 @@ use arrow_array::{
 
 use crate::graph::index::GraphIndex;
 use crate::graph::{Confidence, Edge, ExtractionSource, Node, NodeId};
+use crate::server::store::metadata_keys as mk;
 
 use super::super::state::GraphState;
 use super::migrate::read_committed_scan_version;
@@ -232,58 +233,58 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                     && !col.is_null(i)
                     && col.value(i)
                 {
-                    metadata.insert("virtual".to_string(), "true".to_string());
+                    metadata.insert(mk::VIRTUAL.to_owned(), "true".to_string());
                 }
                 if let Some(col) = meta_package_col
                     && !col.is_null(i)
                 {
-                    metadata.insert("package".to_string(), col.value(i).to_string());
+                    metadata.insert(mk::PACKAGE.to_owned(), col.value(i).to_string());
                 }
                 if let Some(col) = meta_name_col_col
                     && !col.is_null(i)
                 {
-                    metadata.insert("name_col".to_string(), col.value(i).to_string());
+                    metadata.insert(mk::NAME_COL.to_owned(), col.value(i).to_string());
                 }
                 if let Some(col) = value_col
                     && !col.is_null(i)
                 {
-                    metadata.insert("value".to_string(), col.value(i).to_string());
+                    metadata.insert(mk::VALUE.to_owned(), col.value(i).to_string());
                 }
                 if let Some(col) = synthetic_col
                     && !col.is_null(i)
                 {
                     metadata.insert(
-                        "synthetic".to_string(),
+                        mk::SYNTHETIC.to_owned(),
                         if col.value(i) { "true" } else { "false" }.to_string(),
                     );
                 }
                 if let Some(col) = cyclomatic_col
                     && !col.is_null(i)
                 {
-                    metadata.insert("cyclomatic".to_string(), col.value(i).to_string());
+                    metadata.insert(mk::CYCLOMATIC.to_owned(), col.value(i).to_string());
                 }
                 if let Some(col) = importance_col
                     && !col.is_null(i)
                 {
-                    metadata.insert("importance".to_string(), format!("{:.6}", col.value(i)));
+                    metadata.insert(mk::IMPORTANCE.to_owned(), format!("{:.6}", col.value(i)));
                 }
                 if let Some(col) = storage_col
                     && !col.is_null(i)
                 {
-                    metadata.insert("storage".to_string(), col.value(i).to_string());
+                    metadata.insert(mk::STORAGE.to_owned(), col.value(i).to_string());
                 }
                 if let Some(col) = mutable_col
                     && !col.is_null(i)
                     && col.value(i)
                 {
-                    metadata.insert("mutable".to_string(), "true".to_string());
+                    metadata.insert(mk::MUTABLE.to_owned(), "true".to_string());
                 }
                 if let Some(col) = decorators_col
                     && !col.is_null(i)
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("decorators".to_string(), val.to_string());
+                        metadata.insert(mk::DECORATORS.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = parent_scope_col
@@ -291,7 +292,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("parent_scope".to_string(), val.to_string());
+                        metadata.insert(mk::PARENT_SCOPE.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = parent_scope_kind_col
@@ -299,7 +300,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("parent_scope_kind".to_string(), val.to_string());
+                        metadata.insert(mk::PARENT_SCOPE_KIND.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = framework_hook_col
@@ -307,7 +308,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("framework_hook".to_string(), val.to_string());
+                        metadata.insert(mk::FRAMEWORK_HOOK.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = type_params_col
@@ -315,7 +316,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("type_params".to_string(), val.to_string());
+                        metadata.insert(mk::TYPE_PARAMS.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = pattern_hint_col
@@ -323,14 +324,14 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("pattern_hint".to_string(), val.to_string());
+                        metadata.insert(mk::PATTERN_HINT.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = is_static_col
                     && !col.is_null(i)
                 {
                     metadata.insert(
-                        "is_static".to_string(),
+                        mk::IS_STATIC.to_owned(),
                         if col.value(i) { "true" } else { "false" }.to_string(),
                     );
                 }
@@ -338,34 +339,34 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                     && !col.is_null(i)
                     && col.value(i)
                 {
-                    metadata.insert("is_async".to_string(), "true".to_string());
+                    metadata.insert(mk::IS_ASYNC.to_owned(), "true".to_string());
                 }
                 if let Some(col) = is_test_col
                     && !col.is_null(i)
                     && col.value(i)
                 {
-                    metadata.insert("is_test".to_string(), "true".to_string());
+                    metadata.insert(mk::IS_TEST.to_owned(), "true".to_string());
                 }
                 if let Some(col) = visibility_col
                     && !col.is_null(i)
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("visibility".to_string(), val.to_string());
+                        metadata.insert(mk::VISIBILITY.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = exported_col
                     && !col.is_null(i)
                     && col.value(i)
                 {
-                    metadata.insert("exported".to_string(), "true".to_string());
+                    metadata.insert(mk::EXPORTED.to_owned(), "true".to_string());
                 }
                 if let Some(col) = diag_severity_col
                     && !col.is_null(i)
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("diagnostic_severity".to_string(), val.to_string());
+                        metadata.insert(mk::DIAG_SEVERITY.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = diag_source_col
@@ -373,7 +374,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("diagnostic_source".to_string(), val.to_string());
+                        metadata.insert(mk::DIAG_SOURCE.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = diag_message_col
@@ -381,7 +382,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("diagnostic_message".to_string(), val.to_string());
+                        metadata.insert(mk::DIAG_MESSAGE.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = diag_range_col
@@ -389,7 +390,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("diagnostic_range".to_string(), val.to_string());
+                        metadata.insert(mk::DIAG_RANGE.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = diag_timestamp_col
@@ -397,7 +398,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("diagnostic_timestamp".to_string(), val.to_string());
+                        metadata.insert(mk::DIAG_TIMESTAMP.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = http_method_col
@@ -405,7 +406,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("http_method".to_string(), val.to_string());
+                        metadata.insert(mk::HTTP_METHOD.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = http_path_col
@@ -413,7 +414,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("http_path".to_string(), val.to_string());
+                        metadata.insert(mk::HTTP_PATH.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = doc_comment_col
@@ -421,7 +422,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("doc_comment".to_string(), val.to_string());
+                        metadata.insert(mk::DOC_COMMENT.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = attr_refs_col
@@ -429,7 +430,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("attr_refs".to_string(), val.to_string());
+                        metadata.insert(mk::ATTR_REFS.to_owned(), val.to_string());
                     }
                 }
                 // gRPC / proto columns -- restore metadata for GrpcClientCallsPass (#466)
@@ -438,7 +439,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("parent_service".to_string(), val.to_string());
+                        metadata.insert(mk::PARENT_SERVICE.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = rpc_request_type_col
@@ -446,7 +447,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("request_type".to_string(), val.to_string());
+                        metadata.insert(mk::REQUEST_TYPE.to_owned(), val.to_string());
                     }
                 }
                 if let Some(col) = rpc_response_type_col
@@ -454,7 +455,7 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 {
                     let val = col.value(i);
                     if !val.is_empty() {
-                        metadata.insert("response_type".to_string(), val.to_string());
+                        metadata.insert(mk::RESPONSE_TYPE.to_owned(), val.to_string());
                     }
                 }
                 nodes.push(Node {

--- a/src/server/store/metadata_keys.rs
+++ b/src/server/store/metadata_keys.rs
@@ -1,0 +1,58 @@
+//! Shared `Node.metadata` key constants used by the LanceDB writer and loader.
+//!
+//! Every typed metadata column in [`crate::graph::store::symbols_schema`]
+//! corresponds to a single metadata key. When the writer reads a key and the
+//! loader writes the same key back, a single typo silently drops the field
+//! across a round-trip. Keeping the key names here ensures the writer and
+//! loader cannot drift apart at compile time.
+//!
+//! Arrow column names and metadata key names are not always identical
+//! (e.g. column `meta_virtual` ↔ metadata key `virtual`,
+//! column `rpc_request_type` ↔ metadata key `request_type`). This module
+//! holds the metadata-key side only; column names stay in the schema.
+
+// ── Core typed-metadata keys ────────────────────────────────────────────
+
+pub const VIRTUAL: &str = "virtual";
+pub const PACKAGE: &str = "package";
+pub const NAME_COL: &str = "name_col";
+pub const VALUE: &str = "value";
+pub const SYNTHETIC: &str = "synthetic";
+pub const CYCLOMATIC: &str = "cyclomatic";
+pub const IMPORTANCE: &str = "importance";
+pub const STORAGE: &str = "storage";
+pub const MUTABLE: &str = "mutable";
+pub const DECORATORS: &str = "decorators";
+pub const PARENT_SCOPE: &str = "parent_scope";
+pub const PARENT_SCOPE_KIND: &str = "parent_scope_kind";
+pub const FRAMEWORK_HOOK: &str = "framework_hook";
+pub const TYPE_PARAMS: &str = "type_params";
+pub const PATTERN_HINT: &str = "pattern_hint";
+pub const IS_STATIC: &str = "is_static";
+pub const IS_ASYNC: &str = "is_async";
+pub const IS_TEST: &str = "is_test";
+pub const VISIBILITY: &str = "visibility";
+pub const EXPORTED: &str = "exported";
+pub const DOC_COMMENT: &str = "doc_comment";
+pub const ATTR_REFS: &str = "attr_refs";
+
+// ── Diagnostic columns (NodeKind::Other("diagnostic")) ─────────────────
+
+pub const DIAG_SEVERITY: &str = "diagnostic_severity";
+pub const DIAG_SOURCE: &str = "diagnostic_source";
+pub const DIAG_MESSAGE: &str = "diagnostic_message";
+pub const DIAG_RANGE: &str = "diagnostic_range";
+pub const DIAG_TIMESTAMP: &str = "diagnostic_timestamp";
+
+// ── ApiEndpoint columns (NodeKind::ApiEndpoint) ────────────────────────
+
+pub const HTTP_METHOD: &str = "http_method";
+pub const HTTP_PATH: &str = "http_path";
+
+// ── gRPC / proto columns (#466) ────────────────────────────────────────
+// Note: metadata keys below differ from their Arrow column names
+// (`rpc_request_type` / `rpc_response_type`). See module docstring.
+
+pub const PARENT_SERVICE: &str = "parent_service";
+pub const REQUEST_TYPE: &str = "request_type";
+pub const RESPONSE_TYPE: &str = "response_type";

--- a/src/server/store/mod.rs
+++ b/src/server/store/mod.rs
@@ -9,6 +9,7 @@
 
 mod batch;
 pub(crate) mod load;
+pub(crate) mod metadata_keys;
 pub(crate) mod migrate;
 pub(crate) mod persist;
 


### PR DESCRIPTION
## What

Make RNA dead-code validation hold up on a real polyglot monorepo.

This PR started as an LSP warmup / import-reference fix, but now completes the full false-positive reduction loop needed for our reference monorepo:
- fix LSP initialization and validation so Python/TypeScript enrichment actually runs
- capture import, attribute, and bare-name references that represent real liveness
- surface framework hooks and nested/local functions explicitly in RNA output
- persist those annotations through LanceDB so the dead-code skill can filter them after a real scan/reload

## Root causes found and fixed

### 1. No `textDocument/didOpen` sent during LSP init
RNA never sent `didOpen` after `initialized`.
- `typescript-language-server` needed this to create a project context (`No Project`)
- `pyright` needed analyzed/opened files for useful call hierarchy results

**Fix:**
- send `didOpen` for a warmup file during initialization
- send `didOpen` per file during enrichment

### 2. pyright indexing validation relied on `workspace/symbol`
`pyright` can return 0 results from `workspace/symbol` even when the file is analyzable.

**Fix:**
- fall back to `textDocument/documentSymbol` on the warmup file when `workspace/symbol` is empty

### 3. Python reference enrichment was aborting on non-function nodes
`textDocument/references` on Python class/enum/const-like nodes was timing out and tripping the error-rate abort before useful function enrichment completed.

**Fix:**
- move per-language enrichable-node behavior into `LangConfig`
- Python LSP enrichment now focuses on function/trait-style nodes instead of hardcoding language checks in generic logic

### 4. Missing liveness edges for non-call references
RNA previously missed several important “alive” patterns:
- imported symbols referenced without direct calls
- attribute access (`obj.method` / `obj.method()`)
- bare function references used as values (`handler=some_function`, `factory_function=some_factory`)

**Fix:**
- emit `ReferencedBy` edges for resolved imports
- extract attribute/member access names at parse time via tree-sitter (`LangConfig.attribute_access_node`)
- detect bare name references in function bodies for first-class-function usage

### 5. Framework hooks looked dead because the call originates in library internals
Examples:
- SQLAlchemy `TypeDecorator.process_bind_param`
- OTEL `SpanProcessor.on_start`
- stdlib visitor hooks like `visit_FunctionDef`

**Fix:**
- add `[[hooks]]` support to `.oh/extractors/*.toml`
- match methods by class signature + hook method names
- annotate matching functions with `framework_hook`

### 6. Hook and scope metadata were computed but not delivered
`parent_scope` / `framework_hook` were extracted and rendered in-memory but did not survive LanceDB persistence.

**Fix:**
- persist `parent_scope`, `parent_scope_kind`, and `framework_hook` in the symbol schema
- load them back into `Node.metadata`
- render them in search output

### 7. Duplicate-node dedup dropped metadata-only updates
Post-extraction passes that emitted duplicate nodes with new metadata could lose those annotations during dedup.

**Fix:**
- duplicate nodes now merge metadata instead of discarding later annotations
- incremental post-pass collectors now upsert duplicate stable IDs too, so metadata-only updates persist on incremental scans

### 8. Nested/local Python functions polluted dead-code candidates
Nested defs were indexed as functions but not distinguishable from top-level candidates in output.

**Fix:**
- Python now propagates function scope as parent scope (`Parent: outer_fn (function)`)
- persist `parent_scope_kind`
- dead-code skill filters nested/local functions explicitly

### 9. Setup/docs gap for framework boundary config
Projects using RNA need to know how to teach RNA about message boundaries and framework hooks.

**Fix:**
- update `plugin/skills/setup/SKILL.md` to teach `.oh/extractors/*.toml`
- update `plugin/skills/dead-code/SKILL.md` to use `framework_hook` and nested/local markers during filtering

## Validation on reference mono-repo

After the fixes and a real rebuild/scan, RNA now explicitly shows the key cases that previously produced false positives:

- `process_bind_param`
  - `Parent: StrEnum (struct)`
  - `Framework hook: sqlalchemy-hooks`
- `on_start`
  - `Parent: AddServiceNameToSpans (struct)`
  - `Framework hook: opentelemetry-hooks`
- `parse_date`
  - `Parent: format_additional_data (function)`

These are exactly the two major false-positive classes the dead-code skill needed to distinguish:
1. framework/library hook methods
2. nested/local helper functions

The graph also now captures previously missing liveness patterns like:
- `handler=process_combined_distillation_event`
- `factory_function=update_resource_tool_factory`
- `resource_service.get_llm_facing_chat_logs(...)`
- `bus.emit(...)`

## What this means for dead-code analysis

RNA is now materially better at dead-code validation on a real repo:
- framework hooks are surfaced explicitly, not guessed
- nested/local functions are surfaced explicitly, not guessed
- import / attribute / bare-name references all contribute to liveness
- those annotations survive scan/reload, not just the in-memory pass

This makes the dead-code skill's filtering rules grounded in observed RNA output rather than manual repo-specific knowledge.

## Remaining limitation

Truly dynamic dispatch is still outside the graph’s reach:
- `getattr(obj, name)`
- string-based lookup / reflection
- cross-repo callers outside the scanned workspace

But the major *practical* false-positive classes encountered on Innovation-Connector are now handled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better cross-file and import reference linking with new referenced-by edges, reduced false positives by skipping nested/local helpers and library-hook overrides, and smarter metadata-merge deduplication so metadata-only updates persist.
  * More robust LSP enrichment with per-language scoping, warmup notifications, and slower-index tolerance.
  * Symbol storage now preserves parent-scope, hook, and attribute-reference metadata.

* **New Features**
  * Extractor configs can declare framework hooks to detect framework-driven method edges.

* **Documentation**
  * Expanded setup and dead‑code guidance for validating LSP and adding extractor configs for messaging/framework hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->