### PR TITLE
Fix P0 release blockers for scan and release install

### DIFF
--- a/.oh/friction-logs/2026-05-23-p0-release-blockers.md
+++ b/.oh/friction-logs/2026-05-23-p0-release-blockers.md
@@ -1,0 +1,12 @@
+---
+id: 2026-05-23-p0-release-blockers
+outcome: context-assembly
+severity: mixed
+---
+
+# P0 release blockers friction
+
+| Time | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-05-23 | RNA MCP `search(query="Fix Pass 1 scheduling dead-code readiness delivery #677 queue changed scope", include_artifacts=true)` | minor | Search timed out after 60s while investigating #677 prior art. | Had to rely on GitHub issue/PR context and local files for the #677 split decision instead of a clean RNA artifact query. | Keep #677 as a dedicated control-plane issue; avoid overloading the scan/release blocker PR with incomplete LSP architecture work. |
+| 2026-05-23 | `cargo fmt` | minor | Running formatter after a surgical Rust change reformatted unrelated files that were not part of the task. | Created noisy working-tree drift that had to be reverted before shipping. | Use targeted manual formatting or `rustfmt --check` first on this repo when minimizing diffs is required. |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5375,6 +5375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5382,6 +5391,7 @@ checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ regex = "1"
 pulldown-cmark = "0.13"
 
 # Git integration (change detection, history)
-git2 = "0.20"
+git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 
 # Code parsing (symbol extraction)
 tree-sitter = "0.26"

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ claude plugin install rna-mcp
 /rna-mcp:setup
 ```
 
-Setup detects your platform (optimized binary for M2+ chips with bf16/i8mm), installs a release artifact to `~/.cargo/bin/`, configures `.mcp.json`, and updates AGENTS.md with tool guidance.
+Setup detects your platform (optimized binary for M2+ chips with bf16/i8mm CPU instructions), installs a release artifact to `~/.cargo/bin/`, configures `.mcp.json`, and updates AGENTS.md with tool guidance.
 
 **Download a prebuilt binary** (manual):
 
@@ -96,6 +96,8 @@ curl -L https://github.com/open-horizon-labs/repo-native-alignment/releases/late
 ```
 
 Release and user-facing verification should use successful GitHub Actions/release artifacts, not a local source build.
