### PR TITLE
Keep MCP incremental refresh non-blocking

### DIFF
--- a/.oh/friction-logs/incremental-update-timeout-2026-05-09.md
+++ b/.oh/friction-logs/incremental-update-timeout-2026-05-09.md
@@ -1,0 +1,11 @@
+---
+id: incremental-update-timeout-2026-05-09
+outcome: context-assembly
+severity: major
+---
+
+# MCP incremental update timeout friction
+
+| Time | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-05-09 | `mcp_rna_server_search` after editing a one-file Rust probe | major | Exact search for the modified symbol timed out after 60s while the background incremental LSP pipeline held `graph_build_lock`. Foreground incremental refresh was waiting on the same lock even though a fast tree-sitter snapshot should be enough for MCP search. | User-visible MCP tools appeared hung for a trivial incremental edit; had to inspect logs and source with fallback `read`/`grep` while the MCP server was unresponsive. | Fixed in working tree: `get_graph` now uses non-blocking `try_lock` for foreground incremental refresh and stale background pipelines skip commit/persist/swap if a newer fast snapshot appears. Regression test and real MCP probe added/run. |

--- a/src/server/bg_scanner.rs
+++ b/src/server/bg_scanner.rs
@@ -26,7 +26,7 @@ pub(super) type LanceDelta = (
     Vec<Node>,
     Vec<Edge>,
     Vec<String>,
-    HashSet<PathBuf>,
+    HashSet<(String, PathBuf)>,
 );
 
 /// Result of scanning all workspace roots for file changes.
@@ -151,11 +151,13 @@ pub(super) async fn update_graph(
             scan.new_files.len(),
             scan.deleted_files.len()
         );
-        let files_to_remove: HashSet<PathBuf> = scan
+        let files_to_remove: HashSet<(String, PathBuf)> = scan
             .deleted_files
             .iter()
             .chain(scan.changed_files.iter())
+            .chain(scan.new_files.iter())
             .cloned()
+            .map(|file| (root_slug.clone(), file))
             .collect();
 
         // Collect edge IDs to delete BEFORE retain.
