### PR TITLE
Use live graph for current-repo MCP search

### DIFF
--- a/.oh/friction-logs/mcp-search-empty-nodes-current-repo-2026-05-09.md
+++ b/.oh/friction-logs/mcp-search-empty-nodes-current-repo-2026-05-09.md
@@ -1,0 +1,11 @@
+---
+id: mcp-search-empty-nodes-current-repo-2026-05-09
+outcome: context-assembly
+severity: major
+---
+
+# MCP search empty nodes/current repo friction
+
+| Time | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-05-09 | `mcp_rna_server_search` with generated defaults | major | The harness supplied `nodes: []` and `repo: <current repo>`. The server interpreted empty `nodes` as batch mode and returned `Empty nodes list`, and interpreted the current repo path as an external persisted LanceDB query instead of the live in-memory graph. | Incremental mutations were extracted but not observable through MCP tools using the generated call shape; agents could falsely conclude incremental indexing was still broken. | Behavior changed so empty `nodes`/blank fields are absent, and blank/current repo paths use live graph requests where foreground incremental snapshots are visible. |

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -6,9 +6,10 @@
 //! ## `repo` parameter
 //!
 //! `search`, `repo_map`, and `outcome_progress` accept an optional `repo` path.
-//! When provided, the handler loads a fresh [`GraphState`] from that path's
-//! `.oh/.cache/lance/` LanceDB instead of the server's in-memory graph. This
-//! lets agents in git worktrees query their own repo:
+//! Blank strings and paths resolving to the server's own repo use the live in-memory
+//! graph (including foreground incremental updates). Other paths load a fresh
+//! [`GraphState`] from that path's `.oh/.cache/lance/`, which lets agents in git
+//! worktrees query their own repo:
 //!
 //! ```text
 //! search(query="build_code_embedding_text", repo="/path/to/worktree")
@@ -19,7 +20,7 @@
 //!
 //! Embedding (semantic) search is not available for external repos.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use petgraph::Direction;
 use rust_mcp_sdk::schema::{CallToolError, CallToolResult};
@@ -80,12 +81,37 @@ impl RnaHandler {
         Ok((graph, repo_path))
     }
 
