### PR TITLE
Fix extraction capability search recall

### DIFF
--- a/.oh/friction-logs/lsp-treesitter-extraction-search-2026-05-09.md
+++ b/.oh/friction-logs/lsp-treesitter-extraction-search-2026-05-09.md
@@ -1,0 +1,13 @@
+---
+id: lsp-treesitter-extraction-search-2026-05-09
+outcome: context-assembly
+severity: friction
+---
+
+# LSP/tree-sitter extraction search friction
+
+| Time | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-05-09 | `mcp_rna_server_search` query `LangConfig language parser tree_sitter extractor suffixes` | friction | Search returned no results, despite `src/extract/generic.rs` defining `LangConfig` and `src/extract/configs.rs` defining many `LangConfig` instances. | Investigation of extraction capabilities could miss the canonical language configuration model and over-rely on fallback source inspection. | Improve exact/compound search recall for Rust struct definitions and construction sites; verify `LangConfig` symbols and instances are indexed and retrievable. |
+| 2026-05-09 | `mcp_rna_server_search` queries for parser dependency names in `Cargo.toml` | friction | Search returned no results for parser dependency names, despite `Cargo.toml` lines 24-52 listing tree-sitter grammar crates. | Agents cannot reliably discover available parser coverage through MCP search and must inspect manifest text directly. | Ensure manifest/dependency sections are searchable, especially exact crate names and `tree-sitter-*` dependencies. |
+| 2026-05-09 | `mcp_rna_server_search` query `tree_sitter_` scoped to `src/extract` | friction | Search returned only a test function and missed actual parser registrations/usages in extraction configs; specialized `grep` was needed. | MCP search under-reported tree-sitter usage and could lead agents to conclude parser registration coverage is absent. | Improve underscore/prefix matching and symbol/body/config recall for parser registration calls in `src/extract`. |

--- a/docs/extractors.md
+++ b/docs/extractors.md
@@ -529,6 +529,12 @@ RNA's built-in extractors run via tree-sitter to produce symbols, import graphs,
 - **Docs & schema/API** — Markdown (heading-aware), .proto, SQL, OpenAPI/JSON Schema, GraphQL
 - **Architecture** — subprocess, network, async boundaries detected as topology edges (Rust extractor)
 
+### Tree-sitter parser support policy
+
+Do we need to manually add parsers? Yes. The upstream tree-sitter parser list is a candidate catalog, not automatic RNA support. A language is supported only after its parser crate is packaged, the extractor is registered and configured, the behavior is tested with expected symbols/edges, and search/MCP delivery exposes the facts.
+
+Packaged parser dependencies live in `Cargo.toml`. Parser registration and language configuration live in the language extractor modules and `src/extract/configs.rs`; for example, Python support uses `tree_sitter_python::LANGUAGE` in `src/extract/python.rs`. Registry coverage is exposed through `ExtractorRegistry` and the `languages()` methods.
+
 ### Constants and literals (cross-language)
 
 Built-in extractors index constants and literal values where the parser exposes them. `search` returns the value inline:

