### PR TITLE
Fix scoped ignore handling and optional outcome smoke check

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -763,14 +763,14 @@ impl Scanner {
             }
         }
 
-        // ── Step 4: Detect deleted files ────────────────────────────
+        // ── Step 4: Detect deleted or newly-filtered files ───────────────
         let deleted_files: Vec<PathBuf> = self
             .state
             .file_mtimes
             .keys()
             .filter(|rel_path| {
                 let abs = self.repo_root.join(rel_path);
-                !abs.exists()
+                !abs.exists() || !new_file_mtimes.contains_key(*rel_path)
             })
             .cloned()
             .collect();
@@ -1630,6 +1630,39 @@ mod tests {
         assert_eq!(new_files, vec![PathBuf::from("src/index.ts")]);
         assert!(result.changed_files.is_empty());
         assert!(result.deleted_files.is_empty());
+    }
+
+    #[test]
+    fn test_scoped_scan_reports_previously_tracked_gitignored_files_as_deleted() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        git2::Repository::init(root).unwrap();
+        create_file(
+            root,
+            "app/src/index.ts",
+            "export function realCode() { return 1; }",
+        );
+        create_file(
+            root,
+            "app/bin/Debug/generated.ts",
+            "export function previouslyTracked() { return 2; }",
+        );
+
+        let mut scanner = Scanner::new(root.join("app")).unwrap();
+        let first = scanner.scan().unwrap();
+        assert!(first
+            .new_files
+            .contains(&PathBuf::from("bin/Debug/generated.ts")));
+
+        fs::write(root.join(".gitignore"), "bin/\n").unwrap();
+        let second = scanner.scan().unwrap();
+
+        assert!(second.new_files.is_empty());
+        assert!(second.changed_files.is_empty());
+        assert_eq!(
+            second.deleted_files,
+            vec![PathBuf::from("bin/Debug/generated.ts")]
+        );
     }
 
     #[test]

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -506,6 +506,11 @@ pub struct Scanner {
     custom_state_path: Option<PathBuf>,
 }
 