+
+Prebuilt release binaries are intentionally built without local embedding/reranking support. They support extraction, graph traversal, lexical search, LSP call/reference enrichment, repo maps, and MCP delivery. Semantic search and cross-encoder reranking require a development/source build with embedding features (for Apple Silicon Metal: `cargo install --locked --path . --features metal` from a checked-out repo). Do not use source builds as release verification; release verification must install the successful GitHub Actions/release artifact for the target commit.
 
 **Build from source for development** (requires [Rust toolchain](https://rustup.rs)):
 
@@ -131,7 +133,7 @@ For HTTP transport: `repo-native-alignment --repo . --transport http --port 8382
 repo-native-alignment scan --repo . --full
 ```
 
-Runs the complete pipeline: scan → extract → embed → LSP enrich → graph. Without `--full`, LSP analysis is skipped — subsystem detection and "what calls this" queries are degraded until call/reference enrichment completes. Subsequent scans are incremental (~0.1s on no-change runs).
+Runs the complete release-binary pipeline: scan → extract → LSP enrich → graph. Without `--full`, LSP analysis is skipped — subsystem detection and "what calls this" queries are degraded until call/reference enrichment completes. Release binaries do not include embedding/reranking support; builds compiled with `--features embeddings` or `--features metal` also run embedding enrichment. Subsequent scans are incremental (~0.1s on no-change runs).
 OperationReport output tells you which capabilities are ready, which query classes are degraded, and which `enrich` command can close any remaining gap.
 
 **Why run this before starting the MCP server?** The MCP server pre-warms the graph automatically at startup, but building from scratch can take 10-30s on large repos. Running `scan` first populates `.oh/.cache/lance/` so the server loads the cached graph in seconds.

--- a/plugin/commands/setup.md
+++ b/plugin/commands/setup.md
@@ -45,6 +45,8 @@ cargo install --locked --git https://github.com/open-horizon-labs/repo-native-al
 
 If `~/.cargo/bin` is not on PATH (no Rust toolchain installed), tell the user to add it: `export PATH="$HOME/.cargo/bin:$PATH"`
 
+Release artifacts are intentionally built without local embedding/reranking support. They support extraction, graph traversal, lexical search, LSP call/reference enrichment, repo maps, and MCP delivery. Semantic search and cross-encoder reranking require a development/source build with embedding features (Apple Silicon Metal: `cargo install --locked --path . --features metal` from a checked-out repo); source builds are not a substitute for release verification from successful CI/release artifacts.
+
 ## Step 3: Add MCP server to Claude Code
 
 RNA is a per-project MCP server (it indexes the repo it's pointed at), so add it with project scope:
@@ -63,7 +65,7 @@ Run a one-time scan to build the code index before the MCP server starts. This a
 repo-native-alignment scan --repo . --full
 ```
 
-This builds the full pipeline (scan, extract, embed, LSP enrich, graph) and caches results in `.oh/.cache/lance/`. The MCP server reuses this cache on startup -- if no files changed, graph loads in seconds with zero re-extraction. Subsequent scans are incremental.
+This builds the release-binary pipeline (scan, extract, LSP enrich, graph) and caches results in `.oh/.cache/lance/`. Builds compiled with `--features embeddings` or `--features metal` also run embedding enrichment. The MCP server reuses this cache on startup -- if no files changed, graph loads in seconds with zero re-extraction. Subsequent scans are incremental.
 
 Without this step, the MCP server pre-warms the graph automatically at startup, but the first tool call may need to wait for that to complete. Pre-building ensures instant readiness.
 

--- a/plugin/skills/setup/SKILL.md
+++ b/plugin/skills/setup/SKILL.md
@@ -50,6 +50,8 @@ cargo install --locked --git https://github.com/open-horizon-labs/repo-native-al
 
 If `~/.cargo/bin` is not on PATH (no Rust toolchain installed), tell the user to add it: `export PATH="$HOME/.cargo/bin:$PATH"`
 
+Release artifacts are intentionally built without local embedding/reranking support. They support extraction, graph traversal, lexical search, LSP call/reference enrichment, repo maps, and MCP delivery. Semantic search and cross-encoder reranking require a development/source build with embedding features (Apple Silicon Metal: `cargo install --locked --path . --features metal` from a checked-out repo); source builds are not a substitute for release verification from successful CI/release artifacts.
+
 ## Step 3: Configure the MCP server
 
 RNA is a per-project MCP server (it indexes the repo it's pointed at).
@@ -83,7 +85,7 @@ Run a full scan to build the code index before the MCP server starts. This avoid
 repo-native-alignment scan --repo . --full
 ```
 
-This builds the full pipeline (scan, extract, embed, LSP enrich, graph) and caches results in `.oh/.cache/lance/`. The MCP server reuses this cache on startup -- if no files changed, graph loads in seconds with zero re-extraction. Subsequent scans are incremental.
+This builds the release-binary pipeline (scan, extract, LSP enrich, graph) and caches results in `.oh/.cache/lance/`. Builds compiled with `--features embeddings` or `--features metal` also run embedding enrichment. The MCP server reuses this cache on startup -- if no files changed, graph loads in seconds with zero re-extraction. Subsequent scans are incremental.
 
 Without this step, the MCP server pre-warms the graph automatically at startup, but the first tool call may need to wait for that to complete. Pre-building ensures instant readiness.
 

--- a/src/extract/import_calls.rs
+++ b/src/extract/import_calls.rs
@@ -660,11 +660,10 @@ fn parse_es6_import_names(text: &str) -> Vec<String> {
     // Split named `{ … }` block from default import prefix.
     let (default_part, named_part) = if let Some(brace_start) = specifier.find('{') {
         let before = specifier[..brace_start].trim().trim_end_matches(',').trim();
-        let end = specifier
-            .rfind('}')
-            .map(|i| i + 1)
-            .unwrap_or(specifier.len());
-        let inner = &specifier[brace_start + 1..end - 1];
+        let Some(brace_end) = specifier[brace_start + 1..].find('}').map(|i| brace_start + 1 + i) else {
+            return Vec::new();
+        };
+        let inner = &specifier[brace_start + 1..brace_end];
         (before, Some(inner))
     } else {
         (specifier, None)
@@ -1083,6 +1082,24 @@ mod tests {
             names.is_empty(),
             "type-only import should return empty, got {:?}",
             names
+        );
+    }
+
+    #[test]
+    fn test_parse_es6_malformed_named_import_does_not_panic() {
+        let names = parse_imported_names("import { from './fresh-module'");
+        assert!(
+            names.is_empty(),
+            "malformed import should be skipped, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_es6_malformed_mixed_import_does_not_emit_default() {
+        let names = parse_imported_names("import Client, { from './fresh-module'");
+        assert!(
+            names.is_empty(),
+            "partially extracted import should be skipped, got {names:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #698.
Fixes #692.
Fixes #693.
Refs #677.

This PR keeps the P0 release-blocking fixes coherent and deliberately does **not** bundle a partial #677 control-plane rewrite.

## Changes

- Harden ES import parsing so malformed/partial named imports skip safely instead of panicking during `import_calls`.
- Add regression coverage for malformed named and malformed mixed imports while preserving valid ES import extraction.
- Vendor libgit2 and OpenSSL through `git2` features so macOS release binaries no longer link against Homebrew `libgit2`/`openssl` dylibs.
- Update README and setup docs to state the release artifact story: prebuilt binaries support graph/lexical/LSP/MCP capabilities, but not embedding/reranking; source/Metal builds are development paths, not release verification substitutes.
- Record dogfood/process friction from this oversight pass.

## #677 pipeline decision

#677 remains open by design. The immediate release-blocking Pass 1 stall/readiness failures were already addressed by #678/#679, but #677's remaining acceptance criteria require a broader queued, capability-scoped LSP control plane: durable work items, snapshots, partial coverage readiness, changed-file planning, and dead-code/review-readiness planners. That is not safe to complete as a sidecar in the scan panic/release artifact PR without producing a partial architecture. This PR references #677 and keeps the issue scoped for a dedicated pipeline pass.

## Verification

- `cargo test -p repo-native-alignment test_parse_es6 -- --nocapture` — 8 passed.
- `cargo check --lib --bins --tests` — passed.
- `git diff --check` — passed.
- `cargo build --no-default-features` — passed.
- `otool -L target/debug/repo-native-alignment` — verified no `/opt/homebrew/opt/libgit2` or `/opt/homebrew/opt/openssl` dylib linkage remains; only system libraries are linked.
- Real CLI delivery spot-check against a temporary TypeScript repo containing `import { from './fresh-module'`:
  - `target/debug/repo-native-alignment scan --repo "$TMP" --full --no-lsp --no-embed` completed and persisted LanceDB symbols.
  - `target/debug/repo-native-alignment stats --repo "$TMP"` loaded the persisted symbols table successfully.

## Remaining release verification

The linkage fix is locally observable with `otool`, but final shipped-user verification for #692 must install the successful GitHub Actions release artifact for this PR/commit before publication, per the repo guardrail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed import statements to prevent crashes

* **Documentation**
  * Clarified that release binaries exclude local embedding and reranking features
  * Added setup guidance for enabling semantic search through source builds
  * Updated pipeline documentation explaining when embedding enrichment runs
  * Enhanced platform-specific installation instructions, including Apple Silicon support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-horizon-labs/repo-native-alignment/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->