### PR TITLE
fix(test-suite): scope direct-pass-call ADR check to call sites only

### DIFF
--- a/scripts/test-suite.sh
+++ b/scripts/test-suite.sh
@@ -145,9 +145,11 @@ check "EventBus::register exists" \
   "grep -c 'pub fn register' $RNA_REPO/src/extract/event_bus.rs" "[1-9]"
 check "consumers.rs built-in consumers present" \
   "grep -c 'ExtractionConsumer for' $RNA_REPO/src/extract/consumers.rs" "[1-9]"
-# ADR constraint: no direct pass calls in server/ (bus must coordinate)
+# ADR constraint: no direct pass calls in src/server/ (bus must coordinate).
+# Match the call form `name(` only; mentions in comments, docstrings, error
+# messages, and test assertions are not architectural violations.
 check "ADR constraint: no direct pass calls in server/" \
-  "grep -r 'api_link_pass\|tested_by_pass\|import_calls_pass' $RNA_REPO/src/server/ 2>/dev/null | grep -v '//\|test' | wc -l | tr -d ' '" "^0$"
+  "grep -rE 'api_link_pass\\(|tested_by_pass\\(|import_calls_pass\\(' $RNA_REPO/src/server/ 2>/dev/null | grep -v '//\|test' | wc -l | tr -d ' '" "^0$"
 
 # ── Custom Extractor Config (#468 / #494) ─────────────────────────────────────
 # The extractor_config_pass_with_configs function must be callable and produce


### PR DESCRIPTION
## What

Tighten the test-suite's "no direct pass calls in `src/server/`" check from a
substring grep to a call-site grep (`name(` form only).

## Why

PR #655 (the rebased #652) merged after #654 and added regression-test assertion
strings in `src/server/store/persist.rs` that mention `import_calls_pass` by name:

```rust
"attr_refs metadata dropped on round-trip; import_calls_pass step 6 \
 would silently stop emitting edges on cached loads",
```

The pre-existing test-suite check at `scripts/test-suite.sh:149` used
`grep -r 'api_link_pass\|tested_by_pass\|import_calls_pass' src/server/ | grep -v '//\|test'`
which matched this assertion message because:

- The string literal continuation line doesn't start with `//`.
- The token `test` doesn't appear on that specific line.

Result: post-merge `bash scripts/test-suite.sh` on main shows 1 FAIL even though
the architectural invariant is intact.

## Fix

The architectural rule is "no direct pass *calls* in `src/server/`", not
"no mentions of pass names." Match the function-call form `name(` only:

```bash
grep -rE 'api_link_pass\(|tested_by_pass\(|import_calls_pass\(' src/server/ \
  | grep -v '//\|test'
```

Comments, docstrings, error-message strings, and test-assertion messages are
not violations and now correctly slip through.

## Verification

```
bash scripts/test-suite.sh
=== RESULTS: 111 passed, 0 failed, 2 skipped ===
ALL TESTS PASSING (excluding skipped)
```

The 2 SKIPs are unchanged: IC repo (no local Innovation-Connector cache) and
ReferencedBy edge count from cached load (will pass once an `#652`-aware
binary is reinstalled — the currently-installed CI fast build sha
`2c0bc7b48...` predates `#652`'s persistence fix).

## Relation to #650

This is a test-suite hygiene follow-up that surfaced from the merge order
between #654 (closes #650) and #655 (rebased #652). Not folded back into #650
because the regression came from a sibling PR's content, not from #650's own
changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test constraint validation to more accurately detect specific function calls, reducing false positives in code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->