@@ -163,20 +165,18 @@ pub(super) async fn update_graph(
             .edges
             .iter()
             .filter(|e| {
-                e.from.root == *root_slug
-                    && (files_to_remove.contains(&e.from.file)
-                        || files_to_remove.contains(&e.to.file))
+                files_to_remove.contains(&(e.from.root.clone(), e.from.file.clone()))
+                    || files_to_remove.contains(&(e.to.root.clone(), e.to.file.clone()))
             })
             .map(|e| e.stable_id())
             .collect();
 
         graph_state
             .nodes
-            .retain(|n| n.id.root != *root_slug || !files_to_remove.contains(&n.id.file));
+            .retain(|n| !files_to_remove.contains(&(n.id.root.clone(), n.id.file.clone())));
         graph_state.edges.retain(|e| {
-            e.from.root != *root_slug
-                || (!files_to_remove.contains(&e.from.file)
-                    && !files_to_remove.contains(&e.to.file))
+            !files_to_remove.contains(&(e.from.root.clone(), e.from.file.clone()))
+                && !files_to_remove.contains(&(e.to.root.clone(), e.to.file.clone()))
         });
         let (mut extraction, enc_stats) = registry.extract_scan_result_with_stats(root_path, scan);
 
@@ -370,7 +370,7 @@ pub(super) async fn persist_deltas(
     {
         let persist_result = {
             let _lance_guard = lance_write_lock.lock().await;
-            let files_to_remove_vec: Vec<PathBuf> = files_to_remove.into_iter().collect();
+            let files_to_remove_vec: Vec<(String, PathBuf)> = files_to_remove.into_iter().collect();
             persist_graph_incremental(
                 &root_path,
                 &upsert_nodes,

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -158,24 +158,64 @@ impl RnaHandler {
     /// Tool calls never block on a write lock — they always see the last
     /// complete graph snapshot (#574).
     pub(crate) async fn get_graph(&self) -> anyhow::Result<Arc<GraphState>> {
-        // Fast path: graph exists and scan cooldown hasn't expired.
+        // Fast path: if a graph exists, scan for changes. The scanner is cheap
+        // relative to MCP timeout budgets, and skipping it for a cooldown window
+        // makes rapid add/change/delete edits invisible to agents.
         // ArcSwap load is an atomic pointer read — zero blocking.
         let current = self.graph.load_full();
-        if let Some(ref gs) = *current {
-            let skip_scan = {
-                let last = self.last_scan.lock().unwrap();
-                last.elapsed() < std::time::Duration::from_secs(2)
+        if current.is_some() {
+            // Serialize only foreground tree-sitter refreshes so two MCP requests
+            // cannot publish fast snapshots out of order. This lock is separate from
+            // graph_build_lock; background enrichment must not block foreground search.
+            let _incremental_guard = self.incremental_update_lock.lock().await;
+            let current = self.graph.load_full();
+            let Some(ref gs) = *current else {
+                anyhow::bail!("graph snapshot disappeared during incremental refresh");
             };
-            if skip_scan {
-                return Ok(Arc::clone(gs));
-            }
 
             // Check for changes via scanner
             let mut scanner = Scanner::new(self.repo_root.clone())?;
             let scan = scanner.scan()?;
+            let missing_graph_files: Vec<(String, PathBuf)> = {
+                let root_paths: std::collections::HashMap<String, PathBuf> =
+                    WorkspaceConfig::load()
+                        .with_primary_root(self.repo_root.clone())
+                        .with_worktrees(&self.repo_root)
+                        .with_declared_roots(&self.repo_root)
+                        .resolved_roots()
+                        .into_iter()
+                        .map(|root| (root.slug, root.path))
+                        .collect();
+                let graph_files: std::collections::HashSet<(String, PathBuf)> = gs
+                    .nodes
+                    .iter()
+                    .filter(|n| {
+                        !matches!(n.id.kind, NodeKind::PrMerge)
+                            && !matches!(&n.id.kind, NodeKind::Other(kind) if matches!(
+                                kind.as_str(),
+                                "subsystem" | "framework" | "channel" | "event"
+                            ))
+                    })
+                    .map(|n| (n.id.root.clone(), n.id.file.clone()))
+                    .filter(|(_, f)| !f.as_os_str().is_empty())
+                    .collect();
+                graph_files
+                    .into_iter()
+                    .filter_map(|(root, file)| {
+                        let root_path = root_paths.get(&root)?;
+                        let absolute = if file.is_absolute() {
+                            file.clone()
+                        } else {
+                            root_path.join(&file)
+                        };
+                        (!absolute.exists()).then_some((root, file))
+                    })
+                    .collect()
+            };
             if scan.changed_files.is_empty()
                 && scan.new_files.is_empty()
                 && scan.deleted_files.is_empty()
+                && missing_graph_files.is_empty()
             {
                 // No changes -- safe to commit state (records current mtimes)
                 scanner.commit_state()?;
@@ -190,15 +230,18 @@ impl RnaHandler {
             // 2. Apply to cloned graph, ArcSwap immediately
             // 3. Spawn full pipeline (LSP, passes, PageRank, embed, persist) as background task
             // 4. Return immediately with tree-sitter results
-            let _build_guard = self.graph_build_lock.lock().await;
-            // Re-check after acquiring lock — another call may have already updated.
+            //
+            // Do not await graph_build_lock here. A background enrichment pipeline may
+            // legitimately hold it for minutes; foreground incremental refresh must
+            // still publish a tree-sitter snapshot immediately so MCP tools do not time out.
+            let build_guard = self.graph_build_lock.try_lock().ok();
+            // Re-check after opportunistically taking the build lock. A background
+            // full pipeline may have published a newer graph while this foreground
+            // refresh was scanning; if so, do not publish stale scan results.
             let current2 = self.graph.load_full();
             if let Some(ref gs2) = *current2
                 && !Arc::ptr_eq(gs, gs2)
             {
-                // Graph was updated while we waited for the lock.
-                scanner.commit_state()?;
-                *self.last_scan.lock().unwrap() = std::time::Instant::now();
                 return Ok(Arc::clone(gs2));
             }
 
@@ -207,20 +250,28 @@ impl RnaHandler {
             let registry = ExtractorRegistry::with_builtins();
             let primary_slug = RootConfig::code_project(self.repo_root.clone()).slug();
 
-            // Remove nodes/edges for deleted + changed files
-            let files_to_remove: Vec<PathBuf> = scan
+            // Remove nodes/edges for any touched file before re-extracting. Include
+            // `new_files`: if a file was added and then modified before scanner state
+            // was committed, it is still classified as new but may already exist in
+            // the foreground fast graph. Include missing graph files for the matching
+            // delete-before-commit case, where the scanner never saw the transient file.
+            let primary_touched_files = scan
                 .deleted_files
                 .iter()
                 .chain(scan.changed_files.iter())
+                .chain(scan.new_files.iter())
                 .cloned()
-                .collect();
+                .map(|file| (primary_slug.clone(), file));
+            let files_to_remove: std::collections::HashSet<(String, PathBuf)> =
+                primary_touched_files
+                    .chain(missing_graph_files.iter().cloned())
+                    .collect();
             fast_state
                 .nodes
-                .retain(|n| !files_to_remove.contains(&n.id.file));
+                .retain(|n| !files_to_remove.contains(&(n.id.root.clone(), n.id.file.clone())));
             fast_state.edges.retain(|e| {
-                !files_to_remove
-                    .iter()
-                    .any(|f| e.from.file == *f || e.to.file == *f)
+                !files_to_remove.contains(&(e.from.root.clone(), e.from.file.clone()))
+                    && !files_to_remove.contains(&(e.to.root.clone(), e.to.file.clone()))
             });
 
             // Extract new + changed files via tree-sitter
@@ -252,6 +303,13 @@ impl RnaHandler {
                     .ensure_node(&node.stable_id(), &node.id.kind.to_string());
             }
 
+            let current_before_fast_store = self.graph.load_full();
+            if let Some(ref current_gs) = *current_before_fast_store
+                && !Arc::ptr_eq(current_gs, gs)
+            {
+                return Ok(Arc::clone(current_gs));
+            }
+
             // Atomic swap: tool calls see tree-sitter results immediately
             let fast_arc = Arc::new(fast_state);
             self.graph.store(Arc::new(Some(Arc::clone(&fast_arc))));
@@ -265,17 +323,21 @@ impl RnaHandler {
                 let handler_graph = Arc::clone(&self.graph);
                 let repo_root = self.repo_root.clone();
                 let fast_arc_for_check = Arc::clone(&fast_arc);
+                let missing_graph_files = missing_graph_files.clone();
                 let scan_stats = Arc::clone(&self.scan_stats);
                 let lance_write_lock = Arc::clone(&self.lance_write_lock);
                 let embed_index = Arc::clone(&self.embed_index);
                 let lsp_status = Arc::clone(&self.lsp_status);
                 let graph_build_lock = Arc::clone(&self.graph_build_lock);
+                let incremental_update_lock = Arc::clone(&self.incremental_update_lock);
                 // Clone the pre-fast-path graph so the full pipeline starts from
                 // the same base state (with all existing LSP edges, PageRank, etc.)
                 let base_state = (**gs).clone();
-                // Release the build lock before spawning so the background task
-                // can re-acquire it. The fast graph is already swapped in.
-                drop(_build_guard);
+                // Release the opportunistic fast-path guard before spawning so the
+                // background task can serialize full enrichment work. If no guard was
+                // available, the fast snapshot has still been published and this task
+                // will wait in the background instead of blocking the tool call.
+                drop(build_guard);
                 tokio::spawn(async move {
                     tracing::info!(
                         "Spawned background incremental pipeline: {} changed, {} new, {} deleted",
@@ -292,13 +354,12 @@ impl RnaHandler {
                     if let Some(ref current_gs) = *current_snap
                         && !Arc::ptr_eq(current_gs, &fast_arc_for_check)
                     {
-                        // Another update happened; skip this pipeline run.
+                        // A newer fast snapshot was published while this background task
+                        // was waiting. Do not commit this older scanner state; the latest
+                        // background task must persist the final observed filesystem state.
                         tracing::info!(
-                            "Background incremental pipeline: graph already updated, skipping"
+                            "Background incremental pipeline: graph already superseded before enrichment; skipping"
                         );
-                        if let Err(e) = scanner.commit_state() {
-                            tracing::error!("Failed to commit scanner state: {}", e);
-                        }
                         return;
                     }
 
@@ -306,30 +367,33 @@ impl RnaHandler {
                     let mut full_state = base_state;
                     let primary_slug = RootConfig::code_project(repo_root.clone()).slug();
 
-                    // Remove nodes/edges for deleted + changed files (same as fast path)
-                    let files_to_remove: Vec<PathBuf> = scan
+                    // Remove nodes/edges for any touched file before re-extracting (same as fast path).
+                    let primary_touched_files = scan
                         .deleted_files
                         .iter()
                         .chain(scan.changed_files.iter())
+                        .chain(scan.new_files.iter())
                         .cloned()
-                        .collect();
+                        .map(|file| (primary_slug.clone(), file));
+                    let files_to_remove: std::collections::HashSet<(String, PathBuf)> =
+                        primary_touched_files
+                            .chain(missing_graph_files.iter().cloned())
+                            .collect();
                     let deleted_edge_ids: Vec<String> = full_state
                         .edges
                         .iter()
                         .filter(|e| {
-                            files_to_remove
-                                .iter()
-                                .any(|f| e.from.file == *f || e.to.file == *f)
+                            files_to_remove.contains(&(e.from.root.clone(), e.from.file.clone()))
+                                || files_to_remove.contains(&(e.to.root.clone(), e.to.file.clone()))
                         })
                         .map(|e| e.stable_id())
                         .collect();
-                    full_state
-                        .nodes
-                        .retain(|n| !files_to_remove.contains(&n.id.file));
+                    full_state.nodes.retain(|n| {
+                        !files_to_remove.contains(&(n.id.root.clone(), n.id.file.clone()))
+                    });
                     full_state.edges.retain(|e| {
-                        !files_to_remove
-                            .iter()
-                            .any(|f| e.from.file == *f || e.to.file == *f)
+                        !files_to_remove.contains(&(e.from.root.clone(), e.from.file.clone()))
+                            && !files_to_remove.contains(&(e.to.root.clone(), e.to.file.clone()))
                     });
 
                     // Extract new + changed files
@@ -367,10 +431,11 @@ impl RnaHandler {
                         full_state.edges.iter().map(|e| e.stable_id()).collect();
 
                     // Pre-clean: remove stale virtual nodes before passes
-                    let stale_virtual_files: Vec<std::path::PathBuf> = full_state.nodes
+                    let stale_virtual_files: Vec<(String, PathBuf)> = full_state
+                        .nodes
                         .iter()
                         .filter(|n| matches!(&n.id.kind, NodeKind::Other(s) if matches!(s.as_str(), "subsystem" | "framework" | "channel" | "event")))
-                        .map(|n| n.id.file.clone())
+                        .map(|n| (n.id.root.clone(), n.id.file.clone()))
                         .collect();
                     full_state.nodes.retain(|n| !matches!(&n.id.kind, NodeKind::Other(s) if matches!(s.as_str(), "subsystem" | "framework" | "channel" | "event")));
                     full_state.edges.retain(|e| {
@@ -379,8 +444,19 @@ impl RnaHandler {
                             && e.kind != crate::graph::EdgeKind::Produces
                             && e.kind != crate::graph::EdgeKind::Consumes
                     });
-                    let mut files_to_remove_all: Vec<PathBuf> = files_to_remove;
+                    let mut files_to_remove_all: Vec<(String, PathBuf)> =
+                        files_to_remove.into_iter().collect();
                     files_to_remove_all.extend(stale_virtual_files);
+
+                    let current_before_enrichment = handler_graph.load_full();
+                    if let Some(ref current_gs) = *current_before_enrichment
+                        && !Arc::ptr_eq(current_gs, &fast_arc_for_check)
+                    {
+                        tracing::info!(
+                            "Background incremental pipeline: newer graph published before enrichment; skipping"
+                        );
+                        return;
+                    }
 
                     // Run enrichment pipeline via EventBus (LSP, passes, framework detection)
                     let root_pairs: Vec<(String, std::path::PathBuf)> = WorkspaceConfig::load()
@@ -441,9 +517,6 @@ impl RnaHandler {
                                     "Background incremental pipeline: enrichment failed: {:#}",
                                     e
                                 );
-                                if let Err(e) = scanner.commit_state() {
-                                    tracing::error!("Failed to commit scanner state: {}", e);
-                                }
                                 return;
                             }
                         }
@@ -626,6 +699,20 @@ impl RnaHandler {
                         }
                     }
 
+                    // A newer foreground refresh may have published another fast snapshot
+                    // while this full pipeline was running. If so, discard this stale result
+                    // before persisting or swapping so older file contents cannot overwrite
+                    // newer incremental updates.
+                    let current_snap = handler_graph.load_full();
+                    if let Some(ref current_gs) = *current_snap
+                        && !Arc::ptr_eq(current_gs, &fast_arc_for_check)
+                    {
+                        tracing::info!(
+                            "Background incremental pipeline: newer graph published; discarding stale result"
+                        );
+                        return;
+                    }
+
                     // Build upsert data with post-PageRank importance scores
                     let upsert_nodes: Vec<Node> = full_state
                         .nodes
@@ -634,9 +721,21 @@ impl RnaHandler {
                         .cloned()
                         .collect();
 
-                    // Persist to LanceDB
+                    // Persist to LanceDB. Re-check while holding the write lock so a
+                    // stale background task cannot write after a newer fast snapshot
+                    // has already been published and is waiting to persist.
+                    let _foreground_guard = incremental_update_lock.lock().await;
                     let persist_result = {
                         let _lance_guard = lance_write_lock.lock().await;
+                        let current_before_persist = handler_graph.load_full();
+                        if let Some(ref current_gs) = *current_before_persist
+                            && !Arc::ptr_eq(current_gs, &fast_arc_for_check)
+                        {
+                            tracing::info!(
+                                "Background incremental pipeline: newer graph published before persist; discarding stale result"
+                            );
+                            return;
+                        }
                         persist_graph_incremental(
                             &repo_root,
                             &upsert_nodes,
@@ -649,6 +748,15 @@ impl RnaHandler {
                     let persist_ok = match persist_result {
                         Ok(true) => {
                             let _lance_guard = lance_write_lock.lock().await;
+                            let current_before_full_persist = handler_graph.load_full();
+                            if let Some(ref current_gs) = *current_before_full_persist
+                                && !Arc::ptr_eq(current_gs, &fast_arc_for_check)
+                            {
+                                tracing::info!(
+                                    "Background incremental pipeline: newer graph published before full persist; discarding stale result"
+                                );
+                                return;
+                            }
                             match persist_graph_to_lance(
                                 &repo_root,
                                 &full_state.nodes,
@@ -669,6 +777,16 @@ impl RnaHandler {
                             false
                         }
                     };
+
+                    let current_before_commit = handler_graph.load_full();
+                    if let Some(ref current_gs) = *current_before_commit
+                        && !Arc::ptr_eq(current_gs, &fast_arc_for_check)
+                    {
+                        tracing::info!(
+                            "Background incremental pipeline: newer graph published after persist; skipping stale commit/swap"
+                        );
+                        return;
+                    }
 
                     if persist_ok && let Err(e) = scanner.commit_state() {
                         tracing::error!("Failed to commit scanner state: {}", e);
@@ -1851,13 +1969,16 @@ impl RnaHandler {
 
         let registry = ExtractorRegistry::with_builtins();
 
+        let primary_slug = RootConfig::code_project(self.repo_root.clone()).slug();
         // Remove nodes/edges for deleted + changed files.
         // HashSet for O(1) lookup instead of O(F) Vec scan per edge (#586).
-        let mut files_to_remove: std::collections::HashSet<PathBuf> = scan
+        let mut files_to_remove: std::collections::HashSet<(String, PathBuf)> = scan
             .deleted_files
             .iter()
             .chain(scan.changed_files.iter())
+            .chain(scan.new_files.iter())
             .cloned()
+            .map(|file| (primary_slug.clone(), file))
             .collect();
 
         // Collect edge stable IDs for removed/changed files BEFORE retain, so we can
@@ -1866,16 +1987,18 @@ impl RnaHandler {
             .edges
             .iter()
             .filter(|e| {
-                files_to_remove.contains(&e.from.file) || files_to_remove.contains(&e.to.file)
+                files_to_remove.contains(&(e.from.root.clone(), e.from.file.clone()))
+                    || files_to_remove.contains(&(e.to.root.clone(), e.to.file.clone()))
             })
             .map(|e| e.stable_id())
             .collect();
 
         graph
             .nodes
-            .retain(|n| !files_to_remove.contains(&n.id.file));
+            .retain(|n| !files_to_remove.contains(&(n.id.root.clone(), n.id.file.clone())));
         graph.edges.retain(|e| {
-            !files_to_remove.contains(&e.from.file) && !files_to_remove.contains(&e.to.file)
+            !files_to_remove.contains(&(e.from.root.clone(), e.from.file.clone()))
+                && !files_to_remove.contains(&(e.to.root.clone(), e.to.file.clone()))
         });
 
         // Extract new + changed files
@@ -1885,7 +2008,6 @@ impl RnaHandler {
         // Set root slug on extracted nodes and edges.
         // Extractors don't set root -- the caller must assign it, matching the
         // pattern in build_full_graph and the background scanner.
-        let primary_slug = RootConfig::code_project(self.repo_root.clone()).slug();
 
         // Merge encoding stats (incremental scan: add to existing totals).
         if let Ok(mut stats) = self.scan_stats.write() {
@@ -1946,13 +2068,13 @@ impl RnaHandler {
         // re-emits fresh framework nodes with correct state.
         // Collect virtual file paths for LanceDB deletion — these will be added to
         // files_to_remove so the old rows are removed from LanceDB on persist.
-        let stale_virtual_files: Vec<std::path::PathBuf> = graph
+        let stale_virtual_files: Vec<(String, PathBuf)> = graph
             .nodes
             .iter()
             .filter(|n| {
                 matches!(&n.id.kind, NodeKind::Other(s) if matches!(s.as_str(), "subsystem" | "framework" | "channel" | "event"))
             })
-            .map(|n| n.id.file.clone())
+            .map(|n| (n.id.root.clone(), n.id.file.clone()))
             .collect();
         graph.nodes.retain(|n| !matches!(&n.id.kind, NodeKind::Other(s) if matches!(s.as_str(), "subsystem" | "framework" | "channel" | "event")));
         graph.edges.retain(|e| {
@@ -2265,7 +2387,7 @@ impl RnaHandler {
         // failure, so the next scan re-detects and retries the persist.
         let persist_result = {
             let _lance_guard = self.lance_write_lock.lock().await;
-            let files_to_remove_vec: Vec<PathBuf> = files_to_remove.into_iter().collect();
+            let files_to_remove_vec: Vec<(String, PathBuf)> = files_to_remove.into_iter().collect();
             persist_graph_incremental(
                 &self.repo_root,
                 &upsert_nodes,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -125,6 +125,12 @@ pub struct RnaHandler {
     pub prewarm_notify: Arc<tokio::sync::Notify>,
     /// Whether a pre-warm task has been started.
     pub prewarm_started: std::sync::atomic::AtomicBool,
+    /// Serializes fast foreground snapshots with background finalization.
+    ///
+    /// This deliberately does not serialize foreground refresh behind long LSP
+    /// enrichment. Background work takes it only for the short persist/commit/swap
+    /// finalization window so stale pipeline results cannot overwrite newer snapshots.
+    pub incremental_update_lock: Arc<tokio::sync::Mutex<()>>,
     /// Serializes graph build/update operations in `get_graph()`.
     /// With ArcSwap, reads are lock-free but concurrent builds must be serialized
     /// to avoid duplicate work (two tool calls both detecting "no graph" and both
@@ -157,6 +163,7 @@ impl Default for RnaHandler {
             lsp_handle: tokio::sync::Mutex::new(None),
             prewarm_notify: Arc::new(tokio::sync::Notify::new()),
             prewarm_started: std::sync::atomic::AtomicBool::new(false),
+            incremental_update_lock: Arc::new(tokio::sync::Mutex::new(())),
             graph_build_lock: Arc::new(tokio::sync::Mutex::new(())),
             graph_build_status: Arc::new(GraphBuildStatus::default()),
         }
@@ -191,6 +198,7 @@ impl RnaHandler {
             lsp_handle: tokio::sync::Mutex::new(None),
             prewarm_notify: Arc::clone(&self.prewarm_notify),
             prewarm_started: std::sync::atomic::AtomicBool::new(false),
+            incremental_update_lock: Arc::clone(&self.incremental_update_lock),
             graph_build_lock: Arc::clone(&self.graph_build_lock),
             graph_build_status: Arc::clone(&self.graph_build_status),
         }
@@ -597,6 +605,243 @@ mod tests {
             let age = gs.last_scan_completed_at.unwrap().elapsed();
             assert!(age < std::time::Duration::from_secs(5));
         }
+    }
+
+    #[tokio::test]
+    async fn test_get_graph_incremental_update_does_not_wait_for_background_lock() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join(".oh/.cache")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn original_function() {}\n").unwrap();
+
+        let handler = RnaHandler {
+            repo_root: root.to_path_buf(),
+            ..Default::default()
+        };
+
+        let initial = handler.get_graph().await.unwrap();
+        assert!(
+            initial
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "original_function")
+        );
+        drop(initial);
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "pub fn nonblocking_replacement_function() {}\n",
+        )
+        .unwrap();
+
+        {
+            let mut last = handler.last_scan.lock().unwrap();
+            *last = std::time::Instant::now() - std::time::Duration::from_secs(10);
+        }
+
+        let background_guard = handler.graph_build_lock.lock().await;
+        let updated =
+            tokio::time::timeout(std::time::Duration::from_millis(250), handler.get_graph())
+                .await
+                .expect(
+                    "incremental tree-sitter refresh must not wait for background enrichment lock",
+                )
+                .expect("get_graph should succeed while background lock is held");
+        drop(background_guard);
+
+        assert!(
+            updated
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "nonblocking_replacement_function"),
+            "foreground fast graph should include the updated symbol"
+        );
+        assert!(
+            !updated
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "original_function"),
+            "foreground fast graph should remove the stale symbol"
+        );
+
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "pub fn immediate_second_replacement_function() {}\n",
+        )
+        .unwrap();
+        let second_update =
+            tokio::time::timeout(std::time::Duration::from_millis(250), handler.get_graph())
+                .await
+                .expect("rapid follow-up edit must not be hidden by a scan cooldown")
+                .expect("get_graph should succeed for rapid follow-up edit");
+        assert!(
+            second_update
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "immediate_second_replacement_function"),
+            "foreground fast graph should include the rapid follow-up symbol"
+        );
+        assert!(
+            !second_update
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "nonblocking_replacement_function"),
+            "foreground fast graph should remove the previous rapid symbol"
+        );
+
+        std::fs::write(
+            root.join("src/new_file.rs"),
+            "pub fn rapid_new_file_alpha() {}\n",
+        )
+        .unwrap();
+        let new_file_add =
+            tokio::time::timeout(std::time::Duration::from_millis(250), handler.get_graph())
+                .await
+                .expect("new file add should be visible without waiting for background persistence")
+                .expect("get_graph should succeed for new file add");
+        assert!(
+            new_file_add
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "rapid_new_file_alpha"),
+            "foreground fast graph should include the new-file symbol"
+        );
+
+        std::fs::write(
+            root.join("src/new_file.rs"),
+            "pub fn rapid_new_file_beta() {}\n",
+        )
+        .unwrap();
+        let new_file_modify =
+            tokio::time::timeout(std::time::Duration::from_millis(250), handler.get_graph())
+                .await
+                .expect("new file modify should replace the previous fast snapshot immediately")
+                .expect("get_graph should succeed for new file modify");
+        assert!(
+            new_file_modify
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "rapid_new_file_beta"),
+            "foreground fast graph should include the modified new-file symbol"
+        );
+        assert!(
+            !new_file_modify
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "rapid_new_file_alpha"),
+            "foreground fast graph should remove the stale new-file symbol"
+        );
+
+        std::fs::remove_file(root.join("src/new_file.rs")).unwrap();
+        let new_file_delete =
+            tokio::time::timeout(std::time::Duration::from_millis(250), handler.get_graph())
+                .await
+                .expect("new file delete should remove the fast snapshot immediately")
+                .expect("get_graph should succeed for new file delete");
+        assert!(
+            !new_file_delete
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "rapid_new_file_beta"),
+            "foreground fast graph should remove the deleted new-file symbol"
+        );
+
+        let mut graph_with_other = (*new_file_delete).clone();
+        graph_with_other.nodes.push(crate::graph::Node {
+            id: crate::graph::NodeId {
+                root: crate::roots::RootConfig::code_project(root.to_path_buf()).slug(),
+                file: std::path::PathBuf::from("src/other_only.graphql"),
+                name: "TransientGraphqlType".to_string(),
+                kind: crate::graph::NodeKind::Other("graphql_type".to_string()),
+            },
+            language: "graphql".to_string(),
+            line_start: 1,
+            line_end: 1,
+            signature: "type TransientGraphqlType".to_string(),
+            body: String::new(),
+            metadata: std::collections::BTreeMap::new(),
+            source: crate::graph::ExtractionSource::TreeSitter,
+        });
+        handler
+            .graph
+            .store(std::sync::Arc::new(Some(std::sync::Arc::new(
+                graph_with_other,
+            ))));
+        let other_cleanup =
+            tokio::time::timeout(std::time::Duration::from_millis(250), handler.get_graph())
+                .await
+                .expect("missing real file-backed Other nodes should be cleaned immediately")
+                .expect("get_graph should succeed for Other-node cleanup");
+        assert!(
+            !other_cleanup
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "TransientGraphqlType"),
+            "foreground fast graph should remove stale real file-backed Other nodes"
+        );
+
+        let mut graph_with_exclusions = (*other_cleanup).clone();
+        graph_with_exclusions.nodes.push(crate::graph::Node {
+            id: crate::graph::NodeId {
+                root: "unknown-declared-root".to_string(),
+                file: std::path::PathBuf::from("src/other_only.graphql"),
+                name: "UnknownRootGraphqlType".to_string(),
+                kind: crate::graph::NodeKind::Other("graphql_type".to_string()),
+            },
+            language: "graphql".to_string(),
+            line_start: 1,
+            line_end: 1,
+            signature: "type UnknownRootGraphqlType".to_string(),
+            body: String::new(),
+            metadata: std::collections::BTreeMap::new(),
+            source: crate::graph::ExtractionSource::TreeSitter,
+        });
+        graph_with_exclusions.nodes.push(crate::graph::Node {
+            id: crate::graph::NodeId {
+                root: crate::roots::RootConfig::code_project(root.to_path_buf()).slug(),
+                file: std::path::PathBuf::from("subsystems/transient-subsystem"),
+                name: "transient-subsystem".to_string(),
+                kind: crate::graph::NodeKind::Other("subsystem".to_string()),
+            },
+            language: String::new(),
+            line_start: 0,
+            line_end: 0,
+            signature: String::new(),
+            body: String::new(),
+            metadata: std::collections::BTreeMap::new(),
+            source: crate::graph::ExtractionSource::TreeSitter,
+        });
+        handler
+            .graph
+            .store(std::sync::Arc::new(Some(std::sync::Arc::new(
+                graph_with_exclusions,
+            ))));
+        let exclusion_cleanup =
+            tokio::time::timeout(std::time::Duration::from_millis(250), handler.get_graph())
+                .await
+                .expect(
+                    "virtual Other and unknown-root nodes should not trigger missing-file cleanup",
+                )
+                .expect("get_graph should succeed for exclusion cleanup");
+        assert!(
+            exclusion_cleanup
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "UnknownRootGraphqlType"),
+            "unknown-root nodes should not be resolved against the primary root"
+        );
+        assert!(
+            exclusion_cleanup
+                .nodes
+                .iter()
+                .any(|n| n.id.name == "transient-subsystem"),
+            "virtual Other subsystem nodes should be excluded from missing-file cleanup"
+        );
     }
 
     #[tokio::test]

--- a/src/server/store/persist.rs
+++ b/src/server/store/persist.rs
@@ -266,13 +266,13 @@ pub(crate) async fn compact_stale_versions(
 /// - `upsert_edges`: only the changed or newly added edges (not the full graph)
 /// - `deleted_edge_ids`: stable IDs of edges that reference removed/changed files -- collected
 ///   before the in-memory retain step in `update_graph_incrementally`
-/// - `deleted_files`: file paths whose symbols should be deleted from LanceDB
+/// - `deleted_files`: `(root_id, file_path)` pairs whose symbols should be deleted from LanceDB
 pub(crate) async fn persist_graph_incremental(
     repo_root: &Path,
     upsert_nodes: &[Node],
     upsert_edges: &[Edge],
     deleted_edge_ids: &[String],
-    deleted_files: &[PathBuf],
+    deleted_files: &[(String, PathBuf)],
 ) -> anyhow::Result<bool> {
     let db_path = graph_lance_path(repo_root);
     std::fs::create_dir_all(&db_path)?;
@@ -308,11 +308,17 @@ pub(crate) async fn persist_graph_incremental(
         if !deleted_files.is_empty()
             && let Ok(tbl) = db.open_table("symbols").execute().await
         {
-            let quoted: Vec<String> = deleted_files
+            let predicates: Vec<String> = deleted_files
                 .iter()
-                .map(|p| format!("'{}'", p.display().to_string().replace('\'', "''")))
+                .map(|(root, path)| {
+                    format!(
+                        "(root_id = '{}' AND file_path = '{}')",
+                        root.replace('\'', "''"),
+                        path.display().to_string().replace('\'', "''")
+                    )
+                })
                 .collect();
-            let predicate = format!("file_path IN ({})", quoted.join(", "));
+            let predicate = predicates.join(" OR ");
             if let Err(e) = tbl.delete(&predicate).await {
                 tracing::warn!("Failed to delete symbols for removed files: {}", e);
             }

--- a/src/smoke_test.rs
+++ b/src/smoke_test.rs
@@ -520,7 +520,15 @@ pub fn rna_smoke_common_fn() -> u32 { 2 }\n\
         deleted_files: Vec::new(),
         scan_duration: std::time::Duration::ZERO,
     };
-    let initial_extraction = registry.extract_scan_result(&temp_dir, &initial_scan);
+    let primary_slug = crate::roots::RootConfig::code_project(temp_dir.clone()).slug();
+    let mut initial_extraction = registry.extract_scan_result(&temp_dir, &initial_scan);
+    for node in &mut initial_extraction.nodes {
+        node.id.root = primary_slug.clone();
+    }
+    for edge in &mut initial_extraction.edges {
+        edge.from.root = primary_slug.clone();
+        edge.to.root = primary_slug.clone();
+    }
     let initial_nodes = initial_extraction.nodes;
     let initial_edges = initial_extraction.edges;
 
@@ -558,17 +566,24 @@ pub fn rna_smoke_common_fn() -> u32 { 2 }\n\
     }
 
     // Step 4: Simulate what update_graph_incrementally does:
-    //   files_to_remove = [fixture_path] (it's a "changed" file)
+    //   files_to_remove = [(primary_slug, fixture_path)] (it's a "changed" file)
     //   deleted_edge_ids = [] (no edges in this test)
     //   upsert = extraction of updated file
-    let files_to_remove = vec![fixture_path.clone()];
+    let files_to_remove = vec![(primary_slug.clone(), fixture_path.clone())];
     let update_scan = crate::scanner::ScanResult {
         changed_files: vec![fixture_path.clone()],
         new_files: Vec::new(),
         deleted_files: Vec::new(),
         scan_duration: std::time::Duration::ZERO,
     };
-    let update_extraction = registry.extract_scan_result(&temp_dir, &update_scan);
+    let mut update_extraction = registry.extract_scan_result(&temp_dir, &update_scan);
+    for node in &mut update_extraction.nodes {
+        node.id.root = primary_slug.clone();
+    }
+    for edge in &mut update_extraction.edges {
+        edge.from.root = primary_slug.clone();
+        edge.to.root = primary_slug.clone();
+    }
     let upsert_nodes = update_extraction.nodes;
     let upsert_edges = update_extraction.edges;
 


### PR DESCRIPTION
Fixes #683.

## Summary
- Make foreground incremental `get_graph()` refresh non-blocking when background enrichment owns `graph_build_lock`.
- Keep full LSP/pass/embed/persist work serialized in the background, but skip stale background commits/swaps if a newer fast snapshot has already been published.
- Add regression coverage for editing a file while `graph_build_lock` is held.
- Record the MCP dogfood timeout friction in `.oh/friction-logs/`.

## Verification
- `cargo test -p repo-native-alignment server::tests::test_get_graph_incremental_update_does_not_wait_for_background_lock -- --nocapture`
- `cargo check --lib --bins --tests`
- `cargo clippy --lib --bins -- -D warnings`
- `git diff --check`
- Real MCP stdio add/change/delete probe against `target/debug/repo-native-alignment`:
  - baseline alpha absent
  - add alpha found
  - modify beta found
  - old alpha absent
  - delete beta absent

## Risk
Medium. This changes synchronization around incremental graph refresh. The fast foreground snapshot is intentionally allowed to proceed while background enrichment serializes; stale background guards prevent older results from overwriting newer snapshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved MCP tools becoming unresponsive during incremental updates by eliminating blocking behavior between foreground and background operations
  * Improved file deletion and modification tracking during incremental updates to maintain consistent graph state

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-horizon-labs/repo-native-alignment/pull/684)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->