### PR TITLE
Harden endpoint discovery for ASP.NET and client JS

### DIFF
--- a/.oh/sessions/699-697-dev.md
+++ b/.oh/sessions/699-697-dev.md
@@ -14,4 +14,7 @@ Acceptance criteria are clear: draft PR early, ASP.NET route extraction, noisy J
 |---|---|---|---|---|
 | 2026-05-23 | Read | Read workflow/skill files | Required process docs are local markdown, not code navigation | Accepted |
 | 2026-05-23 | Bash/gh | Read issues and create draft PR | GitHub tools are not exposed in this harness; `gh` is available | Accepted |
+| 2026-05-23 | Read | Pre-edit source anchors for `aspnet_endpoints.rs`, `configs.rs`, and `generic.rs` | Edit tool requires anchored source lines; RNA provided symbol context but not edit anchors | Accepted |
+| 2026-05-23 | Bash/grep | CLI spot-check assertions against captured output | Assertion scripting over real CLI output, not code navigation | Accepted |
+| 2026-05-23 | Bash/ps | Diagnosed and stopped a stale scan process from worktree setup | Process inspection is operational state, not code navigation | Accepted |
 

--- a/.oh/sessions/699-697-dev.md
+++ b/.oh/sessions/699-697-dev.md
@@ -1,10 +1,19 @@
+---
+session: 699-697-dev
+issues: [699, 697]
+pr: 703
+branch: 699-697-endpoint-discovery
+date: 2026-05-25
+tags: [context-assembly, endpoint-discovery, aspnet]
+---
+
 # Endpoint discovery quality group (#699/#697)
 
 ## Phase 1: GitHub Issue
 
 Existing issues read and accepted:
-- #699 ASP.NET controller routes are not returned as `api_endpoint` symbols
-- #697 `api_endpoint` extraction produces noisy false positives from client-side JavaScript
+- `#699` ASP.NET controller routes are not returned as `api_endpoint` symbols
+- `#697` `api_endpoint` extraction produces noisy false positives from client-side JavaScript
 
 Acceptance criteria are clear: draft PR early, ASP.NET route extraction, noisy JS client false-positive reduction/reclassification, tests, delivery spot-check.
 

--- a/.oh/sessions/699-697-dev.md
+++ b/.oh/sessions/699-697-dev.md
@@ -1,0 +1,17 @@
+# Endpoint discovery quality group (#699/#697)
+
+## Phase 1: GitHub Issue
+
+Existing issues read and accepted:
+- #699 ASP.NET controller routes are not returned as `api_endpoint` symbols
+- #697 `api_endpoint` extraction produces noisy false positives from client-side JavaScript
+
+Acceptance criteria are clear: draft PR early, ASP.NET route extraction, noisy JS client false-positive reduction/reclassification, tests, delivery spot-check.
+
+## RNA Tool Friction Log
+
+| Time | Tool | Purpose | Why RNA was insufficient | Outcome |
+|---|---|---|---|---|
+| 2026-05-23 | Read | Read workflow/skill files | Required process docs are local markdown, not code navigation | Accepted |
+| 2026-05-23 | Bash/gh | Read issues and create draft PR | GitHub tools are not exposed in this harness; `gh` is available | Accepted |
+