--- a/scripts/search-recall-fixtures.sh
+++ b/scripts/search-recall-fixtures.sh
@@ -41,12 +41,24 @@ PY
 run_search() {
   local query="$1" mode="$2" limit="$3" outfile="$4"
   shift 4
-  "$RNA_BIN" search "$query" \
+  local status=0
+  if "$RNA_BIN" search "$query" \
     --repo "$RNA_REPO" \
     --search-mode "$mode" \
     --limit "$limit" \
     --compact \
-    "$@" >"$outfile" 2>&1
+    "$@" >"$outfile" 2>&1; then
+    return 0
+  else
+    status=$?
+    {
+      printf '\nERROR: search probe failed with exit code %s\n' "$status"
+      printf 'query=%s mode=%s limit=%s\n' "$query" "$mode" "$limit"
+    } >>"$outfile"
+    printf 'Search probe failed: query=%s mode=%s exit=%s\n' "$query" "$mode" "$status" >&2
+    fail_count=$((fail_count + 1))
+    return 0
+  fi
 }
 
 contains_in_section() {

--- a/scripts/search-recall-fixtures.sh
+++ b/scripts/search-recall-fixtures.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# Diagnose RNA search recall failures by pipeline stage.
+#
+# Usage:
+#   scripts/search-recall-fixtures.sh [repo]
+#
+# The script answers "cast wide net, then filter, then rank: which stage failed?"
+# for a small fixture set taken from issue #687. It is diagnostic, not a broad
+# search benchmark: each fixture has a known source fact and expected retrieval
+# text. The output is a markdown table suitable for pasting into the issue.
+
+set -uo pipefail
+
+RNA_REPO="${1:-$(pwd)}"
+RNA_BIN="${RNA_BIN:-repo-native-alignment}"
+RNA_RECALL_SEMANTIC="${RNA_RECALL_SEMANTIC:-false}"
+RNA_RECALL_RERANK="${RNA_RECALL_RERANK:-false}"
+
+TMP_DIR="${TMPDIR:-/tmp}/rna-search-recall-fixtures.$$"
+mkdir -p "$TMP_DIR"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+pass_count=0
+fail_count=0
+
+have_source() {
+  local file="$1" pattern="$2"
+  python3 - "$RNA_REPO" "$file" "$pattern" <<'PY'
+import re
+import sys
+from pathlib import Path
+root, rel, pattern = sys.argv[1:]
+path = Path(root) / rel
+if not path.exists():
+    sys.exit(1)
+text = path.read_text(errors="replace")
+sys.exit(0 if re.search(pattern, text, re.MULTILINE | re.DOTALL) else 1)
+PY
+}
+
+run_search() {
+  local query="$1" mode="$2" limit="$3" outfile="$4"
+  shift 4
+  "$RNA_BIN" search "$query" \
+    --repo "$RNA_REPO" \
+    --search-mode "$mode" \
+    --limit "$limit" \
+    --compact \
+    "$@" >"$outfile" 2>&1
+}
+
+contains_in_section() {
+  local file="$1" section="$2" pattern="$3"
+  python3 - "$file" "$section" "$pattern" <<'PY'
+import re
+import sys
+from pathlib import Path
+path, section, pattern = sys.argv[1:]
+text = Path(path).read_text(errors="replace")
+start = text.find(f"### {section}")
+if start == -1:
+    sys.exit(1)
+next_section = text.find("\n### ", start + 1)
+chunk = text[start:] if next_section == -1 else text[start:next_section]
+sys.exit(0 if re.search(pattern, chunk, re.MULTILINE | re.IGNORECASE) else 1)
+PY
+}
+
+stage_for() {
+  local source_ok="$1" default_ok="$2" wide_ok="$3" filtered_ok="$4"
+  if [ "$default_ok" = "yes" ]; then
+    echo "pass"
+  elif [ "$wide_ok" = "yes" ]; then
+    echo "ranking/filtering"
+  elif [ "$filtered_ok" = "yes" ]; then
+    echo "wide-net/query-matching"
+  elif [ "$source_ok" = "yes" ]; then
+    echo "indexing/candidate-pool"
+  else
+    echo "corpus/source-gap"
+  fi
+}
+
+record_fixture() {
+  local id="$1" query="$2" section="$3" expected_regex="$4" source_file="$5" source_regex="$6" filtered_query="$7" note="$8"
+  shift 8
+
+  local default_out="$TMP_DIR/${id}.default.out"
+  local keyword_out="$TMP_DIR/${id}.keyword.out"
+  local semantic_out="$TMP_DIR/${id}.semantic.out"
+  local filtered_out="$TMP_DIR/${id}.filtered.out"
+
+  local source_ok="no"
+  if have_source "$source_file" "$source_regex"; then
+    source_ok="yes"
+  fi
+
+  # Default approximates MCP hybrid retrieval. Reranking is opt-in here because
+  # first-run cross-encoder setup can dominate this diagnostic.
+  if [ "$RNA_RECALL_RERANK" = "true" ]; then
+    run_search "$query" hybrid 10 "$default_out" --rerank "$@"
+  else
+    run_search "$query" hybrid 10 "$default_out" "$@"
+  fi
+  # Wide net is mode-specific. If neither keyword nor semantic sees the fact,
+  # rank/fusion cannot recover it. Semantic probing is opt-in because it can
+  # dominate wall-clock time when the benchmark's immediate target is exact/code recall.
+  run_search "$query" keyword 100 "$keyword_out" "$@"
+  if [ "$RNA_RECALL_SEMANTIC" = "true" ]; then
+    run_search "$query" semantic 100 "$semantic_out" "$@"
+  else
+    printf 'semantic probe skipped; set RNA_RECALL_SEMANTIC=true to enable\n' >"$semantic_out"
+  fi
+  # Filtered/control: exact atom or narrower query. If this succeeds while wide
+  # fails, the corpus has a fact but query matching is too brittle.
+  run_search "$filtered_query" keyword 100 "$filtered_out" "$@"
+
+  local default_ok="no" keyword_ok="no" semantic_ok="no" filtered_ok="no"
+  if contains_in_section "$default_out" "$section" "$expected_regex"; then default_ok="yes"; fi
+  if contains_in_section "$keyword_out" "$section" "$expected_regex"; then keyword_ok="yes"; fi
+  if [ "$RNA_RECALL_SEMANTIC" = "true" ] && contains_in_section "$semantic_out" "$section" "$expected_regex"; then semantic_ok="yes"; elif [ "$RNA_RECALL_SEMANTIC" != "true" ]; then semantic_ok="skipped"; fi
+  if contains_in_section "$filtered_out" "$section" "$expected_regex"; then filtered_ok="yes"; fi
+
+  local stage wide_ok
+  if [ "$keyword_ok" = "yes" ] || [ "$semantic_ok" = "yes" ]; then
+    wide_ok="yes"
+  else
+    wide_ok="no"
+  fi
+  stage=$(stage_for "$source_ok" "$default_ok" "$wide_ok" "$filtered_ok")
+
+  printf '| `%s` | `%s` | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+    "$id" "$query" "$section" "$source_ok" "$default_ok" "$keyword_ok" "$semantic_ok" "$filtered_ok" "$stage" "$note"
+
+  pass_count=$((pass_count + 1))
+}
+
+record_corpus_gap() {
+  local id="$1" query="$2" source_file="$3" source_regex="$4" note="$5"
+  local source_ok="no"
+  if have_source "$source_file" "$source_regex"; then
+    source_ok="yes"
+  fi
+  local stage="corpus/source-gap"
+  if [ "$source_ok" = "yes" ]; then
+    stage="needs-search-probe"
+  fi
+  printf '| `%s` | `%s` | n/a | %s | n/a | n/a | n/a | n/a | %s | %s |\n' \
+    "$id" "$query" "$source_ok" "$stage" "$note"
+  pass_count=$((pass_count + 1))
+}
+
+if ! command -v "$RNA_BIN" >/dev/null 2>&1; then
+  echo "RNA binary not found: $RNA_BIN" >&2
+  exit 127
+fi
+
+if [ ! -d "$RNA_REPO" ]; then
+  echo "Repo path not found: $RNA_REPO" >&2
+  exit 2
+fi
+
+cat <<'MD'
+# Search recall fixture diagnosis
+
+| Fixture | Query | Expected section | Source fact exists | Default top-10 | Keyword top-100 | Semantic top-100 | Filtered/control | Stage | Note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+MD
+
+record_fixture \
+  "exact-parser-package" \
+  "tree-sitter-rust" \
+  "Code symbols" \
+  "tree-sitter-rust|Cargo\.toml" \
+  "Cargo.toml" \
+  "tree-sitter-rust" \
+  "tree-sitter-rust" \
+  "Exact dependency lookup should be a regression guard."
+
+record_fixture \
+  "multi-parser-packages" \
+  "tree-sitter-rust tree-sitter-python tree-sitter-typescript tree-sitter-javascript tree-sitter-go" \
+  "Code symbols" \
+  "tree-sitter-rust|tree-sitter-python|tree-sitter-typescript|tree-sitter-javascript|tree-sitter-go" \
+  "Cargo.toml" \
+  "tree-sitter-rust.*tree-sitter-python.*tree-sitter-typescript|tree-sitter-python.*tree-sitter-rust" \
+  "tree-sitter-rust" \
+  "If wide succeeds but default misses, tune ranking/fusion only after candidate-pool proof."
+
+record_fixture \
+  "langconfig-compound" \
+  "LangConfig language parser tree_sitter extractor suffixes" \
+  "Code symbols" \
+  "LangConfig|configs\.rs|generic\.rs" \
+  "src/extract/generic.rs" \
+  "struct LangConfig" \
+  "LangConfig" \
+  "Compound capability-style query should retrieve config facts." \
+  --file src/extract --language rust
+
+record_fixture \
+  "parser-registration-expression" \
+  "tree_sitter_python::LANGUAGE" \
+  "Code symbols" \
+  "tree_sitter_python|LANGUAGE|configs\.rs|python\.rs" \
+  "src/extract/configs.rs" \
+  "tree_sitter_python::LANGUAGE" \
+  "tree_sitter_python" \
+  "Expression-level parser registration or usage must enter the candidate pool before ranking can help." \
+  --file src/extract --language rust
+
+record_fixture \
+  "lsp-vs-treesitter-doc" \
+  "what does LSP add beyond tree-sitter" \
+  "Markdown" \
+  "What LSP Adds Beyond tree-sitter|docs/lsp-enrichment\.md|LSP" \
+  "docs/lsp-enrichment.md" \
+  "What LSP Adds Beyond tree-sitter" \
+  "What LSP Adds Beyond tree-sitter" \
+  "Doc fact exists; classify whether default ranking surfaces it."
+
+record_fixture \
+  "manual-parser-policy" \
+  "do we need to manually add parsers" \
+  "Markdown" \
+  "Tree-sitter parser support policy|upstream tree-sitter parser list|candidate catalog|packaged" \
+  "docs/extractors.md" \
+  "upstream tree-sitter parser list.*candidate catalog|packaged.*registered.*configured.*tested" \
+  "Tree-sitter parser support policy" \
+  "Policy fact should be discoverable through docs once the local source exists."
+
+cat <<MD
+
+Summary: ${pass_count} fixture(s) evaluated, ${fail_count} diagnostic error(s).
+MD
+
+exit "$fail_count"

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -539,8 +539,8 @@ pub struct SearchResult {
 
 impl SearchResult {
     pub fn to_markdown(&self) -> String {
-        let snippet = if self.body.len() > 200 {
-            format!("{}...", &self.body[..200])
+        let snippet = if self.body.chars().count() > 200 {
+            format!("{}...", truncate_chars(&self.body, 200))
         } else {
             self.body.clone()
         };
@@ -1753,11 +1753,27 @@ impl EmbeddingIndex {
 mod tests {
     use super::{
         BACKOFF_THRESHOLD, BATCH_CEILING, BATCH_FLOOR, BATCH_YIELD_MS, CODE_EMBED_CHAR_BUDGET,
-        EmbeddingIndex, SearchFilters, build_artifact_embedding_text, build_code_embedding_text,
-        node_embedding_kind, node_embedding_text, node_embedding_title, node_scalar_filters,
-        truncate_chars,
+        EmbeddingIndex, SearchFilters, SearchResult, build_artifact_embedding_text,
+        build_code_embedding_text, node_embedding_kind, node_embedding_text, node_embedding_title,
+        node_scalar_filters, truncate_chars,
     };
     use std::collections::BTreeMap;
+
+    #[test]
+    fn search_result_markdown_truncates_on_char_boundary() {
+        let result = SearchResult {
+            id: "abc123".into(),
+            kind: "commit".into(),
+            title: "unicode body".into(),
+            body: format!("{}—tail", "a".repeat(199)),
+            score: 1.0,
+        };
+
+        let markdown = result.to_markdown();
+
+        assert!(markdown.contains("..."));
+        assert!(markdown.contains("Hash: `abc123`"));
+    }
 
     // ── Adversarial: has_table ──────────────────────────────────────
 

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -387,11 +387,71 @@ pub struct ScoredMarkdownChunk<'a> {
 /// that merely contains the term in a deep subsection.
 ///
 /// Returns results sorted by descending score.
+fn markdown_query_terms(query: &str) -> Vec<String> {
+    query
+        .split(|c: char| !(c.is_alphanumeric() || c == '_'))
+        .filter_map(|raw| {
+            let mut term = raw.trim().to_lowercase();
+            if term.len() < 3 {
+                return None;
+            }
+            if matches!(
+                term.as_str(),
+                "add"
+                    | "and"
+                    | "are"
+                    | "but"
+                    | "can"
+                    | "does"
+                    | "for"
+                    | "from"
+                    | "have"
+                    | "how"
+                    | "need"
+                    | "the"
+                    | "this"
+                    | "what"
+                    | "when"
+                    | "where"
+                    | "which"
+                    | "why"
+                    | "with"
+            ) {
+                return None;
+            }
+            if term.ends_with('s') && term.len() > 4 {
+                term.pop();
+            }
+            if term.ends_with("ed") && term.len() > 5 {
+                term.truncate(term.len() - 2);
+            }
+            Some(term)
+        })
+        .collect()
+}
+
+fn text_matches_markdown_term(text: &str, term: &str) -> bool {
+    if text.contains(term) {
+        return true;
+    }
+    let plural = format!("{}s", term);
+    text.contains(&plural)
+}
+
+fn markdown_term_match_count(text: &str, terms: &[String]) -> usize {
+    terms
+        .iter()
+        .filter(|term| text_matches_markdown_term(text, term))
+        .count()
+}
+
 pub fn search_chunks_ranked<'a>(
     chunks: &'a [MarkdownChunk],
     query: &str,
 ) -> Vec<ScoredMarkdownChunk<'a>> {
     let query_lower = query.to_lowercase();
+    let terms = markdown_query_terms(query);
+    let allow_term_fallback = !query.is_empty() && terms.len() >= 3;
 
     let mut scored: Vec<ScoredMarkdownChunk<'a>> = chunks
         .iter()
@@ -402,8 +462,12 @@ pub fn search_chunks_ranked<'a>(
             let heading_match = chunk.heading_hierarchy.iter().any(|h| {
                 let text = h.trim_start_matches('#').trim().to_lowercase();
                 text.contains(&query_lower)
+                    || (allow_term_fallback
+                        && markdown_term_match_count(&text, &terms) == terms.len())
             });
-            let content_match = content_lower.contains(&query_lower);
+            let content_match = content_lower.contains(&query_lower)
+                || (allow_term_fallback
+                    && markdown_term_match_count(&content_lower, &terms) == terms.len());
 
             if !heading_match && !content_match {
                 return None;
@@ -416,6 +480,8 @@ pub fn search_chunks_ranked<'a>(
                 let exact_heading = chunk.heading_hierarchy.iter().any(|h| {
                     let text = h.trim_start_matches('#').trim().to_lowercase();
                     text == query_lower
+                        || (allow_term_fallback
+                            && markdown_term_match_count(&text, &terms) == terms.len())
                 });
                 if exact_heading {
                     score += 1.0; // Section is *about* this term
@@ -436,16 +502,24 @@ pub fn search_chunks_ranked<'a>(
             }
 
             // Tier 3: Code span match -- cross-reference to a code symbol
-            if chunk
-                .code_spans
-                .iter()
-                .any(|s| s.to_lowercase().contains(&query_lower))
-            {
+            if chunk.code_spans.iter().any(|s| {
+                let s = s.to_lowercase();
+                s.contains(&query_lower)
+                    || (allow_term_fallback && markdown_term_match_count(&s, &terms) == terms.len())
+            }) {
                 score += 0.15; // strong signal for developer queries
             }
 
             // Tier 4: Match density -- capped so long docs don't dominate
-            let occurrence_count = content_lower.matches(&query_lower).count();
+            let occurrence_count = if query_lower.is_empty() {
+                0
+            } else if content_lower.contains(&query_lower) {
+                content_lower.matches(&query_lower).count()
+            } else if allow_term_fallback {
+                markdown_term_match_count(&content_lower, &terms)
+            } else {
+                0
+            };
             let density_bonus = (occurrence_count as f32 * 0.02).min(0.10);
             score += density_bonus;
 
@@ -1415,6 +1489,31 @@ mod tests {
             "Multi-word query should be exact substring match"
         );
         assert_eq!(results[0].chunk.file_path, PathBuf::from("b.md"));
+    }
+
+    #[test]
+    fn test_ranked_stopword_and_inflection_query_matches_heading_terms() {
+        let chunks = vec![MarkdownChunk {
+            file_path: PathBuf::from("docs/lsp-enrichment.md"),
+            heading_hierarchy: vec!["# What LSP Adds Beyond tree-sitter".to_string()],
+            heading_level: 1,
+            heading_text: String::new(),
+            parent_heading: None,
+            is_frontmatter: false,
+            content: "LSP adds call hierarchy and cross-file references.".to_string(),
+            byte_offset: 0,
+            byte_len: 55,
+            code_spans: vec![],
+            links: vec![],
+        }];
+
+        let results = search_chunks_ranked(&chunks, "what does LSP add beyond tree-sitter");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].chunk.file_path,
+            PathBuf::from("docs/lsp-enrichment.md")
+        );
     }
 
     /// Heading-contains vs exact: "Config" heading should score higher than

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -480,8 +480,6 @@ pub fn search_chunks_ranked<'a>(
                 let exact_heading = chunk.heading_hierarchy.iter().any(|h| {
                     let text = h.trim_start_matches('#').trim().to_lowercase();
                     text == query_lower
-                        || (allow_term_fallback
-                            && markdown_term_match_count(&text, &terms) == terms.len())
                 });
                 if exact_heading {
                     score += 1.0; // Section is *about* this term

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -7,6 +7,7 @@
 use std::collections::HashSet;
 
 use crate::embed::{SearchFilters, SearchMode, SearchOutcome};
+use crate::graph::index::GraphIndex;
 use crate::graph::{EdgeKind, ExtractionSource, Node, NodeKind};
 use crate::ranking;
 use crate::server::handlers::parse_search_mode;
@@ -539,16 +540,13 @@ async fn flat_code_symbol_search<'a>(
         Vec::new()
     };
 
-    // Supplement or fallback: name/signature matching.
+    // Supplement or fallback: text matching over name/signature/body/metadata.
     //
-    // When embed search was used, exact name matches that the embedding missed
-    // are appended after the embed-ranked results. This ensures functions are
-    // always findable by name regardless of embedding quality or index freshness.
-    // (#275: without this, `search("embed_texts")` returned zero code results
-    // because the embedding didn't surface the function and no fallback fired.)
-    //
-    // When embed search was NOT used (unavailable, not ready, or empty query),
-    // name/signature matching is the sole source of results.
+    // The wide-net stage must retrieve known facts before ranking can help.
+    // Exact name/signature matches still dominate, but compound capability-style
+    // queries also match individual high-signal terms against the node body and
+    // metadata so constants such as `tree_sitter_python::LANGUAGE` are searchable.
+    let text_terms = query_terms(query_str);
     if !used_embed {
         matches = graph_state
             .nodes
@@ -558,11 +556,9 @@ async fn flat_code_symbol_search<'a>(
                     return false;
                 }
                 if !query_lower.is_empty() && path_name.is_none() {
-                    // Plain query: check name/signature directly here for early exit.
+                    // Plain query: cast a wider lexical net over name, signature, body, and metadata.
                     // Path/name queries are handled inside node_passes_filters.
-                    let name_match = n.id.name.to_lowercase().contains(&query_lower)
-                        || n.signature.to_lowercase().contains(&query_lower);
-                    if !name_match {
+                    if !node_matches_text_query(n, &query_lower, &text_terms) {
                         return false;
                     }
                 }
@@ -587,11 +583,9 @@ async fn flat_code_symbol_search<'a>(
                     return false;
                 }
                 if path_name.is_none() {
-                    // Plain query: check name/signature for early exit.
-                    // Path/name queries are handled inside node_passes_filters.
-                    let name_match = n.id.name.to_lowercase().contains(&query_lower)
-                        || n.signature.to_lowercase().contains(&query_lower);
-                    if !name_match {
+                    // Plain query: cast the same lexical net for supplements so exact/code-expression
+                    // matches survive embedding misses.
+                    if !node_matches_text_query(n, &query_lower, &text_terms) {
                         return false;
                     }
                 }
@@ -599,11 +593,16 @@ async fn flat_code_symbol_search<'a>(
             })
             .collect();
         if !name_supplements.is_empty() {
-            // Sort supplements by name-match quality, then cap to budget.
+            // Sort supplements by text-match quality, then cap to budget.
             // For path/name queries use only the name part for ranking.
             let sort_key = name_filter_lower.as_deref().unwrap_or(&query_lower);
             let mut sorted_supplements = name_supplements;
-            ranking::sort_symbol_matches(&mut sorted_supplements, sort_key, &graph_state.index);
+            sort_symbol_text_matches(
+                &mut sorted_supplements,
+                sort_key,
+                &text_terms,
+                &graph_state.index,
+            );
             sorted_supplements.truncate(supplement_budget);
             // Evict tail embed results to make room so supplements survive
             // the final truncate(limit).
@@ -654,11 +653,11 @@ async fn flat_code_symbol_search<'a>(
             }
         });
     } else if !used_embed {
-        // Only apply name-match ranking for fallback results; embed results
+        // Only apply text-match ranking for fallback results; embed results
         // are already ranked by the embedding index.
         // For path/name queries use only the name part for ranking.
         let sort_key = name_filter_lower.as_deref().unwrap_or(&query_lower);
-        ranking::sort_symbol_matches(&mut matches, sort_key, &graph_state.index);
+        sort_symbol_text_matches(&mut matches, sort_key, &text_terms, &graph_state.index);
     }
 
     // Cross-encoder reranking: re-score the top candidates using a cross-encoder
@@ -1690,6 +1689,141 @@ fn subsystem_matches(node_subsystem: &str, filter: &str) -> bool {
     false
 }
 
+fn query_terms(query: &str) -> Vec<String> {
+    query
+        .split(|c: char| !(c.is_alphanumeric() || c == '_'))
+        .filter_map(|raw| {
+            let term = raw.trim().to_lowercase();
+            if term.len() < 3 {
+                return None;
+            }
+            if matches!(
+                term.as_str(),
+                "add"
+                    | "and"
+                    | "are"
+                    | "but"
+                    | "can"
+                    | "does"
+                    | "for"
+                    | "from"
+                    | "have"
+                    | "how"
+                    | "need"
+                    | "registered"
+                    | "the"
+                    | "this"
+                    | "what"
+                    | "when"
+                    | "where"
+                    | "which"
+                    | "why"
+                    | "with"
+            ) {
+                return None;
+            }
+            Some(term)
+        })
+        .collect()
+}
+
+fn node_search_text_lower(n: &Node) -> String {
+    let mut text = format!(
+        "{} {} {} {} {}",
+        n.id.name,
+        n.signature,
+        n.body,
+        n.id.file.display(),
+        n.language
+    )
+    .to_lowercase();
+    for (key, value) in &n.metadata {
+        text.push(' ');
+        text.push_str(&key.to_lowercase());
+        text.push(' ');
+        text.push_str(&value.to_lowercase());
+    }
+    text
+}
+
+fn symbol_text_match_score(n: &Node, query_lower: &str, terms: &[String]) -> usize {
+    let name = n.id.name.to_lowercase();
+    let signature = n.signature.to_lowercase();
+    if !query_lower.is_empty() {
+        if name == query_lower {
+            return 10_000;
+        }
+        if name.contains(query_lower) {
+            return 8_000;
+        }
+        if signature.contains(query_lower) {
+            return 6_000;
+        }
+        let search_text = node_search_text_lower(n);
+        if search_text.contains(query_lower) {
+            return 7_000;
+        }
+    }
+
+    if terms.is_empty() {
+        return 0;
+    }
+
+    let search_text = node_search_text_lower(n);
+    let matched_term_score: usize = terms
+        .iter()
+        .filter(|term| search_text.contains(term.as_str()))
+        .map(|term| {
+            if term.contains('_') || term.len() >= 12 {
+                2_000
+            } else {
+                100
+            }
+        })
+        .sum();
+    if matched_term_score == 0 {
+        return 0;
+    }
+
+    let name_hits = terms
+        .iter()
+        .filter(|term| name.contains(term.as_str()))
+        .count();
+    let signature_hits = terms
+        .iter()
+        .filter(|term| signature.contains(term.as_str()))
+        .count();
+
+    matched_term_score + name_hits * 250 + signature_hits * 10
+}
+
+fn node_matches_text_query(n: &Node, query_lower: &str, terms: &[String]) -> bool {
+    symbol_text_match_score(n, query_lower, terms) > 0
+}
+
+fn sort_symbol_text_matches(
+    matches: &mut [&Node],
+    query_lower: &str,
+    terms: &[String],
+    index: &GraphIndex,
+) {
+    matches.sort_by(|a, b| {
+        let score_cmp = symbol_text_match_score(b, query_lower, terms)
+            .cmp(&symbol_text_match_score(a, query_lower, terms));
+        if score_cmp != std::cmp::Ordering::Equal {
+            return score_cmp;
+        }
+
+        let mut pair = [*a, *b];
+        ranking::sort_symbol_matches(&mut pair, query_lower, index);
+        if std::ptr::eq(pair[0], *a) {
+            std::cmp::Ordering::Less
+        } else {
+            std::cmp::Ordering::Greater
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2231,6 +2365,71 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id.name, "process");
+    }
+
+    #[tokio::test]
+    async fn test_flat_search_fallback_body_matching_for_parser_registration() {
+        let mut node = make_node("PYTHON_CONFIG", NodeKind::Const, "src/extract/configs.rs");
+        node.body = r#"pub static PYTHON_CONFIG: LangConfig = LangConfig {
+    language_fn: || tree_sitter_python::LANGUAGE.into(),
+    language_name: "python",
+};"#
+        .to_string();
+        let gs = make_graph_state(vec![node]);
+        let repo_root = PathBuf::from("/tmp/test");
+        let ctx = make_search_context(&gs, &repo_root);
+        let params = SearchParams {
+            query: Some("where is tree_sitter_python::LANGUAGE registered".into()),
+            file: Some("src/extract".into()),
+            language: Some("rust".into()),
+            ..Default::default()
+        };
+
+        let results = flat_code_symbol_search(
+            "where is tree_sitter_python::LANGUAGE registered",
+            SearchMode::Keyword,
+            10,
+            &params,
+            &gs,
+            &ctx,
+            false,
+            false,
+        )
+        .await;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id.name, "PYTHON_CONFIG");
+    }
+
+    #[tokio::test]
+    async fn test_flat_search_fallback_compound_query_matches_config_symbol() {
+        let mut lang_config = make_node("LangConfig", NodeKind::Struct, "src/extract/generic.rs");
+        lang_config.body = "pub struct LangConfig { pub language_fn: fn() -> tree_sitter::Language, pub extensions: &'static [&'static str] }".to_string();
+        let unrelated = make_node("ExtractorRegistry", NodeKind::Struct, "src/extract/mod.rs");
+        let gs = make_graph_state(vec![unrelated, lang_config]);
+        let repo_root = PathBuf::from("/tmp/test");
+        let ctx = make_search_context(&gs, &repo_root);
+        let params = SearchParams {
+            query: Some("LangConfig language parser tree_sitter extractor suffixes".into()),
+            file: Some("src/extract".into()),
+            language: Some("rust".into()),
+            ..Default::default()
+        };
+
+        let results = flat_code_symbol_search(
+            "LangConfig language parser tree_sitter extractor suffixes",
+            SearchMode::Keyword,
+            10,
+            &params,
+            &gs,
+            &ctx,
+            false,
+            false,
+        )
+        .await;
+
+        assert!(!results.is_empty());
+        assert_eq!(results[0].id.name, "LangConfig");
     }
 
     /// Kind filter works with fallback path.

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -4,7 +4,7 @@
 //! `search_flat`, `search_traversal`, or `search_batch` depending on the
 //! parameters supplied by the caller.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::embed::{SearchFilters, SearchMode, SearchOutcome};
 use crate::graph::index::GraphIndex;
@@ -540,12 +540,12 @@ async fn flat_code_symbol_search<'a>(
         Vec::new()
     };
 
