### PR TITLE
Add canonical enrichment executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ CLI and MCP share the same index. Run `scan --full` from the CLI to build the co
 | `search "auth"` | `search(query="auth")` | Find symbols by name |
 | `graph --node <id> --mode neighbors` | `search(node="<id>", mode="neighbors")` | Graph traversal |
 | `scan --full` | *(runs automatically on first query)* | Full pipeline: scan → extract → embed → LSP → graph |
+| `enrich --capability embeddings --scope repo` | — | Run one enrichment capability against an existing cache without re-extracting source |
 | `test` | — | 29 pipeline checks end-to-end |
 
 ### CLI Subcommands
@@ -188,6 +189,7 @@ CLI and MCP share the same index. Run `scan --full` from the CLI to build the co
 | `graph --node <id> --mode <mode>` | Traverse neighbors, impact analysis, or reachability |
 | `scan --repo <dir>` | Scan + extract + embed + persist |
 | `scan --repo <dir> --full` | Full pipeline including LSP enrichment. Incremental on repeat runs. |
+| `enrich --repo <dir> --capability embeddings\|call-references --scope repo\|root\|changed` | Run selected enrichment against an existing graph cache without source extraction. Use `--root <slug>` with `--scope root`; use `--no-background-continuation` to skip remaining repo-wide coverage. |
 | `stats --repo <dir>` | Show repo stats from persisted index (no re-scan) |
 | `test --repo <dir>` | Run 29 pipeline checks end-to-end |
 | `adr compile --repo <dir>` | Compile ADR frontmatter into `.oh/adr-validation/*.json` and refresh `docs/ADRs/README.md` when present |

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ use rust_mcp_sdk::schema::{Implementation, InitializeResult, ServerCapabilities}
 use repo_native_alignment::adr::{self, ValidateSelection};
 use repo_native_alignment::roots::WorkspaceConfig;
 use repo_native_alignment::server::{
-    self, EnrichmentCapability, EnrichmentJobLedger, EnrichmentScope, RnaHandler,
-    ScanEnrichmentOptions,
+    self, EnrichmentCapability, EnrichmentContinuation, EnrichmentJobLedger, EnrichmentScope,
+    RnaHandler, ScanEnrichmentOptions,
 };
 use repo_native_alignment::service::{
     self, GraphParams, OutcomeProgressContext, OutcomeProgressParams, RepoMapContext,
@@ -100,7 +100,7 @@ struct EnrichArgs {
     /// Workspace root slug to enrich when `--scope root` is selected.
     #[arg(long)]
     root: Option<String>,
-    /// Do not continue repo-wide enrichment in the background after the requested scope completes.
+    /// Do not continue repo-wide enrichment after the requested scope completes.
     #[arg(long)]
     no_background_continuation: bool,
 }
@@ -562,6 +562,12 @@ async fn async_main() -> anyhow::Result<()> {
         Some(Commands::Enrich(args)) => {
             init_tracing("info", log_path.as_deref());
             let repo_root = args.repo.canonicalize()?;
+            let workspace_config = WorkspaceConfig::load()
+                .with_primary_root(repo_root.clone())
+                .with_worktrees(&repo_root)
+                .with_claude_memory(&repo_root)
+                .with_agent_memories(&repo_root)
+                .with_declared_roots(&repo_root);
             let capability = match args.capability {
                 EnrichCapabilityArg::Embeddings => EnrichmentCapability::Embeddings,
                 EnrichCapabilityArg::CallReferences => EnrichmentCapability::CallReferences,
@@ -570,15 +576,25 @@ async fn async_main() -> anyhow::Result<()> {
                 EnrichScopeArg::Repo => EnrichmentScope::Repo,
                 EnrichScopeArg::Changed => EnrichmentScope::ChangedFiles,
                 EnrichScopeArg::Root => {
-                    EnrichmentScope::Root(args.root.clone().ok_or_else(|| {
+                    let root = args.root.clone().ok_or_else(|| {
                         anyhow::anyhow!("--root <slug> is required when --scope root is selected")
-                    })?)
+                    })?;
+                    let known_roots: Vec<String> = workspace_config
+                        .resolved_roots()
+                        .into_iter()
+                        .map(|root| root.slug)
+                        .collect();
+                    if !known_roots.iter().any(|known| known == &root) {
+                        anyhow::bail!(
+                            "unknown root slug `{}`; known roots: {}",
+                            root,
+                            known_roots.join(", ")
+                        );
+                    }
+                    EnrichmentScope::Root(root)
                 }
             };
-            let lsp_only_roots = WorkspaceConfig::load()
-                .with_primary_root(repo_root.clone())
-                .with_declared_roots(&repo_root)
-                .lsp_only_roots();
+            let lsp_only_roots = workspace_config.lsp_only_roots();
             let handler = RnaHandler {
                 repo_root: repo_root.clone(),
                 lsp_only_roots: Arc::new(lsp_only_roots),
@@ -608,7 +624,11 @@ async fn async_main() -> anyhow::Result<()> {
                 .run_explicit_enrichment(
                     capability,
                     scope,
-                    !args.no_background_continuation,
+                    if args.no_background_continuation {
+                        EnrichmentContinuation::Disabled
+                    } else {
+                        EnrichmentContinuation::RunToCompletion
+                    },
                     |msg| {
                         eprintln!("{}", msg);
                     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,17 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use rust_mcp_sdk::McpServer;
 use rust_mcp_sdk::ToMcpServerHandler;
 use rust_mcp_sdk::schema::{Implementation, InitializeResult, ServerCapabilities};
 
 use repo_native_alignment::adr::{self, ValidateSelection};
 use repo_native_alignment::roots::WorkspaceConfig;
-use repo_native_alignment::server::{self, EnrichmentJobLedger, RnaHandler, ScanEnrichmentOptions};
+use repo_native_alignment::server::{
+    self, EnrichmentCapability, EnrichmentJobLedger, EnrichmentScope, RnaHandler,
+    ScanEnrichmentOptions,
+};
 use repo_native_alignment::service::{
     self, GraphParams, OutcomeProgressContext, OutcomeProgressParams, RepoMapContext,
     RepoMapParams, SearchContext, SearchParams,
@@ -39,6 +42,7 @@ enum Commands {
     Setup(SetupArgs),
     Test(TestArgs),
     Scan(ScanArgs),
+    Enrich(EnrichArgs),
     Search(SearchArgs),
     Graph(GraphArgs),
     Stats(StatsArgs),
@@ -83,6 +87,35 @@ struct ScanArgs {
     no_embed: bool,
     #[arg(long, default_value = ".")]
     repo: PathBuf,
+}
+
+#[derive(clap::Args, Debug)]
+struct EnrichArgs {
+    #[arg(long, default_value = ".")]
+    repo: PathBuf,
+    #[arg(long, value_enum)]
+    capability: EnrichCapabilityArg,
+    #[arg(long, value_enum, default_value_t = EnrichScopeArg::Repo)]
+    scope: EnrichScopeArg,
+    /// Workspace root slug to enrich when `--scope root` is selected.
+    #[arg(long)]
+    root: Option<String>,
+    /// Do not continue repo-wide enrichment in the background after the requested scope completes.
+    #[arg(long)]
+    no_background_continuation: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum EnrichCapabilityArg {
+    Embeddings,
+    CallReferences,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum EnrichScopeArg {
+    Repo,
+    Root,
+    Changed,
 }
 #[derive(clap::Args, Debug)]
 struct SearchArgs {
@@ -524,6 +557,63 @@ async fn async_main() -> anyhow::Result<()> {
             }
             let elapsed = t0.elapsed();
             print_scan_summary(&graph, handler.embed_index.load().is_some(), elapsed);
+            return Ok(());
+        }
+        Some(Commands::Enrich(args)) => {
+            init_tracing("info", log_path.as_deref());
+            let repo_root = args.repo.canonicalize()?;
+            let capability = match args.capability {
+                EnrichCapabilityArg::Embeddings => EnrichmentCapability::Embeddings,
+                EnrichCapabilityArg::CallReferences => EnrichmentCapability::CallReferences,
+            };
+            let scope = match args.scope {
+                EnrichScopeArg::Repo => EnrichmentScope::Repo,
+                EnrichScopeArg::Changed => EnrichmentScope::ChangedFiles,
+                EnrichScopeArg::Root => {
+                    EnrichmentScope::Root(args.root.clone().ok_or_else(|| {
+                        anyhow::anyhow!("--root <slug> is required when --scope root is selected")
+                    })?)
+                }
+            };
+            let lsp_only_roots = WorkspaceConfig::load()
+                .with_primary_root(repo_root.clone())
+                .with_declared_roots(&repo_root)
+                .lsp_only_roots();
+            let handler = RnaHandler {
+                repo_root: repo_root.clone(),
+                lsp_only_roots: Arc::new(lsp_only_roots),
+                ..Default::default()
+            };
+            let graph = match try_load_cached_graph(&repo_root).await? {
+                Some(graph) => graph,
+                None => anyhow::bail!(
+                    "no cached graph found for {}; run `repo-native-alignment scan --extract-only --repo {}` first",
+                    repo_root.display(),
+                    repo_root.display()
+                ),
+            };
+            handler.graph.store(Arc::new(Some(Arc::new(graph))));
+            if capability == EnrichmentCapability::Embeddings
+                && let Some(embed_idx) = load_existing_embedding_index(&repo_root, |msg| {
+                    tracing::warn!(
+                        "{}; explicit embedding enrichment may need a repo-scope run",
+                        msg
+                    );
+                })
+                .await
+            {
+                handler.embed_index.store(Arc::new(Some(embed_idx)));
+            }
+            handler
+                .run_explicit_enrichment(
+                    capability,
+                    scope,
+                    !args.no_background_continuation,
+                    |msg| {
+                        eprintln!("{}", msg);
+                    },
+                )
+                .await?;
             return Ok(());
         }
         Some(Commands::Search(args)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -609,16 +609,23 @@ async fn async_main() -> anyhow::Result<()> {
                 ),
             };
             handler.graph.store(Arc::new(Some(Arc::new(graph))));
-            if capability == EnrichmentCapability::Embeddings
-                && let Some(embed_idx) = load_existing_embedding_index(&repo_root, |msg| {
+            if capability == EnrichmentCapability::Embeddings {
+                if let Some(embed_idx) = load_existing_embedding_index(&repo_root, |msg| {
                     tracing::warn!(
                         "{}; explicit embedding enrichment may need a repo-scope run",
                         msg
                     );
                 })
                 .await
-            {
-                handler.embed_index.store(Arc::new(Some(embed_idx)));
+                {
+                    handler.embed_index.store(Arc::new(Some(embed_idx)));
+                } else if !matches!(scope, EnrichmentScope::Repo) {
+                    anyhow::bail!(
+                        "no embedding index found for {}; run `repo-native-alignment enrich --capability embeddings --scope repo --repo {}` before scoped embedding enrichment",
+                        repo_root.display(),
+                        repo_root.display()
+                    );
+                }
             }
             handler
                 .run_explicit_enrichment(

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -1071,6 +1071,7 @@ impl RnaHandler {
                     EnrichmentScope::Repo,
                     EnrichmentTrigger::ForegroundScan,
                     None,
+                    false,
                 )
                 .await?
             } else {
@@ -1636,7 +1637,7 @@ impl RnaHandler {
                     edges.len(),
                     lsp_edge_count,
                 );
-                if let Some(job_id) = lsp_job_id.as_deref() {
+                if lsp_stage_completed && let Some(job_id) = lsp_job_id.as_deref() {
                     self.enrichment_jobs.mark_persisting(
                         &self.repo_root,
                         job_id,
@@ -1646,7 +1647,7 @@ impl RnaHandler {
                 }
                 if let Err(e) = persist_graph_to_lance(&self.repo_root, &nodes, &edges).await {
                     tracing::error!("Foreground full persist failed: {}", e);
-                    if let Some(job_id) = lsp_job_id.as_deref() {
+                    if lsp_stage_completed && let Some(job_id) = lsp_job_id.as_deref() {
                         self.enrichment_jobs.mark_failed(
                             &self.repo_root,
                             job_id,
@@ -1665,7 +1666,7 @@ impl RnaHandler {
                 } else {
                     super::sentinel::clear_lsp_sentinel(&self.repo_root);
                 }
-                if let Some(job_id) = lsp_job_id.as_deref() {
+                if lsp_stage_completed && let Some(job_id) = lsp_job_id.as_deref() {
                     self.enrichment_jobs.mark_completed(
                         &self.repo_root,
                         job_id,
@@ -1717,6 +1718,7 @@ impl RnaHandler {
         scope: EnrichmentScope,
         trigger: EnrichmentTrigger,
         dirty_slugs: Option<HashSet<String>>,
+        fail_on_lsp_error: bool,
     ) -> anyhow::Result<usize>
     where
         F: Fn(&str) + Send + Sync,
@@ -1726,6 +1728,7 @@ impl RnaHandler {
             let gs = snap.as_ref().as_ref().unwrap();
             (gs.nodes.clone(), gs.edges.clone())
         };
+        let repo_wide_lsp = dirty_slugs.is_none();
 
         let server_name = self.lsp_status.server_name();
         if let Some(ref name) = server_name {
@@ -1838,11 +1841,13 @@ impl RnaHandler {
                 }
                 // Persist succeeded -- write LSP sentinel so future startups know
                 // LSP enrichment is durable and can skip re-enrichment (#477).
-                super::sentinel::write_lsp_sentinel(
-                    &self.repo_root,
-                    enriched_nodes.len(),
-                    enriched_edges.len(),
-                );
+                if repo_wide_lsp {
+                    super::sentinel::write_lsp_sentinel(
+                        &self.repo_root,
+                        enriched_nodes.len(),
+                        enriched_edges.len(),
+                    );
+                }
                 self.enrichment_jobs.mark_completed(
                     &self.repo_root,
                     &job_id,
@@ -1866,6 +1871,9 @@ impl RnaHandler {
                     self.lsp_status.set_unavailable();
                     self.enrichment_jobs
                         .mark_failed(&self.repo_root, &job_id, format!("{}", e));
+                }
+                if fail_on_lsp_error {
+                    return Err(anyhow::anyhow!("LSP enrichment failed: {}", e));
                 }
                 Ok(0)
             }
@@ -1911,6 +1919,7 @@ impl RnaHandler {
                         scope.clone(),
                         EnrichmentTrigger::Explicit,
                         dirty_slugs,
+                        true,
                     )
                     .await?;
                 on_progress(&format!(

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -17,7 +17,8 @@ use crate::roots::{RootConfig, WorkspaceConfig};
 use crate::scanner::Scanner;
 
 use super::enrichment_jobs::{
-    EnrichmentCapability, EnrichmentScope, EnrichmentTrigger, JobStart, ScanEnrichmentOptions,
+    EnrichmentCapability, EnrichmentJobState, EnrichmentScope, EnrichmentTrigger, JobStart,
+    ScanEnrichmentOptions,
 };
 use super::state::GraphState;
 use super::store::persist_graph_to_lance;
@@ -53,6 +54,19 @@ pub(crate) fn cache_needs_enrichment(nodes: &[Node]) -> bool {
 }
 
 type LspBusOutput = (Vec<Node>, Vec<Edge>, HashSet<String>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnrichmentContinuation {
+    Disabled,
+    SpawnBackground,
+    RunToCompletion,
+}
+
+impl EnrichmentContinuation {
+    fn enabled(self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct LspBudget {
@@ -1749,10 +1763,10 @@ impl RnaHandler {
             }
             JobStart::Joined { existing_job_id } => {
                 on_progress(&format!(
-                    "LSP: joined active enrichment job {}; skipping duplicate foreground LSP",
+                    "LSP: joined active enrichment job {}; waiting for completion",
                     existing_job_id
                 ));
-                return Ok(0);
+                return self.wait_for_joined_enrichment_job(&existing_job_id).await;
             }
         };
 
@@ -1815,7 +1829,13 @@ impl RnaHandler {
                         self.graph.store(Arc::new(Some(Arc::new(gs))));
                     }
                 }
-                self.lsp_status.set_complete(lsp_edge_count);
+                if repo_wide_lsp {
+                    self.lsp_status.set_complete(lsp_edge_count);
+                } else {
+                    let existing_coverage = self.lsp_status.coverage_edge_count();
+                    self.lsp_status
+                        .set_complete_with_coverage(lsp_edge_count, existing_coverage);
+                }
 
                 self.enrichment_jobs.mark_progress(
                     &self.repo_root,
@@ -1884,7 +1904,7 @@ impl RnaHandler {
         &self,
         capability: EnrichmentCapability,
         scope: EnrichmentScope,
-        continue_background: bool,
+        continuation: EnrichmentContinuation,
         on_progress: F,
     ) -> anyhow::Result<()>
     where
@@ -1906,12 +1926,17 @@ impl RnaHandler {
                 self.run_explicit_embedding_enrichment(
                     &all_nodes,
                     scope.clone(),
-                    continue_background,
+                    continuation,
                     &on_progress,
                 )
                 .await?;
             }
             EnrichmentCapability::CallReferences => {
+                if matches!(scope, EnrichmentScope::ChangedFiles) {
+                    anyhow::bail!(
+                        "changed-file call-reference enrichment is not supported by the LSP executor yet; use `--scope root --root <slug>` or `--scope repo`"
+                    );
+                }
                 let dirty_slugs = self.dirty_slugs_for_scope(&scope);
                 let count = self
                     .run_foreground_lsp_and_persist(
@@ -1926,11 +1951,34 @@ impl RnaHandler {
                     "LSP explicit enrichment complete: {} call/reference edges",
                     count
                 ));
-                if continue_background && !matches!(scope, EnrichmentScope::Repo) {
-                    self.spawn_lsp_enrichment_via_bus(&all_nodes, &all_edges);
-                    on_progress(
-                        "LSP background continuation scheduled for remaining cached graph coverage",
-                    );
+                if continuation.enabled() && !matches!(scope, EnrichmentScope::Repo) {
+                    match continuation {
+                        EnrichmentContinuation::Disabled => {}
+                        EnrichmentContinuation::SpawnBackground => {
+                            self.spawn_lsp_enrichment_via_bus(&all_nodes, &all_edges);
+                            on_progress(
+                                "LSP background continuation scheduled for remaining cached graph coverage",
+                            );
+                        }
+                        EnrichmentContinuation::RunToCompletion => {
+                            on_progress(
+                                "LSP continuation: enriching remaining cached graph coverage",
+                            );
+                            let continuation_count = self
+                                .run_foreground_lsp_and_persist(
+                                    &on_progress,
+                                    EnrichmentScope::Repo,
+                                    EnrichmentTrigger::Explicit,
+                                    None,
+                                    true,
+                                )
+                                .await?;
+                            on_progress(&format!(
+                                "LSP continuation complete: {} call/reference edges",
+                                continuation_count
+                            ));
+                        }
+                    }
                 }
             }
             EnrichmentCapability::ExtractedGraph => {
@@ -1948,7 +1996,46 @@ impl RnaHandler {
         &self,
         all_nodes: &[Node],
         scope: EnrichmentScope,
-        continue_background: bool,
+        continuation: EnrichmentContinuation,
+        on_progress: &F,
+    ) -> anyhow::Result<()>
+    where
+        F: Fn(&str) + Send + Sync,
+    {
+        self.run_embedding_enrichment_once(all_nodes, scope.clone(), on_progress)
+            .await?;
+
+        if continuation.enabled() && !matches!(scope, EnrichmentScope::Repo) {
+            match continuation {
+                EnrichmentContinuation::Disabled => {}
+                EnrichmentContinuation::SpawnBackground => {
+                    let handle = self.spawn_background_enrichment(all_nodes);
+                    *self.embed_handle.lock().await = Some(handle);
+                    on_progress(
+                        "Embedding background continuation scheduled for remaining cached graph coverage",
+                    );
+                }
+                EnrichmentContinuation::RunToCompletion => {
+                    on_progress(
+                        "Embedding continuation: enriching remaining cached graph coverage",
+                    );
+                    self.run_embedding_enrichment_once(
+                        all_nodes,
+                        EnrichmentScope::Repo,
+                        on_progress,
+                    )
+                    .await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn run_embedding_enrichment_once<F>(
+        &self,
+        all_nodes: &[Node],
+        scope: EnrichmentScope,
         on_progress: &F,
     ) -> anyhow::Result<()>
     where
@@ -1969,9 +2056,11 @@ impl RnaHandler {
             JobStart::Started(job) => job.job_id,
             JobStart::Joined { existing_job_id } => {
                 on_progress(&format!(
-                    "Embed: joined active enrichment job {}; skipping duplicate explicit embedding",
+                    "Embed: joined active enrichment job {}; waiting for completion",
                     existing_job_id
                 ));
+                self.wait_for_joined_enrichment_job(&existing_job_id)
+                    .await?;
                 return Ok(());
             }
         };
@@ -2016,13 +2105,6 @@ impl RnaHandler {
                     "Embed explicit enrichment complete: {} embedded items",
                     count
                 ));
-                if continue_background && !matches!(scope, EnrichmentScope::Repo) {
-                    let handle = self.spawn_background_enrichment(all_nodes);
-                    *self.embed_handle.lock().await = Some(handle);
-                    on_progress(
-                        "Embedding background continuation scheduled for remaining cached graph coverage",
-                    );
-                }
                 Ok(())
             }
             Err(e) => {
@@ -2031,6 +2113,46 @@ impl RnaHandler {
                     .mark_failed(&self.repo_root, &job_id, format!("{}", e));
                 Err(e)
             }
+        }
+    }
+
+    async fn wait_for_joined_enrichment_job(&self, job_id: &str) -> anyhow::Result<usize> {
+        let budget = LspBudget::from_env().max_duration;
+        let started = std::time::Instant::now();
+        loop {
+            if let Some(job) = self
+                .enrichment_jobs
+                .recent_jobs(&self.repo_root, 100)
+                .into_iter()
+                .find(|job| job.job_id == job_id)
+            {
+                match job.state {
+                    EnrichmentJobState::Completed => return Ok(job.counters.current),
+                    EnrichmentJobState::Failed => {
+                        let detail = job.failure.unwrap_or_else(|| "unknown failure".to_string());
+                        anyhow::bail!("joined enrichment job {} failed: {}", job_id, detail);
+                    }
+                    EnrichmentJobState::Superseded => {
+                        anyhow::bail!("joined enrichment job {} was superseded", job_id);
+                    }
+                    EnrichmentJobState::Cancelled => {
+                        anyhow::bail!("joined enrichment job {} was cancelled", job_id);
+                    }
+                    EnrichmentJobState::Queued
+                    | EnrichmentJobState::Running
+                    | EnrichmentJobState::Persisting => {}
+                }
+            }
+
+            if started.elapsed() > budget {
+                anyhow::bail!(
+                    "timed out waiting for joined enrichment job {} after {}s",
+                    job_id,
+                    budget.as_secs()
+                );
+            }
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
     }
 

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -1915,7 +1915,7 @@ impl RnaHandler {
     where
         F: Fn(&str) + Send + Sync,
     {
-        let (all_nodes, all_edges) = {
+        let (all_nodes, _all_edges) = {
             let snap = self.graph.load_full();
             let Some(gs) = snap.as_ref().as_ref() else {
                 anyhow::bail!(
@@ -1960,7 +1960,16 @@ impl RnaHandler {
                     match continuation {
                         EnrichmentContinuation::Disabled => {}
                         EnrichmentContinuation::SpawnBackground => {
-                            self.spawn_lsp_enrichment_via_bus(&all_nodes, &all_edges);
+                            let (current_nodes, current_edges) = {
+                                let snap = self.graph.load_full();
+                                let Some(gs) = snap.as_ref().as_ref() else {
+                                    anyhow::bail!(
+                                        "graph cache disappeared before LSP background continuation"
+                                    );
+                                };
+                                (gs.nodes.clone(), gs.edges.clone())
+                            };
+                            self.spawn_lsp_enrichment_via_bus(&current_nodes, &current_edges);
                             on_progress(
                                 "LSP background continuation scheduled for remaining cached graph coverage",
                             );

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -1766,7 +1766,12 @@ impl RnaHandler {
                     "LSP: joined active enrichment job {}; waiting for completion",
                     existing_job_id
                 ));
-                return self.wait_for_joined_enrichment_job(&existing_job_id).await;
+                return self
+                    .wait_for_joined_enrichment_job(
+                        &existing_job_id,
+                        EnrichmentCapability::CallReferences,
+                    )
+                    .await;
             }
         };
 
@@ -2059,8 +2064,11 @@ impl RnaHandler {
                     "Embed: joined active enrichment job {}; waiting for completion",
                     existing_job_id
                 ));
-                self.wait_for_joined_enrichment_job(&existing_job_id)
-                    .await?;
+                self.wait_for_joined_enrichment_job(
+                    &existing_job_id,
+                    EnrichmentCapability::Embeddings,
+                )
+                .await?;
                 return Ok(());
             }
         };
@@ -2116,7 +2124,11 @@ impl RnaHandler {
         }
     }
 
-    async fn wait_for_joined_enrichment_job(&self, job_id: &str) -> anyhow::Result<usize> {
+    async fn wait_for_joined_enrichment_job(
+        &self,
+        job_id: &str,
+        capability: EnrichmentCapability,
+    ) -> anyhow::Result<usize> {
         let budget = LspBudget::from_env().max_duration;
         let started = std::time::Instant::now();
         loop {
@@ -2127,7 +2139,19 @@ impl RnaHandler {
                 .find(|job| job.job_id == job_id)
             {
                 match job.state {
-                    EnrichmentJobState::Completed => return Ok(job.counters.current),
+                    EnrichmentJobState::Completed => {
+                        if capability == EnrichmentCapability::CallReferences
+                            && let Some(progress) = self
+                                .enrichment_jobs
+                                .events_for_job(&self.repo_root, job_id)
+                                .into_iter()
+                                .rev()
+                                .find(|event| event.phase.as_deref() == Some("lsp_edges"))
+                        {
+                            return Ok(progress.counters.current);
+                        }
+                        return Ok(job.counters.current);
+                    }
                     EnrichmentJobState::Failed => {
                         let detail = job.failure.unwrap_or_else(|| "unknown failure".to_string());
                         anyhow::bail!("joined enrichment job {} failed: {}", job_id, detail);

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -6,8 +6,10 @@
 //! - `scan_roots()` -- resolve workspace roots, detect file changes
 //! - `update_graph()` -- apply changes, run enrichment pipeline
 //! - `persist_deltas()` -- write to LanceDB, commit scanner state
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::embed::EmbeddingIndex;
 use crate::graph::{Edge, Node};
@@ -48,6 +50,91 @@ pub(crate) fn cache_needs_enrichment(nodes: &[Node]) -> bool {
     // Quick check: do any imports match known framework patterns?
     let result = crate::extract::framework_detection::framework_detection_pass(nodes, "check");
     !result.detected_frameworks.is_empty()
+}
+
+type LspBusOutput = (Vec<Node>, Vec<Edge>, HashSet<String>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LspBudget {
+    pub max_duration: Duration,
+}
+
+impl LspBudget {
+    pub(crate) fn from_env() -> Self {
+        let millis = std::env::var("RNA_LSP_JOB_TIMEOUT_MS")
+            .ok()
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .filter(|millis| *millis > 0)
+            .unwrap_or(30 * 60 * 1000);
+        Self {
+            max_duration: Duration::from_millis(millis),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum LspPipelineFailure {
+    TimedOut(Duration),
+    Failed(anyhow::Error),
+}
+
+impl LspPipelineFailure {
+    fn is_timeout(&self) -> bool {
+        matches!(self, Self::TimedOut(_))
+    }
+}
+
+impl std::fmt::Display for LspPipelineFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TimedOut(duration) => {
+                write!(f, "LSP enrichment timed out after {}s", duration.as_secs())
+            }
+            Self::Failed(err) => write!(f, "{:#}", err),
+        }
+    }
+}
+
+impl std::error::Error for LspPipelineFailure {}
+
+struct LspPipelineInput {
+    nodes: Vec<Node>,
+    edges: Vec<Edge>,
+    root_pairs: Vec<(String, PathBuf)>,
+    primary_slug: String,
+    repo_root: PathBuf,
+    scan_stats: Arc<std::sync::RwLock<crate::extract::scan_stats::ScanStats>>,
+    skip_lsp: bool,
+    dirty_slugs: Option<HashSet<String>>,
+}
+
+async fn emit_lsp_pipeline_with_budget(
+    input: LspPipelineInput,
+) -> Result<LspBusOutput, LspPipelineFailure> {
+    let fut = crate::extract::consumers::emit_enrichment_pipeline(
+        input.nodes,
+        input.edges,
+        input.root_pairs,
+        input.primary_slug,
+        input.repo_root,
+        crate::extract::consumers::BusOptions {
+            scan_stats: Some(input.scan_stats),
+            embed_idx: None,
+            lance_repo_root: None,
+            skip_lsp: input.skip_lsp,
+        },
+        input.dirty_slugs,
+    );
+
+    if input.skip_lsp {
+        return fut.await.map_err(LspPipelineFailure::Failed);
+    }
+
+    let budget = LspBudget::from_env();
+    match tokio::time::timeout(budget.max_duration, fut).await {
+        Ok(result) => result.map_err(LspPipelineFailure::Failed),
+        Err(_) => Err(LspPipelineFailure::TimedOut(budget.max_duration)),
+    }
 }
 
 impl RnaHandler {
@@ -225,21 +312,17 @@ impl RnaHandler {
                 .collect();
             let primary_slug = crate::roots::RootConfig::code_project(repo_root.clone()).slug();
 
-            // Run enrichment pipeline WITH LSP (skip_lsp=false)
-            let result = crate::extract::consumers::emit_enrichment_pipeline(
+            // Run enrichment pipeline WITH LSP (skip_lsp=false).
+            let result = emit_lsp_pipeline_with_budget(LspPipelineInput {
                 nodes,
                 edges,
                 root_pairs,
-                primary_slug.clone(),
-                repo_root.clone(),
-                crate::extract::consumers::BusOptions {
-                    scan_stats: Some(Arc::clone(&scan_stats)),
-                    embed_idx: None,
-                    lance_repo_root: None,
-                    skip_lsp: false, // this time LSP runs
-                },
-                Some(dirty_slugs),
-            )
+                primary_slug: primary_slug.clone(),
+                repo_root: repo_root.clone(),
+                scan_stats: Arc::clone(&scan_stats),
+                skip_lsp: false,
+                dirty_slugs: Some(dirty_slugs),
+            })
             .await;
 
             match result {
@@ -473,8 +556,13 @@ impl RnaHandler {
                 }
                 Err(e) => {
                     tracing::error!("[background-lsp] LSP enrichment pipeline failed: {:#}", e);
-                    lsp_status.set_unavailable();
-                    jobs.mark_failed(&repo_root, &job_id, format!("{}", e));
+                    if e.is_timeout() {
+                        lsp_status.set_timed_out(&format!("{}", e));
+                        jobs.mark_timed_out(&repo_root, &job_id, format!("{}", e));
+                    } else {
+                        lsp_status.set_unavailable();
+                        jobs.mark_failed(&repo_root, &job_id, format!("{}", e));
+                    }
                 }
             }
         })
@@ -664,28 +752,29 @@ impl RnaHandler {
             // Cache-hit LSP enrichment: all roots are "dirty" because this is
             // the first time LSP runs on a cached graph (no prior LSP edges).
             // `None` = all roots dirty on first LSP run.
-            let result = crate::extract::consumers::emit_enrichment_pipeline(
-                bg_nodes,
-                bg_edges,
+            let result = emit_lsp_pipeline_with_budget(LspPipelineInput {
+                nodes: bg_nodes,
+                edges: bg_edges,
                 root_pairs,
                 primary_slug,
-                bus_repo_root,
-                crate::extract::consumers::BusOptions {
-                    scan_stats: Some(bg_scan_stats),
-                    embed_idx: None,
-                    lance_repo_root: None,
-                    skip_lsp: false,
-                },
-                None,
-            )
+                repo_root: bus_repo_root,
+                scan_stats: bg_scan_stats,
+                skip_lsp: false,
+                dirty_slugs: None,
+            })
             .await;
 
             let (mut enriched_nodes, mut enriched_edges, _detected_frameworks) = match result {
                 Ok(r) => r,
                 Err(e) => {
                     tracing::error!("[cache-hit bus] emit_enrichment_pipeline failed: {:#}", e);
-                    bg_lsp_status.set_failed(&format!("{}", e));
-                    bg_jobs.mark_failed(&bg_repo_root, &job_id, format!("{}", e));
+                    if e.is_timeout() {
+                        bg_lsp_status.set_timed_out(&format!("{}", e));
+                        bg_jobs.mark_timed_out(&bg_repo_root, &job_id, format!("{}", e));
+                    } else {
+                        bg_lsp_status.set_failed(&format!("{}", e));
+                        bg_jobs.mark_failed(&bg_repo_root, &job_id, format!("{}", e));
+                    }
                     return;
                 }
             };
@@ -977,7 +1066,13 @@ impl RnaHandler {
             } else if enrichment.runs_lsp() {
                 // LSP sentinel absent or stale enrichment -- run full enrichment.
                 on_progress("LSP: running full enrichment...");
-                self.run_foreground_lsp_and_persist(&on_progress).await?
+                self.run_foreground_lsp_and_persist(
+                    &on_progress,
+                    EnrichmentScope::Repo,
+                    EnrichmentTrigger::ForegroundScan,
+                    None,
+                )
+                .await?
             } else {
                 on_progress("LSP: skipped by scan options");
                 0
@@ -1090,20 +1185,16 @@ impl RnaHandler {
 
         let mut lsp_stage_completed = false;
         let t2 = std::time::Instant::now();
-        let bus_result = crate::extract::consumers::emit_enrichment_pipeline(
-            all_nodes,
-            all_edges,
+        let bus_result = emit_lsp_pipeline_with_budget(LspPipelineInput {
+            nodes: all_nodes,
+            edges: all_edges,
             root_pairs,
             primary_slug,
-            self.repo_root.clone(),
-            crate::extract::consumers::BusOptions {
-                scan_stats: Some(Arc::clone(&self.scan_stats)),
-                embed_idx: None,
-                lance_repo_root: None,
-                skip_lsp: !enrichment.runs_lsp(),
-            },
+            repo_root: self.repo_root.clone(),
+            scan_stats: Arc::clone(&self.scan_stats),
+            skip_lsp: !enrichment.runs_lsp(),
             dirty_slugs,
-        )
+        })
         .await;
         let bus_time = t2.elapsed();
 
@@ -1168,7 +1259,11 @@ impl RnaHandler {
                     bus_time.as_secs_f64(),
                 ));
                 if enrichment.runs_lsp() {
-                    self.lsp_status.set_unavailable();
+                    if e.is_timeout() {
+                        self.lsp_status.set_timed_out(&format!("{}", e));
+                    } else {
+                        self.lsp_status.set_unavailable();
+                    }
                 }
                 lsp_edge_count = 0;
             }
@@ -1407,20 +1502,16 @@ impl RnaHandler {
         let (root_pairs, primary_slug) = self.build_bus_root_pairs();
         let bus_fut = async {
             let t2 = std::time::Instant::now();
-            let result = crate::extract::consumers::emit_enrichment_pipeline(
-                graph_state.nodes.clone(),
-                graph_state.edges.clone(),
+            let result = emit_lsp_pipeline_with_budget(LspPipelineInput {
+                nodes: graph_state.nodes.clone(),
+                edges: graph_state.edges.clone(),
                 root_pairs,
                 primary_slug,
-                self.repo_root.clone(),
-                crate::extract::consumers::BusOptions {
-                    scan_stats: Some(Arc::clone(&self.scan_stats)),
-                    embed_idx: None,
-                    lance_repo_root: None,
-                    skip_lsp: !run_lsp_in_bus,
-                },
-                None, // full rebuild: all roots dirty
-            )
+                repo_root: self.repo_root.clone(),
+                scan_stats: Arc::clone(&self.scan_stats),
+                skip_lsp: !run_lsp_in_bus,
+                dirty_slugs: None,
+            })
             .await;
             let elapsed = t2.elapsed();
             (result, elapsed)
@@ -1506,12 +1597,24 @@ impl RnaHandler {
                     bus_time.as_secs_f64(),
                 ));
                 if run_lsp_in_bus {
-                    self.lsp_status.set_unavailable();
+                    if e.is_timeout() {
+                        self.lsp_status.set_timed_out(&format!("{}", e));
+                    } else {
+                        self.lsp_status.set_unavailable();
+                    }
                 }
                 lsp_edge_count = 0;
                 if let Some(job_id) = lsp_job_id.as_deref() {
-                    self.enrichment_jobs
-                        .mark_failed(&self.repo_root, job_id, format!("{}", e));
+                    if e.is_timeout() {
+                        self.enrichment_jobs.mark_timed_out(
+                            &self.repo_root,
+                            job_id,
+                            format!("{}", e),
+                        );
+                    } else {
+                        self.enrichment_jobs
+                            .mark_failed(&self.repo_root, job_id, format!("{}", e));
+                    }
                 }
             }
         }
@@ -1608,7 +1711,13 @@ impl RnaHandler {
     /// Used when the cached graph has no LSP sentinel and needs enrichment.
     /// Routes through `emit_enrichment_pipeline` per ADR-001 (#583).
     /// Returns the number of LSP call edges added.
-    async fn run_foreground_lsp_and_persist<F>(&self, on_progress: &F) -> anyhow::Result<usize>
+    async fn run_foreground_lsp_and_persist<F>(
+        &self,
+        on_progress: &F,
+        scope: EnrichmentScope,
+        trigger: EnrichmentTrigger,
+        dirty_slugs: Option<HashSet<String>>,
+    ) -> anyhow::Result<usize>
     where
         F: Fn(&str) + Send + Sync,
     {
@@ -1625,8 +1734,8 @@ impl RnaHandler {
         let job_id = match self.enrichment_jobs.begin_job(
             &self.repo_root,
             EnrichmentCapability::CallReferences,
-            EnrichmentScope::Repo,
-            EnrichmentTrigger::ForegroundScan,
+            scope,
+            trigger,
             None,
         )? {
             JobStart::Started(job) => {
@@ -1647,20 +1756,16 @@ impl RnaHandler {
         on_progress("Enrichment: running pipeline via event bus (no sentinel)...");
 
         let (root_pairs, primary_slug) = self.build_bus_root_pairs();
-        let bus_result = crate::extract::consumers::emit_enrichment_pipeline(
-            all_nodes,
-            all_edges,
+        let bus_result = emit_lsp_pipeline_with_budget(LspPipelineInput {
+            nodes: all_nodes,
+            edges: all_edges,
             root_pairs,
             primary_slug,
-            self.repo_root.clone(),
-            crate::extract::consumers::BusOptions {
-                scan_stats: Some(Arc::clone(&self.scan_stats)),
-                embed_idx: None,
-                lance_repo_root: None,
-                skip_lsp: false,
-            },
-            None, // no sentinel means all roots need enrichment
-        )
+            repo_root: self.repo_root.clone(),
+            scan_stats: Arc::clone(&self.scan_stats),
+            skip_lsp: false,
+            dirty_slugs,
+        })
         .await;
 
         match bus_result {
@@ -1753,11 +1858,219 @@ impl RnaHandler {
                     e
                 );
                 on_progress("Enrichment: pipeline failed -- no LSP edges available");
-                self.lsp_status.set_unavailable();
-                self.enrichment_jobs
-                    .mark_failed(&self.repo_root, &job_id, format!("{}", e));
+                if e.is_timeout() {
+                    self.lsp_status.set_timed_out(&format!("{}", e));
+                    self.enrichment_jobs
+                        .mark_timed_out(&self.repo_root, &job_id, format!("{}", e));
+                } else {
+                    self.lsp_status.set_unavailable();
+                    self.enrichment_jobs
+                        .mark_failed(&self.repo_root, &job_id, format!("{}", e));
+                }
                 Ok(0)
             }
+        }
+    }
+
+    pub async fn run_explicit_enrichment<F>(
+        &self,
+        capability: EnrichmentCapability,
+        scope: EnrichmentScope,
+        continue_background: bool,
+        on_progress: F,
+    ) -> anyhow::Result<()>
+    where
+        F: Fn(&str) + Send + Sync,
+    {
+        let (all_nodes, all_edges) = {
+            let snap = self.graph.load_full();
+            let Some(gs) = snap.as_ref().as_ref() else {
+                anyhow::bail!(
+                    "no cached graph loaded; run `repo-native-alignment scan --extract-only --repo {}` first",
+                    self.repo_root.display()
+                );
+            };
+            (gs.nodes.clone(), gs.edges.clone())
+        };
+
+        match capability {
+            EnrichmentCapability::Embeddings => {
+                self.run_explicit_embedding_enrichment(
+                    &all_nodes,
+                    scope.clone(),
+                    continue_background,
+                    &on_progress,
+                )
+                .await?;
+            }
+            EnrichmentCapability::CallReferences => {
+                let dirty_slugs = self.dirty_slugs_for_scope(&scope);
+                let count = self
+                    .run_foreground_lsp_and_persist(
+                        &on_progress,
+                        scope.clone(),
+                        EnrichmentTrigger::Explicit,
+                        dirty_slugs,
+                    )
+                    .await?;
+                on_progress(&format!(
+                    "LSP explicit enrichment complete: {} call/reference edges",
+                    count
+                ));
+                if continue_background && !matches!(scope, EnrichmentScope::Repo) {
+                    self.spawn_lsp_enrichment_via_bus(&all_nodes, &all_edges);
+                    on_progress(
+                        "LSP background continuation scheduled for remaining cached graph coverage",
+                    );
+                }
+            }
+            EnrichmentCapability::ExtractedGraph => {
+                anyhow::bail!(
+                    "explicit enrich does not extract source; run `repo-native-alignment scan --extract-only --repo {}`",
+                    self.repo_root.display()
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn run_explicit_embedding_enrichment<F>(
+        &self,
+        all_nodes: &[Node],
+        scope: EnrichmentScope,
+        continue_background: bool,
+        on_progress: &F,
+    ) -> anyhow::Result<()>
+    where
+        F: Fn(&str) + Send + Sync,
+    {
+        let selected_nodes = self.cached_nodes_for_scope(all_nodes, &scope)?;
+        let embeddable_count = selected_nodes
+            .iter()
+            .filter(|n| n.id.kind.is_embeddable())
+            .count();
+        let job_id = match self.enrichment_jobs.begin_job(
+            &self.repo_root,
+            EnrichmentCapability::Embeddings,
+            scope.clone(),
+            EnrichmentTrigger::Explicit,
+            None,
+        )? {
+            JobStart::Started(job) => job.job_id,
+            JobStart::Joined { existing_job_id } => {
+                on_progress(&format!(
+                    "Embed: joined active enrichment job {}; skipping duplicate explicit embedding",
+                    existing_job_id
+                ));
+                return Ok(());
+            }
+        };
+
+        self.enrichment_jobs
+            .mark_running(&self.repo_root, &job_id, "embedding");
+        self.embed_status.set_building(embeddable_count);
+        self.enrichment_jobs.mark_progress(
+            &self.repo_root,
+            &job_id,
+            "embedding",
+            0,
+            Some(embeddable_count),
+        );
+
+        let result = async {
+            let idx = EmbeddingIndex::new(&self.repo_root).await?;
+            if !matches!(scope, EnrichmentScope::Repo) && !idx.has_table().await? {
+                anyhow::bail!(
+                    "embedding table is missing; run `repo-native-alignment enrich --capability embeddings --scope repo --repo {}` before scoped embedding enrichment",
+                    self.repo_root.display()
+                );
+            }
+            let count = if matches!(scope, EnrichmentScope::Repo) {
+                idx.index_all_with_symbols(&self.repo_root, &selected_nodes).await?
+            } else {
+                idx.reindex_nodes(&selected_nodes).await?
+            };
+            anyhow::Ok((idx, count))
+        }
+        .await;
+
+        match result {
+            Ok((idx, count)) => {
+                self.enrichment_jobs
+                    .mark_persisting(&self.repo_root, &job_id, count, count);
+                self.embed_index.store(Arc::new(Some(idx)));
+                self.embed_status.set_complete(count);
+                self.enrichment_jobs
+                    .mark_completed(&self.repo_root, &job_id, count, count);
+                on_progress(&format!(
+                    "Embed explicit enrichment complete: {} embedded items",
+                    count
+                ));
+                if continue_background && !matches!(scope, EnrichmentScope::Repo) {
+                    let handle = self.spawn_background_enrichment(all_nodes);
+                    *self.embed_handle.lock().await = Some(handle);
+                    on_progress(
+                        "Embedding background continuation scheduled for remaining cached graph coverage",
+                    );
+                }
+                Ok(())
+            }
+            Err(e) => {
+                self.embed_status.set_failed(format!("{}", e));
+                self.enrichment_jobs
+                    .mark_failed(&self.repo_root, &job_id, format!("{}", e));
+                Err(e)
+            }
+        }
+    }
+
+    fn cached_nodes_for_scope(
+        &self,
+        all_nodes: &[Node],
+        scope: &EnrichmentScope,
+    ) -> anyhow::Result<Vec<Node>> {
+        let nodes: Vec<Node> = match scope {
+            EnrichmentScope::Repo => all_nodes
+                .iter()
+                .filter(|n| n.id.root != "external")
+                .cloned()
+                .collect(),
+            EnrichmentScope::Root(root) => all_nodes
+                .iter()
+                .filter(|n| n.id.root == *root && n.id.root != "external")
+                .cloned()
+                .collect(),
+            EnrichmentScope::ChangedFiles => {
+                let scan = Scanner::new(self.repo_root.clone())?.scan()?;
+                let changed: HashSet<String> = scan
+                    .changed_files
+                    .iter()
+                    .chain(scan.new_files.iter())
+                    .map(|path| path.to_string_lossy().to_string())
+                    .collect();
+                all_nodes
+                    .iter()
+                    .filter(|node| changed.contains(&node.id.file.to_string_lossy().to_string()))
+                    .cloned()
+                    .collect()
+            }
+            EnrichmentScope::Explicit(value) => {
+                anyhow::bail!("unsupported explicit enrichment scope: {}", value);
+            }
+        };
+        Ok(nodes)
+    }
+
+    fn dirty_slugs_for_scope(&self, scope: &EnrichmentScope) -> Option<HashSet<String>> {
+        match scope {
+            EnrichmentScope::Repo => None,
+            EnrichmentScope::Root(root) => Some(std::iter::once(root.clone()).collect()),
+            EnrichmentScope::ChangedFiles => {
+                let primary_slug = RootConfig::code_project(self.repo_root.clone()).slug();
+                Some(std::iter::once(primary_slug).collect())
+            }
+            EnrichmentScope::Explicit(value) => Some(std::iter::once(value.clone()).collect()),
         }
     }
 }

--- a/src/server/enrichment_jobs.rs
+++ b/src/server/enrichment_jobs.rs
@@ -174,6 +174,8 @@ pub struct EnrichmentJobRecord {
     pub counters: EnrichmentCounters,
     pub created_at: u64,
     pub updated_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_progress_at: Option<u64>,
     pub completed_at: Option<u64>,
     pub failure: Option<String>,
     pub superseded_by: Option<String>,
@@ -255,6 +257,7 @@ impl EnrichmentJobLedger {
             counters: EnrichmentCounters::empty(),
             created_at: now,
             updated_at: now,
+            last_progress_at: Some(now),
             completed_at: None,
             failure: None,
             superseded_by: None,
@@ -314,6 +317,7 @@ impl EnrichmentJobLedger {
                 existing.state = EnrichmentJobState::Superseded;
                 existing.phase = Some("superseded".to_string());
                 existing.updated_at = now;
+                existing.last_progress_at = Some(now);
                 existing.completed_at = Some(now);
                 existing.superseded_by = Some(job.job_id.clone());
                 existing.owner_id = None;
@@ -447,6 +451,20 @@ impl EnrichmentJobLedger {
         );
     }
 
+    pub fn mark_timed_out(&self, repo_root: &Path, job_id: &str, detail: impl Into<String>) {
+        self.update_job(
+            repo_root,
+            job_id,
+            JobUpdate {
+                state: EnrichmentJobState::Failed,
+                phase: Some("timed_out".to_string()),
+                counters: None,
+                failure: Some(detail.into()),
+                superseded_by: None,
+            },
+        );
+    }
+
     pub fn mark_superseded(
         &self,
         repo_root: &Path,
@@ -522,6 +540,7 @@ impl EnrichmentJobLedger {
                 job.superseded_by = Some(superseded_by);
             }
             job.updated_at = now;
+            job.last_progress_at = Some(now);
             if update.state.is_terminal() {
                 job.lease_expires_at = None;
                 job.owner_id = None;
@@ -878,6 +897,40 @@ mod tests {
 
         assert!(matches!(second, JobStart::Started(_)));
         assert_eq!(ledger.recent_jobs(tmp.path(), 10).len(), 2);
+    }
+
+    #[test]
+    fn timed_out_job_records_terminal_failure_and_progress_time() {
+        let tmp = TempDir::new().unwrap();
+        let ledger = EnrichmentJobLedger::default();
+        let job = match ledger
+            .begin_job(
+                tmp.path(),
+                EnrichmentCapability::CallReferences,
+                EnrichmentScope::Repo,
+                EnrichmentTrigger::Explicit,
+                None,
+            )
+            .unwrap()
+        {
+            JobStart::Started(job) => job,
+            JobStart::Joined { .. } => panic!("first job should start"),
+        };
+
+        ledger.mark_running(tmp.path(), &job.job_id, "lsp");
+        ledger.mark_progress(tmp.path(), &job.job_id, "lsp_edges", 3, Some(10));
+        ledger.mark_timed_out(tmp.path(), &job.job_id, "budget exceeded");
+
+        let jobs = ledger.recent_jobs(tmp.path(), 10);
+        assert_eq!(jobs.len(), 1);
+        let persisted = &jobs[0];
+        assert_eq!(persisted.state, EnrichmentJobState::Failed);
+        assert_eq!(persisted.phase.as_deref(), Some("timed_out"));
+        assert_eq!(persisted.failure.as_deref(), Some("budget exceeded"));
+        assert!(persisted.completed_at.is_some());
+        assert!(persisted.last_progress_at.is_some());
+        assert!(persisted.owner_id.is_none());
+        assert!(persisted.lease_expires_at.is_none());
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,6 +15,7 @@ pub mod tools;
 pub(crate) use graph::SUBSYSTEM_KEY;
 
 // Re-export public API so external `use crate::server::X` still works.
+pub use enrichment::EnrichmentContinuation;
 pub use enrichment_jobs::{
     EmbeddingEnrichmentMode, EnrichmentCapability, EnrichmentJobLedger, EnrichmentJobRecord,
     EnrichmentScope, EnrichmentTrigger, JobStart, LspEnrichmentMode, ScanEnrichmentOptions,

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -741,6 +741,10 @@ impl LspEnrichmentStatus {
         self.log_transition(prev, LspState::Failed, error);
     }
 
+    pub fn set_timed_out(&self, detail: &str) {
+        self.set_failed(&format!("timed out: {}", detail));
+    }
+
     /// Mark that at least one LSP server binary was found on PATH.
     /// Called synchronously at startup before async enrichment begins.
     pub fn set_server_found(&self) {
@@ -777,6 +781,7 @@ impl LspEnrichmentStatus {
     }
 
     pub fn call_reference_readiness(&self) -> CapabilityReadiness {
+        self.check_running_timeout();
         self.check_server_found_timeout();
         match self.current_state() {
             LspState::Complete => {
@@ -905,6 +910,40 @@ impl LspEnrichmentStatus {
         false
     }
 
+    pub fn check_running_timeout(&self) -> bool {
+        self.check_running_timeout_after(default_lsp_running_timeout())
+    }
+
+    fn check_running_timeout_after(&self, max_elapsed: std::time::Duration) -> bool {
+        let current = self.current_state();
+        if current != LspState::Running {
+            return false;
+        }
+        let elapsed = self.elapsed_since_last_transition();
+        if elapsed <= max_elapsed {
+            return false;
+        }
+        let message = format!(
+            "RUNNING timed out after {}s without a terminal state",
+            max_elapsed.as_secs()
+        );
+        let result = self.state.compare_exchange(
+            Self::RUNNING,
+            Self::FAILED,
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+        );
+        if result.is_ok() {
+            *self.last_error.lock().unwrap() = Some(message.clone());
+            *self.completed_at.lock().unwrap() = Some(std::time::Instant::now());
+            self.coverage_edge_count
+                .store(0, std::sync::atomic::Ordering::Release);
+            self.log_transition(LspState::Running, LspState::Failed, &message);
+            return true;
+        }
+        false
+    }
+
     /// Synchronously probe for known LSP server binaries on PATH.
     /// Fast (just `which` calls, no process spawning). Call at handler construction
     /// to distinguish "server exists but pending" from "no server available."
@@ -969,6 +1008,7 @@ impl LspEnrichmentStatus {
     pub fn footer_segment(&self) -> Option<String> {
         // Check for SERVER_FOUND timeout before rendering
         self.check_server_found_timeout();
+        self.check_running_timeout();
 
         match self.state.load(std::sync::atomic::Ordering::Acquire) {
             Self::NOT_STARTED => None,
@@ -1029,6 +1069,15 @@ impl LspEnrichmentStatus {
     }
 }
 
+fn default_lsp_running_timeout() -> std::time::Duration {
+    let millis = std::env::var("RNA_LSP_RUNNING_TIMEOUT_MS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|millis| *millis > 0)
+        .unwrap_or(30 * 60 * 1000);
+    std::time::Duration::from_millis(millis)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1081,6 +1130,24 @@ mod tests {
         status.set_running();
         let footer = status.footer_segment().unwrap();
         assert!(footer.starts_with("LSP: enriching"), "got: {}", footer);
+    }
+
+    #[test]
+    fn test_lsp_running_timeout_projects_failed_readiness() {
+        let status = LspEnrichmentStatus::default();
+        status.set_running();
+        *status.last_transition_at.lock().unwrap() =
+            std::time::Instant::now() - std::time::Duration::from_secs(10);
+
+        assert!(status.check_running_timeout_after(std::time::Duration::from_secs(1)));
+        assert_eq!(status.current_state(), LspState::Failed);
+
+        let readiness = status.call_reference_readiness();
+        assert_eq!(readiness.state, CapabilityReadinessState::Failed);
+        assert!(readiness.detail.contains("RUNNING timed out"));
+
+        let footer = status.footer_segment().unwrap();
+        assert!(footer.contains("RUNNING timed out"), "got: {}", footer);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Parent: #659
Targets: #666, #667

Deferred enrichment is split across scan/background execution, explicit command intent, durable job lifecycle, timeout/stalled semantics, persistence, sentinels, and readiness rendering.

## Chosen solution

Implement the solution-space revision: a canonical enrichment execution plane / `EnrichmentExecutor` so explicit enrichment and bounded LSP lifecycle share one request/job/readiness contract.

## Scope

- Add executor request/summary types and route existing enrichment lifecycle through the executor.
- Add bounded LSP timeout/stalled/degraded projection inside that lifecycle.
- Add explicit `enrich` command as a thin executor client if the executor cutover remains bounded.
- Preserve existing scan skip flags and non-blocking MCP startup.

## Non-goals

- No general priority scheduler.
- No cancellation/retry API beyond current run-or-join semantics.
- No silent extraction for explicit existing-cache enrichment.

## Verification plan

- Targeted unit tests for executor/job lifecycle/readiness.
- `cargo check --lib --bins --no-default-features`.
- Targeted CLI verification for `enrich` and stalled/degraded rendering.
- Real MCP-client verification for #667 before ready-for-review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "enrich" CLI to run embeddings or call/reference enrichment with capability, scope, optional root targeting, and choice of background continuation or run-to-completion; validates root selection and bails when required cached indexes are missing for non-repo scopes.
  * Explicit enrichment can continue unfinished work in background or run to completion.

* **Bug Fixes**
  * LSP enrichment respects configurable budgets and distinguishes timeouts from failures.
  * Job tracking now records progress timestamps and supports explicit timeout marking.

* **Documentation**
  * README updated with CLI usage and options for the new enrich command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->