+struct GitIgnoreContext {
+    repo: git2::Repository,
+    workdir: PathBuf,
+}
+
 impl Scanner {
     /// Create a new scanner for the given root directory.
     /// Loads exclude config from `.oh/config.toml` if it exists,
@@ -568,6 +573,49 @@ impl Scanner {
         Ok(())
     }
 
+    fn git_ignore_context(&self) -> Option<GitIgnoreContext> {
+        let repo = match git2::Repository::discover(&self.repo_root) {
+            Ok(repo) => repo,
+            Err(err) => {
+                tracing::debug!(
+                    "Scanner: git ignore context unavailable for {}: {}",
+                    self.repo_root.display(),
+                    err
+                );
+                return None;
+            }
+        };
+        let workdir = match repo.workdir() {
+            Some(workdir) => workdir
+                .canonicalize()
+                .unwrap_or_else(|_| workdir.to_path_buf()),
+            None => {
+                tracing::debug!(
+                    "Scanner: git ignore context unavailable for {}: bare repository",
+                    self.repo_root.display()
+                );
+                return None;
+            }
+        };
+        Some(GitIgnoreContext { repo, workdir })
+    }
+
+    fn is_git_ignored(git_ignore: Option<&GitIgnoreContext>, path: &Path) -> bool {
+        let Some(git_ignore) = git_ignore else {
+            return false;
+        };
+        if let Ok(rel) = path.strip_prefix(&git_ignore.workdir) {
+            return git_ignore.repo.is_path_ignored(rel).unwrap_or(false);
+        }
+        let Ok(canonical_path) = path.canonicalize() else {
+            return false;
+        };
+        let Ok(rel) = canonical_path.strip_prefix(&git_ignore.workdir) else {
+            return false;
+        };
+        git_ignore.repo.is_path_ignored(rel).unwrap_or(false)
+    }
+
     /// Perform an incremental scan. Returns changed/new/deleted file lists.
     ///
     /// The scan updates internal state (mtimes, hashes) in memory but does
@@ -594,6 +642,8 @@ impl Scanner {
             self.excludes.len(),
             self.excludes
         );
+
+        let git_ignore = self.git_ignore_context();
 
         let mut changed_files = Vec::new();
         let mut new_files = Vec::new();
@@ -625,6 +675,7 @@ impl Scanner {
 
         self.walk_dir_mtime(
             &self.repo_root.clone(),
+            git_ignore.as_ref(),
             &mut changed_files,
             &mut new_files,
             &mut new_dir_mtimes,
@@ -636,7 +687,10 @@ impl Scanner {
         if let Some(git_files) = git_changed {
             for rel_path in git_files {
                 let abs_path = self.repo_root.join(&rel_path);
-                if abs_path.is_file() && !self.is_excluded(&rel_path) {
+                if abs_path.is_file()
+                    && !self.is_excluded(&rel_path)
+                    && !Self::is_git_ignored(git_ignore.as_ref(), &abs_path)
+                {
                     // If not already captured by mtime walk
                     if !changed_files.contains(&rel_path) && !new_files.contains(&rel_path) {
                         if self.state.file_mtimes.contains_key(&rel_path) {
@@ -785,6 +839,7 @@ impl Scanner {
     fn walk_dir_mtime(
         &self,
         dir: &Path,
+        git_ignore: Option<&GitIgnoreContext>,
         changed: &mut Vec<PathBuf>,
         new: &mut Vec<PathBuf>,
         new_dir_mtimes: &mut HashMap<PathBuf, SystemTimeWrapper>,
@@ -804,6 +859,13 @@ impl Scanner {
         // Check exclude patterns for this directory
         if !rel_dir.as_os_str().is_empty() && self.is_excluded_dir(&rel_dir) {
             tracing::debug!("Scanner: skipping excluded directory {}", rel_dir_display);
+            return Ok(());
+        }
+        if dir != self.repo_root && Self::is_git_ignored(git_ignore, dir) {
+            tracing::debug!(
+                "Scanner: skipping git-ignored directory {}",
+                rel_dir_display
+            );
             return Ok(());
         }
 
@@ -833,7 +895,14 @@ impl Scanner {
             // Directory unchanged: no files added/removed in this dir. But file
             // contents may have been modified in place. Re-check file mtimes
             // while skipping subdirectories whose mtimes are also unchanged.
-            self.carry_forward_subtree(dir, changed, new, new_dir_mtimes, new_file_mtimes)?;
+            self.carry_forward_subtree(
+                dir,
+                git_ignore,
+                changed,
+                new,
+                new_dir_mtimes,
+                new_file_mtimes,
+            )?;
             tracing::debug!(
                 "Scanner: carried subtree {} in {:?}",
                 rel_dir_display,
@@ -857,7 +926,14 @@ impl Scanner {
                 if skip_if_independent_worktree(&path) {
                     continue;
                 }
-                self.walk_dir_mtime(&path, changed, new, new_dir_mtimes, new_file_mtimes)?;
+                self.walk_dir_mtime(
+                    &path,
+                    git_ignore,
+                    changed,
+                    new,
+                    new_dir_mtimes,
+                    new_file_mtimes,
+                )?;
             } else if ft.is_file() {
                 let file_start = Instant::now();
                 let rel_file = path
@@ -865,8 +941,11 @@ impl Scanner {
                     .unwrap_or(&path)
                     .to_path_buf();
 
-                if self.is_excluded(&rel_file) {
-                    tracing::debug!("Scanner: skipping excluded file {}", rel_file.display());
+                if self.is_excluded(&rel_file) || Self::is_git_ignored(git_ignore, &path) {
+                    tracing::debug!(
+                        "Scanner: skipping excluded or git-ignored file {}",
+                        rel_file.display()
+                    );
                     continue;
                 }
 
@@ -914,6 +993,7 @@ impl Scanner {
     fn carry_forward_subtree(
         &self,
         dir: &Path,
+        git_ignore: Option<&GitIgnoreContext>,
         changed: &mut Vec<PathBuf>,
         new: &mut Vec<PathBuf>,
         new_dir_mtimes: &mut HashMap<PathBuf, SystemTimeWrapper>,
@@ -949,9 +1029,9 @@ impl Scanner {
                     .unwrap_or(&path)
                     .to_path_buf();
 
-                if self.is_excluded_dir(&rel_dir) {
+                if self.is_excluded_dir(&rel_dir) || Self::is_git_ignored(git_ignore, &path) {
                     tracing::debug!(
-                        "Scanner: skipping excluded directory {} during subtree carry",
+                        "Scanner: skipping excluded or git-ignored directory {} during subtree carry",
                         rel_dir.display()
                     );
                     continue;
@@ -974,11 +1054,19 @@ impl Scanner {
                     );
                     // Subdirectory changed: files may have been added/removed.
                     // Fall through to full enumeration via walk_dir_mtime.
-                    self.walk_dir_mtime(&path, changed, new, new_dir_mtimes, new_file_mtimes)?;
+                    self.walk_dir_mtime(
+                        &path,
+                        git_ignore,
+                        changed,
+                        new,
+                        new_dir_mtimes,
+                        new_file_mtimes,
+                    )?;
                 } else {
                     // Subdirectory also unchanged: recurse with same logic
                     self.carry_forward_subtree(
                         &path,
+                        git_ignore,
                         changed,
                         new,
                         new_dir_mtimes,
@@ -992,9 +1080,9 @@ impl Scanner {
                     .unwrap_or(&path)
                     .to_path_buf();
 
-                if self.is_excluded(&rel_file) {
+                if self.is_excluded(&rel_file) || Self::is_git_ignored(git_ignore, &path) {
                     tracing::debug!(
-                        "Scanner: skipping excluded file {} during subtree carry",
+                        "Scanner: skipping excluded or git-ignored file {} during subtree carry",
                         rel_file.display()
                     );
                     continue;
@@ -1047,7 +1135,7 @@ impl Scanner {
                 return None;
             }
         };
-        let repo = match git2::Repository::open(&self.repo_root) {
+        let repo = match git2::Repository::discover(&self.repo_root) {
             Ok(repo) => repo,
             Err(err) => {
                 tracing::debug!(
@@ -1058,6 +1146,22 @@ impl Scanner {
                 return None;
             }
         };
+        let workdir = match repo.workdir() {
+            Some(workdir) => workdir
+                .canonicalize()
+                .unwrap_or_else(|_| workdir.to_path_buf()),
+            None => {
+                tracing::debug!(
+                    "Scanner: git diff unavailable for {}: bare repository",
+                    self.repo_root.display()
+                );
+                return None;
+            }
+        };
+        let scan_root = self
+            .repo_root
+            .canonicalize()
+            .unwrap_or_else(|_| self.repo_root.clone());
 
         let old_oid = match git2::Oid::from_str(last_sha) {
             Ok(oid) => oid,
@@ -1140,10 +1244,12 @@ impl Scanner {
         if diff
             .foreach(
                 &mut |delta, _| {
-                    if let Some(path) = delta.new_file().path() {
-                        paths.push(path.to_path_buf());
-                    } else if let Some(path) = delta.old_file().path() {
-                        paths.push(path.to_path_buf());
+                    let git_rel_path = delta.new_file().path().or_else(|| delta.old_file().path());
+                    if let Some(git_rel_path) = git_rel_path {
+                        let abs_path = workdir.join(git_rel_path);
+                        if let Ok(scan_rel_path) = abs_path.strip_prefix(&scan_root) {
+                            paths.push(scan_rel_path.to_path_buf());
+                        }
                     }
                     true
                 },
@@ -1173,8 +1279,12 @@ impl Scanner {
 
     /// Get the current HEAD commit SHA.
     fn current_head_sha(&self) -> Result<String> {
-        let repo =
-            git2::Repository::open(&self.repo_root).context("Failed to open git repository")?;
+        let repo = git2::Repository::discover(&self.repo_root).with_context(|| {
+            format!(
+                "Failed to discover git repository from {}",
+                self.repo_root.display()
+            )
+        })?;
         let head = repo.head().context("Failed to get HEAD")?;
         let commit = head
             .peel_to_commit()
@@ -1482,6 +1592,76 @@ mod tests {
         // State should be persisted after commit
         scanner.commit_state().unwrap();
         assert!(state_path(root).exists());
+    }
+
+    #[test]
+    fn test_scoped_scan_uses_parent_gitignore() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        git2::Repository::init(root).unwrap();
+        fs::write(root.join(".gitignore"), "bin/\nobj/\n.angular/\n").unwrap();
+
+        create_file(
+            root,
+            "app/src/index.ts",
+            "export function realCode() { return 1; }",
+        );
+        create_file(
+            root,
+            "app/bin/Debug/generated.ts",
+            "export function ignoredBin() { return 2; }",
+        );
+        create_file(
+            root,
+            "app/obj/generated.ts",
+            "export function ignoredObj() { return 3; }",
+        );
+        create_file(
+            root,
+            "app/.angular/cache/generated.ts",
+            "export function ignoredAngularCache() { return 4; }",
+        );
+
+        let mut scanner = Scanner::new(root.join("app")).unwrap();
+        let result = scanner.scan().unwrap();
+        let mut new_files = result.new_files.clone();
+        new_files.sort();
+
+        assert_eq!(new_files, vec![PathBuf::from("src/index.ts")]);
+        assert!(result.changed_files.is_empty());
+        assert!(result.deleted_files.is_empty());
+    }
+
+    #[test]
+    fn test_scan_outside_git_uses_configured_excludes() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        create_file(root, ".oh/config.toml", "[scanner]\nexclude = [\"bin/\"]\n");
+        create_file(
+            root,
+            "src/index.ts",
+            "export function realCode() { return 1; }",
+        );
+        create_file(
+            root,
+            "bin/generated.ts",
+            "export function configuredIgnore() { return 2; }",
+        );
+
+        let mut scanner = Scanner::new(root.to_path_buf()).unwrap();
+        let result = scanner.scan().unwrap();
+        let mut new_files = result.new_files.clone();
+        new_files.sort();
+
+        assert_eq!(
+            new_files,
+            vec![
+                PathBuf::from(".oh/config.toml"),
+                PathBuf::from("src/index.ts")
+            ]
+        );
+        assert!(result.changed_files.is_empty());
+        assert!(result.deleted_files.is_empty());
     }
 
     // ── Incremental scan: detect changes ────────────────────────────

--- a/src/smoke_test.rs
+++ b/src/smoke_test.rs
@@ -26,6 +26,7 @@ use crate::server::{
     check_and_migrate_schema, graph_lance_path, load_graph_from_lance, persist_graph_incremental,
     persist_graph_to_lance,
 };
+use crate::types::OhArtifactKind;
 
 // ── Args ────────────────────────────────────────────────────────────
 
@@ -86,6 +87,14 @@ impl Check {
             detail: Some(detail.into()),
         }
     }
+}
+
+const SMOKE_OUTCOME_ID: &str = "agent-alignment";
+
+fn outcome_artifact_exists(repo: &Path, outcome_id: &str) -> Result<bool> {
+    Ok(crate::oh::load_oh_artifacts(repo)?
+        .into_iter()
+        .any(|artifact| artifact.kind == OhArtifactKind::Outcome && artifact.id() == outcome_id))
 }
 
 // ── Runner ──────────────────────────────────────────────────────────
@@ -349,31 +358,43 @@ pub async fn run(args: &TestArgs) -> Result<bool> {
     }
 
     // 9. outcome_progress path
-    match query::outcome_progress(&repo, "agent-alignment", &all_nodes) {
-        Ok(result) => {
-            let outcome_count = result.outcomes.len();
-            if outcome_count > 0
-                || !result.markdown_chunks.is_empty()
-                || !result.code_symbols.is_empty()
-            {
-                checks.push(Check::pass(
+    match outcome_artifact_exists(&repo, SMOKE_OUTCOME_ID) {
+        Ok(false) => checks.push(Check::skip(
+            "outcome_progress",
+            format!(
+                "optional outcome '{}' is absent; skipping outcome_progress smoke check",
+                SMOKE_OUTCOME_ID
+            ),
+        )),
+        Ok(true) => match query::outcome_progress(&repo, SMOKE_OUTCOME_ID, &all_nodes) {
+            Ok(result) => {
+                let outcome_count = result.outcomes.len();
+                if outcome_count > 0
+                    || !result.markdown_chunks.is_empty()
+                    || !result.code_symbols.is_empty()
+                {
+                    checks.push(Check::pass(
+                        "outcome_progress",
+                        format!("{} outcomes in progress result", outcome_count),
+                    ));
+                } else {
+                    checks.push(Check::skip(
+                        "outcome_progress",
+                        "outcome_progress returned empty for existing outcome",
+                    ));
+                }
+            }
+            Err(e) => {
+                checks.push(Check::fail(
                     "outcome_progress",
-                    format!("{} outcomes in progress result", outcome_count),
-                ));
-            } else {
-                // No outcomes for "agent-alignment" is possible but worth noting
-                checks.push(Check::skip(
-                    "outcome_progress",
-                    "outcome_progress returned empty (outcome may not exist)",
+                    format!("outcome_progress error: {}", e),
                 ));
             }
-        }
-        Err(e) => {
-            checks.push(Check::fail(
-                "outcome_progress",
-                format!("outcome_progress error: {}", e),
-            ));
-        }
+        },
+        Err(e) => checks.push(Check::fail(
+            "outcome_progress",
+            format!("failed to inspect outcome artifacts: {}", e),
+        )),
     }
 
     // 10. list_roots path
@@ -2216,4 +2237,31 @@ fn print_and_return(args: &TestArgs, checks: Vec<Check>) -> bool {
     }
 
     result.pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_outcome_artifact_exists_false_when_optional_outcome_absent() {
+        let dir = tempfile::tempdir().unwrap();
+
+        assert!(!outcome_artifact_exists(dir.path(), SMOKE_OUTCOME_ID).unwrap());
+    }
+
+    #[test]
+    fn test_outcome_artifact_exists_true_for_matching_outcome() {
+        let dir = tempfile::tempdir().unwrap();
+        let outcomes = dir.path().join(".oh").join("outcomes");
+        fs::create_dir_all(&outcomes).unwrap();
+        fs::write(
+            outcomes.join("agent-alignment.md"),
+            "---\nid: agent-alignment\n---\n\n# Agent Alignment\n",
+        )
+        .unwrap();
+
+        assert!(outcome_artifact_exists(dir.path(), SMOKE_OUTCOME_ID).unwrap());
+    }
 }

--- a/src/smoke_test.rs
+++ b/src/smoke_test.rs
@@ -368,14 +368,13 @@ pub async fn run(args: &TestArgs) -> Result<bool> {
         )),
         Ok(true) => match query::outcome_progress(&repo, SMOKE_OUTCOME_ID, &all_nodes) {
             Ok(result) => {
-                let outcome_count = result.outcomes.len();
-                if outcome_count > 0
-                    || !result.markdown_chunks.is_empty()
-                    || !result.code_symbols.is_empty()
-                {
+                if !result.markdown_chunks.is_empty() || !result.code_symbols.is_empty() {
                     checks.push(Check::pass(
                         "outcome_progress",
-                        format!("{} outcomes in progress result", outcome_count),
+                        format!(
+                            "{} outcomes with progress details",
+                            result.outcomes.len()
+                        ),
                     ));
                 } else {
                     checks.push(Check::skip(

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -40,9 +40,14 @@ pub fn is_worktree_with_own_cache(dir: &Path) -> bool {
 }
 
 fn git2_walk(repo_root: &Path, extensions: &[&str]) -> Result<Vec<PathBuf>> {
-    let repo = git2::Repository::open(repo_root)?;
+    let repo = git2::Repository::discover(repo_root)?;
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| anyhow::anyhow!("git walk requires a non-bare repository"))?
+        .canonicalize()
+        .unwrap_or_else(|_| repo.workdir().expect("checked workdir").to_path_buf());
     let mut files = Vec::new();
-    walk_dir_git2(&repo, repo_root, repo_root, extensions, &mut files)?;
+    walk_dir_git2(&repo, repo_root, &workdir, extensions, &mut files)?;
     files.sort();
     Ok(files)
 }
@@ -50,7 +55,7 @@ fn git2_walk(repo_root: &Path, extensions: &[&str]) -> Result<Vec<PathBuf>> {
 fn walk_dir_git2(
     repo: &git2::Repository,
     dir: &Path,
-    repo_root: &Path,
+    git_root: &Path,
     extensions: &[&str],
     files: &mut Vec<PathBuf>,
 ) -> Result<()> {
@@ -67,8 +72,21 @@ fn walk_dir_git2(
         }
 
         // Check if git ignores this path
-        let rel = path.strip_prefix(repo_root).unwrap_or(&path);
-        if repo.is_path_ignored(rel).unwrap_or(false) {
+        let ignored = path
+            .strip_prefix(git_root)
+            .map(|rel| repo.is_path_ignored(rel).unwrap_or(false))
+            .unwrap_or_else(|_| {
+                path.canonicalize()
+                    .ok()
+                    .and_then(|canonical| {
+                        canonical
+                            .strip_prefix(git_root)
+                            .ok()
+                            .map(|rel| repo.is_path_ignored(rel).unwrap_or(false))
+                    })
+                    .unwrap_or(false)
+            });
+        if ignored {
             continue;
         }
 
@@ -78,7 +96,7 @@ fn walk_dir_git2(
                 tracing::info!("skipping worktree {}: has own RNA cache", path.display());
                 continue;
             }
-            walk_dir_git2(repo, &path, repo_root, extensions, files)?;
+            walk_dir_git2(repo, &path, git_root, extensions, files)?;
         } else if path.is_file()
             && let Some(ext) = path.extension().and_then(|e| e.to_str())
             && extensions.iter().any(|e| e.eq_ignore_ascii_case(ext))
@@ -168,6 +186,46 @@ mod tests {
         let cache = path.join(".oh").join(".cache").join("lance");
         fs::create_dir_all(&cache).unwrap();
         assert!(!is_worktree_with_own_cache(path));
+    }
+
+    #[test]
+    fn test_walk_repo_files_uses_parent_gitignore_for_scoped_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        git2::Repository::init(root).unwrap();
+        fs::write(root.join(".gitignore"), "bin/\nobj/\n.angular/\n").unwrap();
+        fs::create_dir_all(root.join("app/src")).unwrap();
+        fs::create_dir_all(root.join("app/bin/Debug")).unwrap();
+        fs::create_dir_all(root.join("app/obj")).unwrap();
+        fs::create_dir_all(root.join("app/.angular/cache")).unwrap();
+        fs::write(
+            root.join("app/src/index.ts"),
+            "export function realCode() { return 1; }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("app/bin/Debug/generated.ts"),
+            "export function ignoredBin() { return 2; }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("app/obj/generated.ts"),
+            "export function ignoredObj() { return 3; }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("app/.angular/cache/generated.ts"),
+            "export function ignoredAngularCache() { return 4; }\n",
+        )
+        .unwrap();
+
+        let files = walk_repo_files(&root.join("app"), &["ts"]).unwrap();
+        let rel_files: Vec<_> = files
+            .iter()
+            .map(|path| path.strip_prefix(root).unwrap().to_path_buf())
+            .collect();
+
+        assert_eq!(rel_files, vec![PathBuf::from("app/src/index.ts")]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #700.
Closes #696.

## Problem
- Scoped scans using --path inside a parent git repo could lose parent .gitignore context and index generated artifacts.
- `rna test` incorrectly failed arbitrary healthy repos that do not have `.oh/outcomes/agent-alignment`.

## Solution
- Scanner git ignore evaluation now discovers the containing parent repository and evaluates ignores relative to that parent workdir, while keeping scan-state paths scoped to the requested root.
- Git-diff optimization now discovers parent repos for scoped roots and converts parent-relative diff paths back to scan-root-relative paths.
- `walk_repo_files` now discovers parent git roots before falling back to basic walking, so search/markdown paths share scoped ignore behavior.
- `rna test` preflights the optional smoke outcome and skips only the `outcome_progress` check when that artifact is absent; real outcome_progress errors still fail when the outcome exists.

## Verification
- `CARGO_TARGET_DIR=/tmp/rna-target-702 cargo check --lib`
- `CARGO_TARGET_DIR=/tmp/rna-target-702 cargo test --lib scanner::tests::test_scoped_scan_uses_parent_gitignore`
- `CARGO_TARGET_DIR=/tmp/rna-target-702 cargo test --lib scanner::tests::test_scan_outside_git_uses_configured_excludes`
- `CARGO_TARGET_DIR=/tmp/rna-target-702 cargo test --lib walk::tests::test_walk_repo_files_uses_parent_gitignore_for_scoped_root`
- `CARGO_TARGET_DIR=/tmp/rna-target-702 cargo test --lib smoke_test::tests::test_outcome_artifact_exists`
- Delivery spot-check: temp parent git repo with `.gitignore` for `bin/`, `obj/`, `.angular/`; `scan --repo . --path app --full --no-lsp --no-embed` indexed 2 symbols/2 files, and `search --repo app ignored --compact --limit 20` returned no ignored generated symbols.
- Delivery spot-check: temp git repo without `.oh/outcomes/agent-alignment`; `repo-native-alignment test --repo <tmp>` reported `[SKIP] outcome_progress: optional outcome` instead of failing on missing outcome. It still reported a real `[FAIL] embed_index` in this local no-embeddings build, proving real smoke failures remain failures.

## Notes
- PR is intentionally still draft pending the normal ship pipeline/CI review gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scanner now skips git-ignored files and directories during scans and diff-based updates
  * Scanner treats previously tracked but now-missing git-ignored files as deleted

* **Bug Fixes**
  * Subdirectory scans correctly inherit parent .gitignore rules
  * Improved repository discovery for more accurate ignore-rule application and diff filtering

* **Tests**
  * Added tests for .gitignore behavior in scoped scans and deleted-file detection
  * Enhanced outcome artifact presence tests for the smoke pipeline

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-horizon-labs/repo-native-alignment/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->