-    // Supplement or fallback: text matching over name/signature/body/metadata.
+    // Supplement or fallback: structured text matching over symbol declarations.
     //
     // The wide-net stage must retrieve known facts before ranking can help.
     // Exact name/signature matches still dominate, but compound capability-style
-    // queries also match individual high-signal terms against the node body and
-    // metadata so constants such as `tree_sitter_python::LANGUAGE` are searchable.
+    // queries also match high-signal terms against non-function declaration text
+    // and extraction metadata. Function bodies stay out of generic symbol search.
     let text_terms = query_terms(query_str);
     if !used_embed {
         matches = graph_state
@@ -1729,14 +1729,32 @@ fn query_terms(query: &str) -> Vec<String> {
 
 fn node_search_text_lower(n: &Node) -> String {
     let mut text = format!(
-        "{} {} {} {} {}",
+        "{} {} {} {}",
         n.id.name,
         n.signature,
-        n.body,
         n.id.file.display(),
         n.language
     )
     .to_lowercase();
+    if matches!(
+        n.id.kind,
+        NodeKind::Struct
+            | NodeKind::Trait
+            | NodeKind::Enum
+            | NodeKind::TypeAlias
+            | NodeKind::Const
+            | NodeKind::ProtoMessage
+            | NodeKind::SqlTable
+            | NodeKind::ApiEndpoint
+            | NodeKind::Macro
+            | NodeKind::Field
+            | NodeKind::EnumVariant
+            | NodeKind::Other(_)
+    ) && !n.body.is_empty()
+    {
+        text.push(' ');
+        text.push_str(&n.body.to_lowercase());
+    }
     for (key, value) in &n.metadata {
         text.push(' ');
         text.push_str(&key.to_lowercase());
@@ -1807,9 +1825,27 @@ fn sort_symbol_text_matches(
     terms: &[String],
     index: &GraphIndex,
 ) {
+    let scores: HashMap<*const Node, usize> = matches
+        .iter()
+        .map(|node| {
+            (
+                *node as *const Node,
+                symbol_text_match_score(node, query_lower, terms),
+            )
+        })
+        .collect();
+
     matches.sort_by(|a, b| {
-        let score_cmp = symbol_text_match_score(b, query_lower, terms)
-            .cmp(&symbol_text_match_score(a, query_lower, terms));
+        let score_cmp = scores
+            .get(&(*b as *const Node))
+            .copied()
+            .unwrap_or_default()
+            .cmp(
+                &scores
+                    .get(&(*a as *const Node))
+                    .copied()
+                    .unwrap_or_default(),
+            );
         if score_cmp != std::cmp::Ordering::Equal {
             return score_cmp;
         }


### PR DESCRIPTION
Closes #687.

## Summary
- widen flat code-symbol fallback to search name/signature/body/metadata for compound capability and parser-registration queries
- add markdown stopword/inflection fallback for natural LSP/tree-sitter questions
- document Tree-sitter parser support policy so manual parser questions have a local source fact
- add executable recall fixture matrix for the reported MCP search failures

## Verification
- `cargo test --lib fallback_ -- --nocapture`
- `cargo test --lib test_ranked_ -- --nocapture`
- `cargo check --lib`
- `cargo build --bin repo-native-alignment`
- `RNA_BIN=target/debug/repo-native-alignment scripts/search-recall-fixtures.sh /Users/muness1/src/open-horizon-labs/repo-native-alignment`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic script to probe search recall across pipeline stages and produce per-fixture reports.

* **Documentation**
  * Added a tree-sitter parser support policy and a friction-log entry documenting recall investigations and follow-ups.

* **Refactor**
  * Improved fallback search ranking with stopword-aware term extraction and broader matching for compound queries.

* **Bug Fixes**
  * Fixed snippet truncation to avoid UTF-8 boundary errors and improved ranking test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->