+    fn non_blank_arg(value: Option<&str>) -> Option<&str> {
+        value.map(str::trim).filter(|s| !s.is_empty())
+    }
+
+    fn external_repo_arg<'a>(value: Option<&'a str>, server_root: &Path) -> Option<&'a str> {
+        let repo = Self::non_blank_arg(value)?;
+        let requested = PathBuf::from(repo);
+        if !requested.is_absolute() {
+            return Some(repo);
+        }
+        let requested_canonical = requested.canonicalize().unwrap_or(requested);
+        let server_canonical = server_root
+            .canonicalize()
+            .unwrap_or_else(|_| server_root.to_path_buf());
+
+        (requested_canonical != server_canonical).then_some(repo)
+    }
+
     pub(crate) async fn handle_search(
         &self,
         args: Search,
     ) -> Result<CallToolResult, CallToolError> {
         let params = SearchParams::from_mcp_search(&args);
-        if params.include_body && args.node.is_none() && args.nodes.is_none() {
+        if params.include_body
+            && params.node.is_none()
+            && params
+                .nodes
+                .as_ref()
+                .map(|nodes| nodes.is_empty())
+                .unwrap_or(true)
+        {
             return Ok(text_result(
                 "include_body requires `node` or `nodes` parameter".into(),
             ));
@@ -93,7 +119,7 @@ impl RnaHandler {
 
         // When `repo` is provided, load an external graph from that path.
         // Semantic search is skipped (no embed_index for external repos).
-        if let Some(ref repo) = args.repo {
+        if let Some(repo) = Self::external_repo_arg(args.repo.as_deref(), &self.repo_root) {
             let (external_graph, repo_path) = match self.load_external_graph(repo).await {
                 Ok(pair) => pair,
                 Err(e) => return Ok(text_result(e)),
@@ -113,7 +139,7 @@ impl RnaHandler {
             return Ok(text_result(markdown));
         }
 
-        let root_filter = self.effective_root_filter(args.root.as_deref());
+        let root_filter = self.effective_root_filter(Self::non_blank_arg(args.root.as_deref()));
         let non_code_slugs = if root_filter.is_some() {
             self.non_code_root_slugs()
         } else {
@@ -149,7 +175,7 @@ impl RnaHandler {
         args: OutcomeProgress,
     ) -> Result<CallToolResult, CallToolError> {
         // When `repo` is provided, load an external graph from that path.
-        if let Some(ref repo) = args.repo {
+        if let Some(repo) = Self::external_repo_arg(args.repo.as_deref(), &self.repo_root) {
             let (external_graph, repo_path) = match self.load_external_graph(repo).await {
                 Ok(pair) => pair,
                 Err(e) => return Ok(text_result(e)),
@@ -168,7 +194,7 @@ impl RnaHandler {
             return Ok(text_result(markdown));
         }
 
-        let root_filter = self.effective_root_filter(args.root.as_deref());
+        let root_filter = self.effective_root_filter(Self::non_blank_arg(args.root.as_deref()));
         let non_code_slugs = if root_filter.is_some() {
             self.non_code_root_slugs()
         } else {
@@ -234,7 +260,7 @@ impl RnaHandler {
         args: RepoMap,
     ) -> Result<CallToolResult, CallToolError> {
         // When `repo` is provided, load an external graph from that path.
-        if let Some(ref repo) = args.repo {
+        if let Some(repo) = Self::external_repo_arg(args.repo.as_deref(), &self.repo_root) {
             let (external_graph, repo_path) = match self.load_external_graph(repo).await {
                 Ok(pair) => pair,
                 Err(e) => return Ok(text_result(e)),
@@ -254,7 +280,7 @@ impl RnaHandler {
             return Ok(text_result(markdown));
         }
 
-        let root_filter = self.effective_root_filter(args.root.as_deref());
+        let root_filter = self.effective_root_filter(Self::non_blank_arg(args.root.as_deref()));
         let non_code_slugs = if root_filter.is_some() {
             self.non_code_root_slugs()
         } else {
@@ -1015,6 +1041,114 @@ mod tests {
             err.contains("absolute path"),
             "error should mention absolute path: {}",
             err
+        );
+    }
+
+    #[test]
+    fn test_external_repo_arg_ignores_blank_repo() {
+        let root = PathBuf::from("/srv/main-repo");
+        assert!(RnaHandler::external_repo_arg(None, &root).is_none());
+        assert!(RnaHandler::external_repo_arg(Some(""), &root).is_none());
+        assert!(RnaHandler::external_repo_arg(Some("   "), &root).is_none());
+    }
+
+    #[test]
+    fn test_external_repo_arg_ignores_current_repo_path() {
+        let root = std::env::current_dir().unwrap();
+        let root_string = root.to_string_lossy().to_string();
+
+        assert!(RnaHandler::external_repo_arg(Some(&root_string), &root).is_none());
+    }
+
+    #[test]
+    fn test_external_repo_arg_keeps_different_absolute_repo() {
+        let root = PathBuf::from("/srv/main-repo");
+
+        assert_eq!(
+            RnaHandler::external_repo_arg(Some("/srv/worktree"), &root),
+            Some("/srv/worktree")
+        );
+    }
+
+    #[test]
+    fn test_external_repo_arg_keeps_relative_repo_for_validation_error() {
+        let root = std::env::current_dir().unwrap();
+
+        assert_eq!(RnaHandler::external_repo_arg(Some("."), &root), Some("."));
+        assert_eq!(
+            RnaHandler::external_repo_arg(Some(" worktrees/feature "), &root),
+            Some("worktrees/feature")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_search_generated_defaults_current_repo_use_live_graph() {
+        let repo_root = std::env::current_dir().unwrap();
+        let handler = make_handler(&repo_root);
+        let symbol = "rna_generated_default_live_graph_probe";
+        let root_slug = handler.primary_root_slug();
+
+        let node = Node {
+            id: NodeId {
+                root: root_slug,
+                file: PathBuf::from("src/generated_default_live.rs"),
+                name: symbol.to_string(),
+                kind: NodeKind::Function,
+            },
+            language: "rust".to_string(),
+            line_start: 1,
+            line_end: 3,
+            signature: format!("pub fn {}() -> &'static str", symbol),
+            body: "\"live\"".to_string(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::TreeSitter,
+        };
+
+        let mut index = GraphIndex::new();
+        index.ensure_node(&node.stable_id(), "function");
+        let graph = GraphState::new(
+            vec![node],
+            Vec::new(),
+            index,
+            Some(std::time::Instant::now()),
+            std::collections::HashSet::new(),
+        );
+        handler
+            .graph
+            .store(std::sync::Arc::new(Some(std::sync::Arc::new(graph))));
+
+        let args: Search = serde_json::from_value(serde_json::json!({
+            "query": symbol,
+            "nodes": [],
+            "edge_types": [],
+            "artifact_types": [],
+            "repo": repo_root.to_string_lossy(),
+            "root": " ",
+            "file": "generated_default_live.rs",
+            "kind": "function",
+            "language": "rust",
+            "include_markdown": false,
+            "include_artifacts": false,
+            "search_mode": "keyword",
+            "compact": true,
+            "verbose": false
+        }))
+        .unwrap();
+
+        let result = handler.handle_search(args).await.unwrap();
+        let rendered = serde_json::to_string(&result).unwrap();
+
+        assert!(
+            rendered.contains(symbol),
+            "generated-default current-repo search should return live graph symbol: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Empty nodes list"),
+            "empty generated nodes must not force batch mode: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Failed to load graph"),
+            "current repo should not be treated as external LanceDB: {rendered}"
         );
     }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -107,6 +107,19 @@ fn non_blank_optional(value: &Option<String>) -> Option<String> {
     })
 }
 
+fn non_empty_string_vec(value: &Option<Vec<String>>) -> Option<Vec<String>> {
+    let values: Vec<String> = value
+        .as_ref()?
+        .iter()
+        .filter_map(|s| {
+            let trimmed = s.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+        .collect();
+
+    (!values.is_empty()).then_some(values)
+}
+
 impl SearchParams {
     pub fn normalized_mode(&self) -> Option<&str> {
         self.mode
@@ -118,29 +131,29 @@ impl SearchParams {
     /// Convert from MCP `Search` tool struct.
     pub fn from_mcp_search(args: &crate::server::tools::Search) -> Self {
         Self {
-            query: args.query.clone(),
-            node: args.node.clone(),
+            query: non_blank_optional(&args.query),
+            node: non_blank_optional(&args.node),
             mode: non_blank_optional(&args.mode),
             hops: args.hops,
             depth: args.depth,
-            direction: args.direction.clone(),
-            edge_types: args.edge_types.clone(),
-            kind: args.kind.clone(),
-            language: args.language.clone(),
-            file: args.file.clone(),
+            direction: non_blank_optional(&args.direction),
+            edge_types: non_empty_string_vec(&args.edge_types),
+            kind: non_blank_optional(&args.kind),
+            language: non_blank_optional(&args.language),
+            file: non_blank_optional(&args.file),
             limit: args.limit.map(|k| k as usize),
-            sort_by: args.sort_by.clone(),
+            sort_by: non_blank_optional(&args.sort_by),
             min_complexity: args.min_complexity,
             synthetic: args.synthetic,
             compact: args.compact.unwrap_or(false),
-            nodes: args.nodes.clone(),
-            search_mode: args.search_mode.clone(),
+            nodes: non_empty_string_vec(&args.nodes),
+            search_mode: non_blank_optional(&args.search_mode),
             rerank: args.rerank.unwrap_or(true),
             include_artifacts: args.include_artifacts.unwrap_or(true),
             include_markdown: args.include_markdown.unwrap_or(true),
-            artifact_types: args.artifact_types.clone(),
-            subsystem: args.subsystem.clone(),
-            target_subsystem: args.target_subsystem.clone(),
+            artifact_types: non_empty_string_vec(&args.artifact_types),
+            subsystem: non_blank_optional(&args.subsystem),
+            target_subsystem: non_blank_optional(&args.target_subsystem),
             include_body: args.include_body.unwrap_or(false),
             minify_body: args.minify_body.unwrap_or(false),
             verbose: args.verbose.unwrap_or(false),
@@ -206,6 +219,83 @@ mod tests {
         let params = SearchParams::from_mcp_search(&search);
 
         assert_eq!(params.mode.as_deref(), Some("bogus"));
+    }
+
+    #[test]
+    fn from_mcp_search_treats_empty_nodes_as_absent() {
+        let search: Search = serde_json::from_value(json!({
+            "query": "get_graph",
+            "nodes": [],
+            "edge_types": [],
+            "artifact_types": []
+        }))
+        .unwrap();
+
+        let params = SearchParams::from_mcp_search(&search);
+
+        assert_eq!(params.query.as_deref(), Some("get_graph"));
+        assert!(params.nodes.is_none());
+        assert!(params.edge_types.is_none());
+        assert!(params.artifact_types.is_none());
+    }
+
+    #[test]
+    fn from_mcp_search_trims_and_drops_blank_nodes() {
+        let search: Search = serde_json::from_value(json!({
+            "nodes": ["  repo:src/lib.rs:thing:function  ", "", "   "]
+        }))
+        .unwrap();
+
+        let params = SearchParams::from_mcp_search(&search);
+
+        assert_eq!(
+            params.nodes,
+            Some(vec!["repo:src/lib.rs:thing:function".to_string()])
+        );
+    }
+
+    #[test]
+    fn from_mcp_search_treats_blank_scalar_filters_as_absent() {
+        let search: Search = serde_json::from_value(json!({
+            "query": "  ",
+            "node": "",
+            "kind": "   ",
+            "language": "",
+            "file": " ",
+            "direction": "   ",
+            "sort_by": "",
+            "search_mode": " ",
+            "subsystem": "",
+            "target_subsystem": "  "
+        }))
+        .unwrap();
+
+        let params = SearchParams::from_mcp_search(&search);
+
+        assert!(params.query.is_none());
+        assert!(params.node.is_none());
+        assert!(params.kind.is_none());
+        assert!(params.language.is_none());
+        assert!(params.file.is_none());
+        assert!(params.direction.is_none());
+        assert!(params.sort_by.is_none());
+        assert!(params.search_mode.is_none());
+        assert!(params.subsystem.is_none());
+        assert!(params.target_subsystem.is_none());
+    }
+
+    #[test]
+    fn from_mcp_search_trims_vector_filters() {
+        let search: Search = serde_json::from_value(json!({
+            "edge_types": [" calls ", "", "   "],
+            "artifact_types": [" outcome ", ""]
+        }))
+        .unwrap();
+
+        let params = SearchParams::from_mcp_search(&search);
+
+        assert_eq!(params.edge_types, Some(vec!["calls".to_string()]));
+        assert_eq!(params.artifact_types, Some(vec!["outcome".to_string()]));
     }
 }
 


### PR DESCRIPTION
Fixes #685.

## Summary
- Treat generated MCP `nodes: []` as omitted so query-mode search runs instead of returning `Empty nodes list`.
- Normalize blank scalar search fields to absent.
- Treat blank `repo` and `repo` paths resolving to the server's own repo as live in-memory graph requests.
- Keep different absolute repo paths on the existing external persisted-LanceDB path.
- Record the dogfood friction in `.oh/friction-logs/`.

## Verification
- `cargo test -p repo-native-alignment from_mcp_search_ -- --nocapture`
- `cargo test -p repo-native-alignment test_external_repo_arg_ -- --nocapture`
- `cargo check --lib --bins --tests`
- `cargo clippy --lib --bins -- -D warnings`
- `git diff --check`
- `cargo build --bin repo-native-alignment`
- Real MCP stdio probe against rebuilt `target/debug/repo-native-alignment` with `nodes: []` and `repo: <current repo absolute path>`:
  - baseline alpha absent
  - after add alpha found
  - after modify beta found
  - after modify alpha absent
  - after delete beta absent

## Risk
Low-to-medium. This changes MCP argument normalization and repo dispatch only. External worktree queries still require a different absolute repo path and continue using persisted LanceDB.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search now treats empty/blank fields and empty node lists as absent so live repo searches show expected, foreground incremental snapshots.
  * Repository context detection improved to reliably use the current in-memory graph vs external repo queries.
  * Input validation tightened to avoid incorrect routing when include_body and node(s) are empty.

* **Documentation**
  * Added a friction log describing the empty-node/current-repo search behavior and its resolution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-horizon-labs/repo-native-alignment/pull/686)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->