--- a/src/extract/aspnet_endpoints.rs
+++ b/src/extract/aspnet_endpoints.rs
@@ -155,7 +155,6 @@ fn extract_endpoints_from_source(
                     result,
                     root_slug,
                     file_path,
-                    "csharp",
                     attribute_line,
                     http_method,
                     &route,
@@ -199,7 +198,6 @@ fn extract_minimal_api_endpoints(
             result,
             root_slug,
             file_path,
-            "csharp",
             line_number,
             http_method,
             route,
@@ -212,7 +210,6 @@ fn push_endpoint(
     result: &mut ExtractionResult,
     root_slug: &str,
     file_path: &Path,
-    language: &str,
     line_number: usize,
     http_method: &str,
     route: &str,
@@ -237,7 +234,7 @@ fn push_endpoint(
 
     result.nodes.push(Node {
         id: node_id,
-        language: language.to_string(),
+        language: "csharp".to_string(),
         line_start: line_number,
         line_end: line_number,
         signature,

--- a/src/extract/aspnet_endpoints.rs
+++ b/src/extract/aspnet_endpoints.rs
@@ -20,20 +20,43 @@ const MAP_METHODS: &[(&str, &str)] = &[
     ("MapPut", "PUT"),
     ("MapDelete", "DELETE"),
     ("MapPatch", "PATCH"),
+    ("MapHead", "HEAD"),
+    ("MapOptions", "OPTIONS"),
 ];
 
-/// Extract ASP.NET minimal API endpoints from C# nodes.
+/// HTTP method attribute mapping patterns in ASP.NET MVC/Web API controllers.
+const HTTP_ATTRIBUTE_METHODS: &[(&str, &str)] = &[
+    ("HttpGet", "GET"),
+    ("HttpPost", "POST"),
+    ("HttpPut", "PUT"),
+    ("HttpDelete", "DELETE"),
+    ("HttpPatch", "PATCH"),
+    ("HttpHead", "HEAD"),
+    ("HttpOptions", "OPTIONS"),
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Attribute {
+    name: String,
+    route: Option<String>,
+    line: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ControllerContext {
+    name: String,
+    route_prefix: Option<String>,
+}
+
+/// Extract ASP.NET minimal API and controller endpoints from C# nodes.
 ///
-/// Reads the source files of C# function nodes, scanning for `app.MapXxx("/path", ...)`
-/// patterns. Each match produces an `ApiEndpoint` node with `method` and `path` metadata.
-pub fn aspnet_endpoint_pass(
-    root_pairs: &[(String, PathBuf)],
-    nodes: &[Node],
-) -> ExtractionResult {
+/// Reads C# source files and emits authoritative server-route `ApiEndpoint` nodes for:
+/// - minimal API registrations such as `app.MapGet("/path", ...)`;
+/// - controller actions decorated with `[HttpGet]`, `[HttpPost]`, etc., optionally
+///   combined with controller-level `[Route("...")]` prefixes.
+pub fn aspnet_endpoint_pass(root_pairs: &[(String, PathBuf)], nodes: &[Node]) -> ExtractionResult {
     let mut result = ExtractionResult::default();
 
-    // Collect C# files that likely contain endpoint mappings.
-    // Look at function nodes in files whose names suggest endpoint registration.
     let cs_files: Vec<(&str, &PathBuf)> = nodes
         .iter()
         .filter(|n| n.language == "csharp")
@@ -43,7 +66,6 @@ pub fn aspnet_endpoint_pass(
         .collect();
 
     for (root_slug, file_path) in &cs_files {
-        // Resolve to absolute path via root_pairs.
         let abs_path = root_pairs
             .iter()
             .find(|(slug, _)| slug == root_slug)
@@ -55,78 +77,332 @@ pub fn aspnet_endpoint_pass(
             Err(_) => continue,
         };
 
-        // Quick check: does this file contain any Map method?
-        if !MAP_METHODS.iter().any(|(pat, _)| content.contains(pat)) {
+        if !contains_aspnet_endpoint_marker(&content) {
             continue;
         }
 
-        extract_endpoints_from_source(
-            &content,
-            file_path,
-            root_slug,
-            &mut result,
-        );
+        extract_endpoints_from_source(&content, file_path, root_slug, &mut result);
     }
 
     result
 }
 
-/// Parse a C# source file for `MapGet("/path", ...)` etc. patterns.
+fn contains_aspnet_endpoint_marker(content: &str) -> bool {
+    MAP_METHODS.iter().any(|(pat, _)| content.contains(pat))
+        || HTTP_ATTRIBUTE_METHODS
+            .iter()
+            .any(|(attr, _)| content.contains(attr))
+}
+
+/// Parse a C# source file for ASP.NET endpoint declarations.
 fn extract_endpoints_from_source(
     content: &str,
     file_path: &Path,
     root_slug: &str,
     result: &mut ExtractionResult,
 ) {
+    let mut pending_attrs: Vec<Attribute> = Vec::new();
+    let mut controller: Option<ControllerContext> = None;
+
     for (i, line) in content.lines().enumerate() {
+        let line_number = i + 1;
         let trimmed = line.trim();
-        // Skip comments to avoid false-positive extraction.
         if trimmed.starts_with("//") || trimmed.starts_with("/*") || trimmed.starts_with('*') {
             continue;
         }
-        for &(map_method, http_method) in MAP_METHODS {
-            // Match patterns like: app.MapGet("/path", ...) or .MapGet("/path", ...)
-            let Some(map_pos) = trimmed.find(map_method) else {
-                continue;
-            };
-            // Allow whitespace between method name and '(' (valid C# formatting).
-            let after_method = trimmed[map_pos + map_method.len()..].trim_start();
-            if !after_method.starts_with('(') {
-                continue;
-            }
-            let after_paren = after_method[1..].trim_start();
-            // Extract the route string (first argument, must be a string literal)
-            if !after_paren.starts_with('"') {
-                continue;
-            }
-            let route_end = after_paren[1..].find('"');
-            let Some(end) = route_end else { continue };
-            let route = &after_paren[1..1 + end];
 
-            let endpoint_name = format!("{} {}", http_method, route);
-            let node_id = NodeId {
-                root: root_slug.to_string(),
-                file: file_path.to_path_buf(),
-                name: endpoint_name.clone(),
-                kind: NodeKind::ApiEndpoint,
-            };
-
-            let mut metadata = BTreeMap::new();
-            metadata.insert("method".to_string(), http_method.to_string());
-            metadata.insert("path".to_string(), route.to_string());
-            metadata.insert("framework".to_string(), "aspnet".to_string());
-
-            result.nodes.push(Node {
-                id: node_id,
-                language: "csharp".to_string(),
-                line_start: i + 1,
-                line_end: i + 1,
-                signature: format!("{}.{}(\"{}\", ...)", "app", map_method, route),
-                body: String::new(),
-                metadata,
-                source: ExtractionSource::TreeSitter,
-            });
+        let minimal_before = result.nodes.len();
+        extract_minimal_api_endpoints(trimmed, line_number, file_path, root_slug, result);
+        if result.nodes.len() != minimal_before {
+            pending_attrs.clear();
+            continue;
         }
+
+        if trimmed.starts_with('[') {
+            let attrs = parse_attributes(trimmed, line_number);
+            if !attrs.is_empty() {
+                pending_attrs.extend(attrs);
+                continue;
+            }
+        }
+
+        if let Some(class_name) = extract_class_name(trimmed) {
+            let route_prefix = pending_attrs
+                .iter()
+                .find(|attr| attr.name == "Route")
+                .and_then(|attr| attr.route.clone());
+            let is_controller = class_name.ends_with("Controller")
+                || trimmed.contains("ControllerBase")
+                || pending_attrs
+                    .iter()
+                    .any(|attr| attr.name == "ApiController");
+            if is_controller {
+                controller = Some(ControllerContext {
+                    name: class_name,
+                    route_prefix,
+                });
+            }
+            pending_attrs.clear();
+            continue;
+        }
+
+        if is_method_declaration(trimmed) {
+            if let Some((http_method, route_fragment, attribute_line)) =
+                route_from_method_attrs(&pending_attrs)
+            {
+                let route = combine_routes(controller.as_ref(), route_fragment.as_deref());
+                push_endpoint(
+                    result,
+                    root_slug,
+                    file_path,
+                    "csharp",
+                    attribute_line,
+                    http_method,
+                    &route,
+                    format!("[aspnet_controller] {} {}", http_method, route),
+                );
+            }
+            pending_attrs.clear();
+            continue;
+        }
+
+        if !trimmed.is_empty() {
+            pending_attrs.clear();
+        }
+    }
+}
+
+fn extract_minimal_api_endpoints(
+    trimmed: &str,
+    line_number: usize,
+    file_path: &Path,
+    root_slug: &str,
+    result: &mut ExtractionResult,
+) {
+    for &(map_method, http_method) in MAP_METHODS {
+        let Some(map_pos) = trimmed.find(map_method) else {
+            continue;
+        };
+        let after_method = trimmed[map_pos + map_method.len()..].trim_start();
+        if !after_method.starts_with('(') {
+            continue;
+        }
+        let after_paren = after_method[1..].trim_start();
+        if !after_paren.starts_with('"') {
+            continue;
+        }
+        let route_end = after_paren[1..].find('"');
+        let Some(end) = route_end else { continue };
+        let route = &after_paren[1..1 + end];
+
+        push_endpoint(
+            result,
+            root_slug,
+            file_path,
+            "csharp",
+            line_number,
+            http_method,
+            route,
+            format!("app.{}(\"{}\", ...)", map_method, route),
+        );
+    }
+}
+
+fn push_endpoint(
+    result: &mut ExtractionResult,
+    root_slug: &str,
+    file_path: &Path,
+    language: &str,
+    line_number: usize,
+    http_method: &str,
+    route: &str,
+    signature: String,
+) {
+    let endpoint_name = format!("{} {}", http_method, route);
+    let node_id = NodeId {
+        root: root_slug.to_string(),
+        file: file_path.to_path_buf(),
+        name: endpoint_name,
+        kind: NodeKind::ApiEndpoint,
+    };
+
+    let mut metadata = BTreeMap::new();
+    metadata.insert("method".to_string(), http_method.to_string());
+    metadata.insert("path".to_string(), route.to_string());
+    metadata.insert("http_method".to_string(), http_method.to_string());
+    metadata.insert("http_path".to_string(), route.to_string());
+    metadata.insert("framework".to_string(), "aspnet".to_string());
+    metadata.insert("endpoint_source".to_string(), "server_route".to_string());
+    metadata.insert("synthetic".to_string(), "false".to_string());
+
+    result.nodes.push(Node {
+        id: node_id,
+        language: language.to_string(),
+        line_start: line_number,
+        line_end: line_number,
+        signature,
+        body: String::new(),
+        metadata,
+        source: ExtractionSource::TreeSitter,
+    });
+}
+
+fn parse_attributes(trimmed: &str, line: usize) -> Vec<Attribute> {
+    let mut attrs = Vec::new();
+    let mut rest = trimmed;
+
+    while let Some(start) = rest.find('[') {
+        let after_start = &rest[start + 1..];
+        let Some(end) = find_attribute_end(after_start) else {
+            break;
+        };
+        let content = after_start[..end].trim();
+        if let Some(attr) = parse_attribute(content, line) {
+            attrs.push(attr);
+        }
+        rest = &after_start[end + 1..];
+    }
+
+    attrs
+}
+
+fn find_attribute_end(input: &str) -> Option<usize> {
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for (idx, ch) in input.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_string => escaped = true,
+            '"' => in_string = !in_string,
+            ']' if !in_string => return Some(idx),
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn parse_attribute(content: &str, line: usize) -> Option<Attribute> {
+    let name_end = content
+        .find(|c: char| c == '(' || c == ',' || c.is_whitespace())
+        .unwrap_or(content.len());
+    let mut name = content[..name_end].trim().to_string();
+    if let Some(stripped) = name.strip_suffix("Attribute") {
+        name = stripped.to_string();
+    }
+    if name.is_empty() {
+        return None;
+    }
+    let route = first_string_literal(content);
+    Some(Attribute { name, route, line })
+}
+
+fn first_string_literal(content: &str) -> Option<String> {
+    let start = content.find('"')?;
+    let rest = &content[start + 1..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+fn extract_class_name(trimmed: &str) -> Option<String> {
+    let class_pos = trimmed.find("class ")?;
+    let after_class = &trimmed[class_pos + "class ".len()..];
+    let name = after_class
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .next()
+        .unwrap_or("")
+        .trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+fn is_method_declaration(trimmed: &str) -> bool {
+    trimmed.contains('(')
+        && trimmed.contains(')')
+        && !trimmed.starts_with("if ")
+        && !trimmed.starts_with("for ")
+        && !trimmed.starts_with("foreach ")
+        && !trimmed.starts_with("while ")
+        && !trimmed.starts_with("switch ")
+        && !trimmed.starts_with("catch ")
+        && !trimmed.starts_with("using ")
+        && !trimmed.starts_with("return ")
+}
+
+fn route_from_method_attrs(attrs: &[Attribute]) -> Option<(&'static str, Option<String>, usize)> {
+    let http_attr = attrs.iter().find_map(|attr| {
+        HTTP_ATTRIBUTE_METHODS
+            .iter()
+            .find(|(name, _)| attr.name == *name)
+            .map(|(_, method)| (*method, attr.route.clone(), attr.line))
+    })?;
+
+    let route_attr = attrs
+        .iter()
+        .find(|attr| attr.name == "Route")
+        .and_then(|attr| attr.route.clone());
+
+    Some((http_attr.0, http_attr.1.or(route_attr), http_attr.2))
+}
+
+fn combine_routes(controller: Option<&ControllerContext>, route_fragment: Option<&str>) -> String {
+    let fragment = route_fragment.unwrap_or("").trim();
+    let fragment = replace_controller_tokens(fragment, controller);
+    let prefix = controller
+        .and_then(|ctx| ctx.route_prefix.as_deref())
+        .map(|prefix| replace_controller_tokens(prefix, controller))
+        .unwrap_or_default();
+
+    if fragment.starts_with('/') {
+        return normalize_route(&fragment);
+    }
+    if let Some(stripped) = fragment.strip_prefix("~/") {
+        return normalize_route(stripped);
+    }
+
+    let mut parts = Vec::new();
+    if !prefix.trim_matches('/').is_empty() {
+        parts.push(prefix.trim_matches('/').to_string());
+    }
+    if !fragment.trim_matches('/').is_empty() {
+        parts.push(fragment.trim_matches('/').to_string());
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!("/{}", parts.join("/"))
+    }
+}
+
+fn replace_controller_tokens(route: &str, controller: Option<&ControllerContext>) -> String {
+    let Some(controller) = controller else {
+        return route.to_string();
+    };
+    let controller_name = controller
+        .name
+        .strip_suffix("Controller")
+        .unwrap_or(&controller.name);
+    route
+        .replace("[controller]", controller_name)
+        .replace("[Controller]", controller_name)
+}
+
+fn normalize_route(route: &str) -> String {
+    let trimmed = route.trim();
+    if trimmed.is_empty() {
+        String::new()
+    } else if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
     }
 }
 
@@ -216,5 +492,67 @@ app.MapGet("/real", handler);
         extract_endpoints_from_source(content, &path, "test", &mut result);
         assert_eq!(result.nodes.len(), 1);
         assert_eq!(result.nodes[0].id.name, "GET /spaced");
+    }
+
+    #[test]
+    fn test_extracts_controller_http_attribute_routes() {
+        let content = r#"
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+public sealed class WeatherController : ControllerBase
+{
+    [HttpGet("weather/{city}")]
+    public IActionResult GetWeather(string city) => Ok(new { city });
+
+    [HttpPost]
+    [Route("weather")]
+    public IActionResult CreateWeather([FromBody] object request) => Ok(request);
+}
+"#;
+        let mut result = ExtractionResult::default();
+        let path = PathBuf::from("Controllers/WeatherController.cs");
+        extract_endpoints_from_source(content, &path, "test", &mut result);
+
+        let names: Vec<_> = result
+            .nodes
+            .iter()
+            .map(|node| node.id.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["GET /weather/{city}", "POST /weather"]);
+        assert!(result.nodes.iter().all(|node| {
+            node.metadata.get("endpoint_source").map(|s| s.as_str()) == Some("server_route")
+        }));
+    }
+
+    #[test]
+    fn test_combines_controller_and_method_route_attributes() {
+        let content = r#"
+using Microsoft.AspNetCore.Mvc;
+
+[Route("api/[controller]")]
+public class WeatherController : ControllerBase
+{
+    [HttpGet("{city}")]
+    public IActionResult GetWeather(string city) => Ok(new { city });
+
+    [HttpDelete("~/admin/weather/{city}")]
+    public IActionResult DeleteWeather(string city) => Ok();
+}
+"#;
+        let mut result = ExtractionResult::default();
+        let path = PathBuf::from("Controllers/WeatherController.cs");
+        extract_endpoints_from_source(content, &path, "test", &mut result);
+
+        let names: Vec<_> = result
+            .nodes
+            .iter()
+            .map(|node| node.id.name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["GET /api/Weather/{city}", "DELETE /admin/weather/{city}"]
+        );
+        assert_eq!(result.nodes[0].metadata["http_path"], "/api/Weather/{city}");
     }
 }

--- a/src/extract/configs.rs
+++ b/src/extract/configs.rs
@@ -151,20 +151,25 @@ static GO_ROUTE_QUERY: RouteQueryConfig = RouteQueryConfig {
 
 /// JavaScript / Node.js Express route registration query.
 ///
-/// Matches method calls where the HTTP method is deterministic:
+/// Matches server-side Express-style route registrations where the receiver is
+/// a conventional route container (`app`, `router`, `routes`, or `server`) and
+/// the first argument is a URL path literal:
 /// - `app.get('/users', handler)`     (Express)    → GET
 /// - `router.post('/items', handler)` (Express)    → POST
 /// - `app.put('/items/:id', handler)` (Express)    → PUT
 /// - `app.delete('/items/:id', handler)` (Express) → DELETE
 /// - `app.patch('/items/:id', handler)` (Express)  → PATCH
 ///
+/// Client calls such as `axios.get('/api/users')`, `fetch('/api/users')`,
+/// `URLSearchParams.get('deviceId')`, and cache/map lookups are deliberately
+/// excluded. They are observations of outbound client behavior, not authoritative
+/// server API surface, so they must not become `api_endpoint` nodes.
+///
 /// NOT included (deferred to #390 or later):
 /// - `use`   — middleware mount; not a route endpoint
 /// - `all`   — matches all HTTP methods; not a single-method endpoint
 /// - `route` — creates a route group for chaining `.get().post()`; not a direct endpoint
-///
-/// These omitted patterns collapse to GET in `infer_method_from_name()`, producing
-/// incorrect metadata before multi-method and prefix expansion are implemented.
+/// - custom receiver names — lower recall is preferable to noisy client false positives
 ///
 /// Tree-sitter JavaScript uses `member_expression` (not `selector_expression`
 /// like Go), with `property: (property_identifier)` for the method name.
@@ -173,10 +178,13 @@ static JAVASCRIPT_ROUTE_QUERY: RouteQueryConfig = RouteQueryConfig {
     query: r#"
 (call_expression
   function: (member_expression
+    object: (identifier) @receiver
     property: (property_identifier) @name)
   arguments: (arguments
     (string) @path)
-  (#match? @name "^(get|post|put|delete|patch|head|options)$"))
+  (#match? @receiver "^(app|router|routes|server)$")
+  (#match? @name "^(get|post|put|delete|patch|head|options)$")
+  (#match? @path "^[\"']/"))
 "#,
     default_method: "GET",
 };
@@ -1232,7 +1240,6 @@ pub static GDSCRIPT_CONFIG: LangConfig = LangConfig {
     has_parent_module_request: false,
     attribute_access_node: None,
 };
-
 
 /// Look up the LangConfig for a language name. Returns None for languages
 /// not supported by the generic extractor (JSON, Markdown, TOML, etc.).

--- a/src/extract/generic.rs
+++ b/src/extract/generic.rs
@@ -335,7 +335,6 @@ impl GenericExtractor {
         Self { config }
     }
 
-
     /// Run extraction and return the result. Used directly or as a base by
     /// per-language extractors that need custom post-processing.
     pub fn run(&self, path: &Path, content: &str) -> Result<ExtractionResult> {
@@ -506,10 +505,7 @@ fn collect_nodes(
             // Parent scope.
             if let Some((scope_name, scope_kind)) = parent_scope {
                 metadata.insert("parent_scope".to_string(), scope_name.clone());
-                metadata.insert(
-                    "parent_scope_kind".to_string(),
-                    scope_kind.to_string(),
-                );
+                metadata.insert("parent_scope_kind".to_string(), scope_kind.to_string());
             }
 
             // Name column for LSP cursor positioning.
@@ -5314,6 +5310,41 @@ class UserController {
         );
     }
 
+    /// JavaScript client HTTP calls and lookup-style `.get()` calls are not
+    /// authoritative server route declarations and must not become ApiEndpoint nodes.
+    #[test]
+    fn test_javascript_client_calls_do_not_emit_api_endpoints() {
+        use crate::extract::configs::JAVASCRIPT_CONFIG;
+        let ext = GenericExtractor::new(&JAVASCRIPT_CONFIG);
+        let code = r#"
+const params = new URLSearchParams(location.search);
+axios.get("/api/users");
+params.get("deviceId");
+cache.get("reset");
+fetch("/api/orders");
+app.get("/health", health);
+
+function health(req, res) {
+  res.send("ok");
+}
+"#;
+        let result = ext.run(Path::new("client.js"), code).unwrap();
+        let api_nodes: Vec<_> = result
+            .nodes
+            .iter()
+            .filter(|n| n.id.kind == NodeKind::ApiEndpoint)
+            .collect();
+
+        assert_eq!(
+            api_nodes
+                .iter()
+                .map(|n| n.id.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["GET /health"],
+            "only Express-style server route registrations should emit ApiEndpoint nodes"
+        );
+    }
+
     /// Verify that the existing function extraction still works alongside route queries.
     #[test]
     fn test_python_route_query_does_not_break_function_extraction() {
@@ -6139,7 +6170,6 @@ fn helper() {}
         assert_eq!(plain, with_md);
     }
 
-    
     #[test]
     fn test_parse_adr_refs_supports_path_and_id() {
         let refs = parse_adr_refs(
@@ -6831,7 +6861,11 @@ def process(self):
             .iter()
             .find(|n| n.id.name == "process")
             .unwrap();
-        let attr_refs = fn_node.metadata.get("attr_refs").map(String::as_str).unwrap_or("");
+        let attr_refs = fn_node
+            .metadata
+            .get("attr_refs")
+            .map(String::as_str)
+            .unwrap_or("");
         assert!(
             attr_refs.split(',').any(|s| s.trim() == "transform"),
             "transform() call should appear in attr_refs, got: {:?}",
@@ -6864,7 +6898,11 @@ function process(handler: Handler): void {
             .iter()
             .find(|n| n.id.name == "process")
             .unwrap();
-        let attr_refs = fn_node.metadata.get("attr_refs").map(String::as_str).unwrap_or("");
+        let attr_refs = fn_node
+            .metadata
+            .get("attr_refs")
+            .map(String::as_str)
+            .unwrap_or("");
         assert!(
             attr_refs.split(',').any(|s| s.trim() == "transform"),
             "transform() call should appear in attr_refs, got: {:?}",


### PR DESCRIPTION
## Summary

Fixes #699.
Fixes #697.

## Problem

Architecture/API discovery missed ASP.NET controller server routes and treated noisy client-side JavaScript URL fragments as authoritative `api_endpoint` symbols.

## Solution

- Extends ASP.NET endpoint extraction from minimal APIs to MVC/Web API controller attributes:
  - combines controller `[Route("...")]` prefixes with method-level `[HttpGet]`, `[HttpPost]`, etc.;
  - supports method-level `[Route("...")]` paired with verb attributes;
  - adds `http_method`, `http_path`, `endpoint_source=server_route`, and `synthetic=false` metadata on ASP.NET endpoint nodes.
- Tightens JavaScript route extraction to Express-style server route registrations on conventional route receivers (`app`, `router`, `routes`, `server`) with URL path literals.
- Keeps client observations like `axios.get('/api/users')`, `fetch('/api/orders')`, `URLSearchParams.get('deviceId')`, and cache/map `.get('reset')` out of authoritative `api_endpoint` results.
- Preserves FastAPI/Python route behavior with targeted regression coverage.

## Verification

- `cargo test aspnet_endpoints --lib -- --nocapture` — 8 passed.
- `cargo test test_javascript_client_calls_do_not_emit_api_endpoints --lib -- --nocapture` — passed.
- `cargo test test_python_extractor_emits_api_endpoint_for_fastapi_router_method --lib -- --nocapture` — passed.
- `cargo check --lib` — passed.
- `cargo build --bin repo-native-alignment` — passed.
- Delivery spot-check with real CLI against `/tmp/rna-endpoint-spot`:
  - `target/debug/repo-native-alignment scan --repo /tmp/rna-endpoint-spot --full --no-lsp --no-embed`
  - `target/debug/repo-native-alignment search --repo /tmp/rna-endpoint-spot "" --kind api_endpoint --compact --limit 20`
  - Observed `GET /api/Weather/weather/{city}`, `POST /api/Weather/weather`, and `GET /health`.
  - Confirmed no `deviceId`, `reset`, `GET /api/users`, or `GET /api/orders` client false-positive endpoints.

## Notes

`cargo fmt --check` currently reports pre-existing formatting diffs in unrelated files (`src/extract/rust.rs`, `src/extract/sql.rs`, `src/extract/yaml_extractor.rs`, `src/server/store/persist.rs`). Touched files were formatted via `cargo fmt`, then unrelated fmt drift was reverted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false positives from client-side JavaScript patterns (e.g., `axios.get`, `fetch`) being incorrectly identified as server endpoints.

* **Improvements**
  * Enhanced ASP.NET endpoint extraction to better support controller routes and attributes, including route normalization and HTTP method combinations.
  * Added validation to distinguish server route registrations from client-side HTTP calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-horizon-labs/repo-native-alignment/pull/703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->