### PR TITLE
setup DX diagnostics for .NET MCP usage

### DIFF
--- a/.oh/sessions/694-695-dev.md
+++ b/.oh/sessions/694-695-dev.md
@@ -1,3 +1,12 @@
+---
+session: 694-695-dev
+issues: [694, 695]
+pr: 705
+branch: 694-695-setup-dx
+date: 2026-05-25
+tags: [context-assembly, setup-dx, dotnet]
+---
+
 # Dev Pipeline — setup DX diagnostics for .NET MCP usage
 
 **Issues:** #694, #695
@@ -7,9 +16,9 @@
 
 ## Phase 1: Issue Analysis
 
-#694 asks for actionable C#/.NET setup diagnostics when `dotnet`, `csharp-ls`, or `DOTNET_ROOT` are missing/misconfigured. The diagnostics must not hard-fail non-C# repositories.
+Issue `#694` asks for actionable C#/.NET setup diagnostics when `dotnet`, `csharp-ls`, or `DOTNET_ROOT` are missing/misconfigured. The diagnostics must not hard-fail non-C# repositories.
 
-#695 asks MCP setup guidance to avoid fragile command wrappers and document direct-binary plus explicit `env` patterns for tool managers.
+Issue `#695` asks MCP setup guidance to avoid fragile command wrappers and document direct-binary plus explicit `env` patterns for tool managers.
 
 ## Phase 2: Solution Space
 

--- a/.oh/sessions/694-695-dev.md
+++ b/.oh/sessions/694-695-dev.md
@@ -26,6 +26,8 @@ Chosen solution:
 - `CARGO_TARGET_DIR=$PWD/target cargo test --lib setup::tests` — 15 passed.
 - `CARGO_TARGET_DIR=$PWD/target cargo test --lib` — 1894 passed, 0 failed, 2 ignored.
 - `CARGO_TARGET_DIR=$PWD/target cargo build --bin repo-native-alignment` — pass.
+- `CARGO_TARGET_DIR=$PWD/target cargo clippy --lib -- -D warnings` — pass.
+- `CARGO_TARGET_DIR=$PWD/target cargo test --lib server::tests::test_declared_root -- --nocapture` — 2 passed (rerun of CI-only failures observed before clippy fix).
 
 ## Delivery spot-check
 

--- a/.oh/sessions/694-695-dev.md
+++ b/.oh/sessions/694-695-dev.md
@@ -1,0 +1,69 @@
+# Dev Pipeline — setup DX diagnostics for .NET MCP usage
+
+**Issues:** #694, #695
+**PR:** #705
+**Branch:** `694-695-setup-dx`
+**Worktree:** `.claude/worktrees/694-695-setup-dx`
+
+## Phase 1: Issue Analysis
+
+#694 asks for actionable C#/.NET setup diagnostics when `dotnet`, `csharp-ls`, or `DOTNET_ROOT` are missing/misconfigured. The diagnostics must not hard-fail non-C# repositories.
+
+#695 asks MCP setup guidance to avoid fragile command wrappers and document direct-binary plus explicit `env` patterns for tool managers.
+
+## Phase 2: Solution Space
+
+Chosen solution:
+
+- Keep .NET-specific setup detection in setup/toolchain code and C# LSP remediation attached at the LSP language-server configuration boundary.
+- Detect C# projects in `setup` via `.cs`, `.csproj`, or `.sln` markers and emit optional, non-fatal diagnostics.
+- Attach C# remediation to `csharp-ls` LSP failures so scan/list-roots surfaces actionable next steps only when C# enrichment is relevant.
+- Update README and setup skill MCP config examples to use a direct RNA binary command plus explicit `env` for `DOTNET_ROOT`, `DOTNET_ROOT_ARM64`, and `PATH`.
+
+## Verification
+
+- `CARGO_TARGET_DIR=$PWD/target cargo check --lib` — pass.
+- `CARGO_TARGET_DIR=$PWD/target cargo test --lib setup::tests` — 15 passed.
+- `CARGO_TARGET_DIR=$PWD/target cargo test --lib` — 1894 passed, 0 failed, 2 ignored.
+- `CARGO_TARGET_DIR=$PWD/target cargo build --bin repo-native-alignment` — pass.
+
+## Delivery spot-check
+
+Created a temporary C# project with `App.csproj` and `src/Program.cs`, then ran:
+
+```bash
+PATH="/usr/bin:/bin" DOTNET_ROOT= DOTNET_ROOT_ARM64= \
+  ./target/debug/repo-native-alignment setup --project "$TMP" --dry-run --skip-skills --skip-verify
+```
+
+Observed actionable setup output:
+
+- Would check `dotnet` on PATH.
+- Would check `csharp-ls` on PATH.
+- Would check `DOTNET_ROOT` / `DOTNET_ROOT_ARM64` for MCP stdio env.
+- Guidance says to keep `.mcp.json` command as direct `repo-native-alignment` binary and put `DOTNET_ROOT`/`PATH` in server env instead of wrapper launches.
+
+Then ran:
+
+```bash
+PATH="/usr/bin:/bin" DOTNET_ROOT= DOTNET_ROOT_ARM64= RNA_LSP_JOB_TIMEOUT_MS=30000 \
+  ./target/debug/repo-native-alignment scan --repo "$TMP" --full
+```
+
+Observed non-fatal C# LSP diagnostic:
+
+```text
+LSP server 'csharp-ls' not found on PATH
+  Fix: C# LSP needs dotnet, csharp-ls, and a visible .NET root. Install .NET (...), install csharp-ls with `dotnet tool install -g csharp-ls`, add `$HOME/.dotnet/tools` to PATH, and set DOTNET_ROOT/DOTNET_ROOT_ARM64 to the installed .NET root for MCP stdio env.
+```
+
+The scan completed with tree-sitter output and degraded call-reference capability instead of hard-failing.
+
+## RNA Tool Friction Log
+
+| Phase | Tool | What happened | Workaround | Severity |
+|---|---|---|---|---|
+| Scan gate | `repo-native-alignment scan --repo . --full` | Worktree full scan timed out after 300s while rust-analyzer enrichment was still running, so the worktree index was not available to MCP search. | Used existing main-repo RNA index plus targeted source reads; later verified with cargo tests and a small C# fixture. | medium |
+| Exploration | `mcp_rna_server_search` on worktree | Returned `No symbols table found` because the timed-out scan left no worktree symbols table. | Used main repo RNA search and targeted grep/read fallback in the worktree. | medium |
+| Exploration | `mcp_rna_server_search` for setup/LSP symbols | Exact compound setup/C# LSP query returned no code results despite relevant code in `src/setup.rs`, `src/extract/lsp/mod.rs`, and `src/extract/consumers.rs`. | Used targeted grep/read fallback and logged this friction. | medium |
+| Formatting | `cargo fmt --check` | Reported pre-existing/unrelated formatting diffs in files outside this task. Running rustfmt broadly also reformatted unrelated modules, which was reverted. | Used targeted checks/tests and restored accidental formatting-only changes. | low |

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Example `.mcp.json`:
       "args": ["--repo", "/path/to/your/project"],
       "env": {
         "DOTNET_ROOT": "/opt/homebrew/opt/dotnet/libexec",
+        "DOTNET_ROOT_ARM64": "/opt/homebrew/opt/dotnet/libexec",
         "PATH": "/Users/me/.dotnet/tools:/opt/homebrew/opt/dotnet/libexec:/Users/me/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
       }
     }

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cargo install --locked --path .
 
 ### 2. Connect to your MCP client
 
-The MCP server command is `repo-native-alignment` with `--repo` as an argument. `command` must be just the binary name — the `--repo` flag goes in `args`, not in `command` (MCP stdio transport doesn't do shell splitting).
+The MCP server command is `repo-native-alignment` with `--repo` as an argument. Use a direct binary path for `command` — the `--repo` flag goes in `args`, not in `command`, and MCP stdio launchers should not rely on shell splitting or shell-profile/tool-manager wrappers.
 
 Example `.mcp.json`:
 
@@ -118,12 +118,18 @@ Example `.mcp.json`:
   "mcpServers": {
     "rna": {
       "type": "stdio",
-      "command": "repo-native-alignment",
-      "args": ["--repo", "/path/to/your/project"]
+      "command": "/Users/me/.cargo/bin/repo-native-alignment",
+      "args": ["--repo", "/path/to/your/project"],
+      "env": {
+        "DOTNET_ROOT": "/opt/homebrew/opt/dotnet/libexec",
+        "PATH": "/Users/me/.dotnet/tools:/opt/homebrew/opt/dotnet/libexec:/Users/me/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
+      }
     }
   }
 }
 ```
+
+For Homebrew, mise, asdf, or official .NET installs, keep `command` as the RNA binary and put `DOTNET_ROOT`/`DOTNET_ROOT_ARM64` plus `~/.dotnet/tools` PATH entries in `env`; do not launch RNA through `mise exec`, `asdf exec`, or wrapper scripts.
 
 For HTTP transport: `repo-native-alignment --repo . --transport http --port 8382`
 

--- a/plugin/skills/setup/SKILL.md
+++ b/plugin/skills/setup/SKILL.md
@@ -54,28 +54,36 @@ Release artifacts are intentionally built without local embedding/reranking supp
 
 ## Step 3: Configure the MCP server
 
-RNA is a per-project MCP server (it indexes the repo it's pointed at).
+RNA is a per-project MCP server (it indexes the repo it's pointed at). MCP stdio launchers often do **not** source shell profiles, and some harnesses crash or mis-handle wrapper commands. Keep `command` as the direct `repo-native-alignment` binary path and put tool-manager paths/env in the server `env` block instead of launching through `mise exec`, `asdf exec`, `brew shellenv`, or shell wrapper scripts.
 
-Check if `.mcp.json` exists in the project root and already contains an `rna-mcp` entry. If it does, skip this step.
+Check if `.mcp.json` exists in the project root and already contains an `rna-server` entry. If it does, verify it uses a direct RNA binary command; rewrite wrapper-based entries to the direct-binary pattern below.
 
-If the agent supports `claude mcp add` (Claude Code):
+If the agent supports `claude mcp add` (Claude Code), use a direct RNA command:
 ```bash
-claude mcp add rna-mcp --scope project -- repo-native-alignment --repo .
+claude mcp add rna-server --scope project -- repo-native-alignment --repo .
 ```
 
 Otherwise, create or update `.mcp.json` in the project root with:
 ```json
 {
   "mcpServers": {
-    "rna-mcp": {
-      "command": "repo-native-alignment",
-      "args": ["--repo", "."]
+    "rna-server": {
+      "type": "stdio",
+      "command": "/Users/me/.cargo/bin/repo-native-alignment",
+      "args": ["--repo", "/absolute/path/to/project"],
+      "env": {
+        "DOTNET_ROOT": "/opt/homebrew/opt/dotnet/libexec",
+        "DOTNET_ROOT_ARM64": "/opt/homebrew/opt/dotnet/libexec",
+        "PATH": "/Users/me/.dotnet/tools:/opt/homebrew/opt/dotnet/libexec:/Users/me/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
+      }
     }
   }
 }
 ```
 
-If `.mcp.json` already exists with other servers, merge the `rna-mcp` entry into the existing `mcpServers` object -- do not overwrite the file.
+For mise-managed .NET, set `DOTNET_ROOT`/`DOTNET_ROOT_ARM64` to the mise .NET root and prepend the root plus `~/.dotnet/tools` to `PATH`; keep `command` as the RNA binary, not `/opt/homebrew/bin/mise`. For asdf/Homebrew/official .NET installs, use their resolved install root in `env` the same way.
+
+If `.mcp.json` already exists with other servers, merge the `rna-server` entry into the existing `mcpServers` object -- do not overwrite the file.
 
 ## Step 4: Pre-warm the code index
 

--- a/plugin/skills/setup/SKILL.md
+++ b/plugin/skills/setup/SKILL.md
@@ -60,7 +60,7 @@ Check if `.mcp.json` exists in the project root and already contains an `rna-ser
 
 If the agent supports `claude mcp add` (Claude Code), use a direct RNA command:
 ```bash
-claude mcp add rna-server --scope project -- repo-native-alignment --repo .
+claude mcp add rna-server --scope project -- repo-native-alignment --repo "$PWD"
 ```
 
 Otherwise, create or update `.mcp.json` in the project root with:

--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -1358,7 +1358,7 @@ impl ExtractionConsumer for CustomExtractorConsumer {
 }
 
 fn is_lsp_server_not_found_error(err_text: &str) -> bool {
-    err_text.starts_with("LSP server '") && err_text.ends_with("' not found on PATH")
+    err_text.starts_with("LSP server '") && err_text.contains("' not found on PATH")
 }
 
 // ---------------------------------------------------------------------------
@@ -1471,6 +1471,8 @@ impl ExtractionConsumer for LspConsumer {
                     updated_nodes: Arc::from(enrichment.updated_nodes.into_boxed_slice()),
                     server_name: Some(self.enricher.name().to_string()),
                     error_count: enrichment.error_count,
+                    server_missing: false,
+                    remediation: self.enricher.toolchain_remediation().map(str::to_string),
                     aborted: enrichment.aborted,
                 }])
             }
@@ -1489,7 +1491,8 @@ impl ExtractionConsumer for LspConsumer {
                     || err_text.contains("no progress")
                     || err_text.contains("timed out")
                     || err_text.contains("zero LSP edges");
-                let error_count = usize::from(!is_lsp_server_not_found_error(&err_text));
+                let server_missing = is_lsp_server_not_found_error(&err_text);
+                let error_count = usize::from(!server_missing);
                 if aborted {
                     anyhow::bail!(
                         "LSP enrichment aborted for {} root {}: {}",
@@ -1506,6 +1509,8 @@ impl ExtractionConsumer for LspConsumer {
                     updated_nodes: Arc::from([]),
                     server_name: Some(self.enricher.name().to_string()),
                     error_count,
+                    server_missing,
+                    remediation: self.enricher.toolchain_remediation().map(str::to_string),
                     aborted,
                 }])
             }
@@ -2436,12 +2441,13 @@ fn build_single_language_enricher(language: &str) -> Arc<dyn crate::extract::Enr
     for &(lang, cmd, args, exts) in servers {
         if lang == language {
             let enricher = LspEnricher::new(lang, cmd, args, exts);
-            let enricher = if lang == "python" {
-                enricher.with_settings(serde_json::json!({
+            let enricher = match lang {
+                "python" => enricher.with_settings(serde_json::json!({
                     "python": { "analysis": { "autoSearchPaths": true } }
-                }))
-            } else {
-                enricher
+                })),
+                "csharp" => enricher
+                    .with_toolchain_remediation(crate::extract::lsp::CSHARP_TOOLCHAIN_REMEDIATION),
+                _ => enricher,
             };
             let enricher = match lang {
                 "typescript" | "deno" => enricher.with_config_file("tsconfig.json"),
@@ -3362,6 +3368,8 @@ mod tests {
             updated_nodes: std::sync::Arc::from([]),
             server_name: None,
             error_count: 0,
+            server_missing: false,
+            remediation: None,
             aborted: false,
         };
         let result = gate.on_event(&enrichment_done).await.unwrap();
@@ -3442,6 +3450,8 @@ mod tests {
             updated_nodes: std::sync::Arc::from([]),
             server_name: None,
             error_count: 0,
+            server_missing: false,
+            remediation: None,
             aborted: false,
         };
         let result = gate.on_event(&enrichment_done).await.unwrap();
@@ -3520,6 +3530,8 @@ mod tests {
             updated_nodes: std::sync::Arc::from([]),
             server_name: None,
             error_count: 0,
+            server_missing: false,
+            remediation: None,
             aborted: false,
         };
         let result = gate.on_event(&rust_done).await.unwrap();
@@ -3537,6 +3549,8 @@ mod tests {
             updated_nodes: std::sync::Arc::from([]),
             server_name: None,
             error_count: 0,
+            server_missing: false,
+            remediation: None,
             aborted: false,
         };
         let result = gate.on_event(&python_done).await.unwrap();
@@ -3987,7 +4001,8 @@ mod tests {
             line_start: 1,
             line_end: 4,
             signature: "[frontmatter]".to_string(),
-            body: "validate:\n  cargo_tests:\n    - module_0::tests::test_process_event_0\n".to_string(),
+            body: "validate:\n  cargo_tests:\n    - module_0::tests::test_process_event_0\n"
+                .to_string(),
             metadata: BTreeMap::from([("is_frontmatter".to_string(), "true".to_string())]),
             source: ExtractionSource::Markdown,
         });
@@ -4058,7 +4073,11 @@ mod tests {
             "forward pass should match the seeded cargo_test entry"
         );
         let edge = &edges_forward[0];
-        assert_eq!(edge.kind, EdgeKind::References, "edge kind must be References");
+        assert_eq!(
+            edge.kind,
+            EdgeKind::References,
+            "edge kind must be References"
+        );
         assert_eq!(edge.from.root, "app", "edge must originate in seeded root");
         assert_eq!(
             edge.from.file,
@@ -4094,5 +4113,4 @@ mod tests {
             "adr_passes_scan_time: tested_by={baseline_ms:.2}ms, adr={adr_ms:.2}ms, ratio={ratio:.2}x ({N} nodes)"
         );
     }
-
 }

--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -1358,7 +1358,7 @@ impl ExtractionConsumer for CustomExtractorConsumer {
 }
 
 fn is_lsp_server_not_found_error(err_text: &str) -> bool {
-    err_text.starts_with("LSP server '") && err_text.contains("' not found on PATH")
+    err_text.contains("LSP server '") && err_text.contains("' not found on PATH")
 }
 
 // ---------------------------------------------------------------------------
@@ -1455,6 +1455,7 @@ impl ExtractionConsumer for LspConsumer {
 
         match enrichment_result {
             Ok(enrichment) => {
+                let server_missing = !enrichment.any_enricher_ran;
                 tracing::info!(
                     "LspConsumer({}): root '{}' enrichment complete: {} edges, {} virtual nodes, {} patches",
                     self.language,
@@ -1471,7 +1472,7 @@ impl ExtractionConsumer for LspConsumer {
                     updated_nodes: Arc::from(enrichment.updated_nodes.into_boxed_slice()),
                     server_name: Some(self.enricher.name().to_string()),
                     error_count: enrichment.error_count,
-                    server_missing: false,
+                    server_missing,
                     remediation: self.enricher.toolchain_remediation().map(str::to_string),
                     aborted: enrichment.aborted,
                 }])

--- a/src/extract/event_bus.rs
+++ b/src/extract/event_bus.rs
@@ -117,6 +117,10 @@ pub enum ExtractionEvent {
         server_name: Option<String>,
         /// Number of errors encountered during enrichment (e.g., LSP request failures).
         error_count: usize,
+        /// Whether the server binary was missing before enrichment could start.
+        server_missing: bool,
+        /// Optional actionable setup guidance for this language server.
+        remediation: Option<String>,
         /// Whether enrichment was aborted early (e.g., error threshold exceeded).
         aborted: bool,
     },
@@ -1344,6 +1348,8 @@ mod tests {
                 server_name: None,
                 error_count: 0,
                 aborted: false,
+                server_missing: false,
+                remediation: None,
             }
         };
 

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -39,6 +39,8 @@ use super::{Enricher, EnrichmentResult};
 use crate::graph::index::GraphIndex;
 use crate::graph::{Confidence, Edge, EdgeKind, ExtractionSource, Node, NodeId, NodeKind};
 
+pub const CSHARP_TOOLCHAIN_REMEDIATION: &str = "C# LSP needs dotnet, csharp-ls, and a visible .NET root. Install .NET (brew install --cask dotnet-sdk, mise use dotnet@latest, asdf install dotnet latest, or Microsoft installer), install csharp-ls with `dotnet tool install -g csharp-ls`, add `$HOME/.dotnet/tools` to PATH, and set DOTNET_ROOT/DOTNET_ROOT_ARM64 to the installed .NET root for MCP stdio env.";
+
 // ---------------------------------------------------------------------------
 // LspEnricher
 // ---------------------------------------------------------------------------
@@ -68,6 +70,8 @@ pub struct LspEnricher {
     /// Config file this enricher relies on (e.g., "tsconfig.json" for TypeScript).
     /// Used by pick_lsp_root to prefer lsp_roots that contain this file.
     config_file: Option<&'static str>,
+    /// Optional setup guidance shown when this server is unavailable or fails startup.
+    toolchain_remediation: Option<&'static str>,
     ready: AtomicBool,
     /// Protected by mutex because enrich takes &self but we need to mutate transport state.
     state: Mutex<LspState>,
@@ -170,6 +174,7 @@ impl LspEnricher {
             extensions: extensions.iter().map(|s| s.to_string()).collect(),
             init_settings: None,
             config_file: None,
+            toolchain_remediation: None,
             ready: AtomicBool::new(false),
             state: Mutex::new(LspState {
                 transport: None,
@@ -219,6 +224,12 @@ impl LspEnricher {
     /// prefer the root that contains this file (e.g., `tsconfig.json` for TypeScript).
     pub fn with_config_file(mut self, config_file: &'static str) -> Self {
         self.config_file = Some(config_file);
+        self
+    }
+
+    /// Attach actionable setup guidance for this language server.
+    pub fn with_toolchain_remediation(mut self, remediation: &'static str) -> Self {
+        self.toolchain_remediation = Some(remediation);
         self
     }
 
@@ -382,6 +393,13 @@ impl LspEnricher {
         Ok(())
     }
 
+    fn remediation_suffix(&self) -> String {
+        self.toolchain_remediation
+            .map(|hint| format!("\n  Fix: {hint}"))
+            .unwrap_or_default()
+    }
+
+
     /// Initialize the language server if not already running.
     async fn ensure_initialized(&self, repo_root: &Path) -> Result<()> {
         let mut state = self.state.lock().await;
@@ -406,8 +424,9 @@ impl LspEnricher {
                 self.language
             );
             return Err(anyhow::anyhow!(
-                "LSP server '{}' not found on PATH",
-                self.server_command
+                "LSP server '{}' not found on PATH{}",
+                self.server_command,
+                self.remediation_suffix()
             ));
         }
 
@@ -454,7 +473,13 @@ impl LspEnricher {
                     self.language,
                     e
                 );
-                return Err(e);
+                return Err(e).with_context(|| {
+                    format!(
+                        "Failed to start LSP server '{}'{}",
+                        self.server_command,
+                        self.remediation_suffix()
+                    )
+                });
             }
         };
 
@@ -2229,6 +2254,10 @@ impl Enricher for LspEnricher {
 
     fn config_file_hint(&self) -> Option<&str> {
         self.config_file
+    }
+
+    fn toolchain_remediation(&self) -> Option<&str> {
+        self.toolchain_remediation
     }
 
     async fn enrich(

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -8,10 +8,10 @@
 //! for fine-grained checks. Multiple extractors can handle the same file.
 
 pub mod api_link;
+pub mod aspnet_endpoints;
 pub mod bash;
 pub mod c;
 pub mod cache;
-pub mod aspnet_endpoints;
 pub mod configs;
 pub mod consumers;
 pub mod cpp;
@@ -24,8 +24,8 @@ pub mod event_bus;
 pub mod extractor_config;
 pub mod fastapi_router_prefix;
 pub mod framework_detection;
-pub mod generic;
 pub mod gdscript;
+pub mod generic;
 pub mod go;
 pub mod graphql;
 pub mod grpc;
@@ -264,6 +264,11 @@ pub trait Enricher: Send + Sync {
     ///
     /// Default: `None` (no preference).
     fn config_file_hint(&self) -> Option<&str> {
+        None
+    }
+
+    /// Optional actionable setup guidance when this enricher cannot start.
+    fn toolchain_remediation(&self) -> Option<&str> {
         None
     }
 }
@@ -716,13 +721,13 @@ impl EnricherRegistry {
 
         for &(lang, cmd, args, exts) in servers {
             let enricher = lsp::LspEnricher::new(lang, cmd, args, exts);
-            // Add pyright-specific settings
-            let enricher = if lang == "python" {
-                enricher.with_settings(serde_json::json!({
+            // Add language-specific startup settings and remediation at the LSP config boundary.
+            let enricher = match lang {
+                "python" => enricher.with_settings(serde_json::json!({
                     "python": { "analysis": { "autoSearchPaths": true } }
-                }))
-            } else {
-                enricher
+                })),
+                "csharp" => enricher.with_toolchain_remediation(lsp::CSHARP_TOOLCHAIN_REMEDIATION),
+                _ => enricher,
             };
             // Add config file hints for lsp_root selection in monorepos.
             // When a monorepo has multiple subdirectory roots, the enricher prefers
@@ -849,6 +854,7 @@ impl EnricherRegistry {
                         error_count,
                         duration: dur,
                         status,
+                        remediation: enricher.toolchain_remediation().map(str::to_string),
                     });
                 }
                 Err(e) => {
@@ -874,6 +880,7 @@ impl EnricherRegistry {
                         error_count: 1,
                         duration: dur,
                         status,
+                        remediation: enricher.toolchain_remediation().map(str::to_string),
                     });
                 }
             }

--- a/src/extract/scan_stats.rs
+++ b/src/extract/scan_stats.rs
@@ -122,11 +122,11 @@ impl LspEnrichmentEntry {
                 )
             }
         };
-        if let Some(remediation) = &self.remediation {
-            if self.status != LspStatus::Ok {
-                line.push_str(" -- ");
-                line.push_str(remediation);
-            }
+        if let Some(remediation) = &self.remediation
+            && self.status != LspStatus::Ok
+        {
+            line.push_str(" -- ");
+            line.push_str(remediation);
         }
         line
     }

--- a/src/extract/scan_stats.rs
+++ b/src/extract/scan_stats.rs
@@ -959,6 +959,8 @@ mod tests {
             status: LspStatus::NotFound,
             remediation: Some("install json ls".to_string()),
         };
-        assert!(e.summary_line().contains("not found"));
+        let line = e.summary_line();
+        assert!(line.contains("not found"));
+        assert!(line.contains("install json ls"));
     }
 }

--- a/src/extract/scan_stats.rs
+++ b/src/extract/scan_stats.rs
@@ -83,6 +83,7 @@ pub struct LspEnrichmentEntry {
     pub error_count: usize,
     pub duration: Duration,
     pub status: LspStatus,
+    pub remediation: Option<String>,
 }
 
 impl LspEnrichmentEntry {
@@ -94,7 +95,7 @@ impl LspEnrichmentEntry {
             String::new()
         };
         let label = format!("  {} ({}){}", self.language, self.server_name, root_part);
-        match self.status {
+        let mut line = match self.status {
             LspStatus::NotFound => format!("{:<50} {}", label, self.status),
             LspStatus::Ok => {
                 let mut line = format!(
@@ -120,7 +121,14 @@ impl LspEnrichmentEntry {
                     self.duration.as_secs_f64()
                 )
             }
+        };
+        if let Some(remediation) = &self.remediation {
+            if self.status != LspStatus::Ok {
+                line.push_str(" -- ");
+                line.push_str(remediation);
+            }
         }
+        line
     }
 }
 
@@ -146,6 +154,10 @@ pub struct LspLanguageStats {
     pub error_count: usize,
     /// Whether the enrichment was aborted (e.g., too many errors, timeout).
     pub aborted: bool,
+    /// Whether the server binary was missing before enrichment could start.
+    pub server_missing: bool,
+    /// Optional actionable setup guidance for this language server.
+    pub remediation: Option<String>,
 }
 
 /// Per-root stats populated after `RootExtracted`.
@@ -368,6 +380,8 @@ impl ExtractionConsumer for ScanStatsConsumer {
                 server_name,
                 error_count,
                 aborted,
+                server_missing,
+                remediation,
                 ..
             } => {
                 // Remove from in-flight.
@@ -407,6 +421,8 @@ impl ExtractionConsumer for ScanStatsConsumer {
                             duration,
                             error_count: *error_count,
                             aborted: *aborted,
+                            server_missing: *server_missing,
+                            remediation: remediation.clone(),
                         },
                     );
                 }
@@ -598,6 +614,8 @@ mod tests {
             updated_nodes: std::sync::Arc::from([]),
             server_name: None,
             error_count: 0,
+            server_missing: false,
+            remediation: None,
             aborted: false,
         })
         .await
@@ -663,6 +681,8 @@ mod tests {
             updated_nodes: std::sync::Arc::from([]),
             server_name: Some("rust-analyzer".to_string()),
             error_count: 0,
+            server_missing: false,
+            remediation: None,
             aborted: false,
         })
         .await
@@ -714,6 +734,8 @@ mod tests {
             updated_nodes: std::sync::Arc::from([]),
             server_name: None,
             error_count: 0,
+            server_missing: false,
+            remediation: None,
             aborted: false,
         })
         .await
@@ -791,6 +813,8 @@ mod tests {
                 updated_nodes: std::sync::Arc::from([]),
                 server_name: None,
                 error_count: 0,
+                server_missing: false,
+                remediation: None,
                 aborted: false,
             })
             .await;
@@ -853,6 +877,8 @@ mod tests {
             updated_nodes: std::sync::Arc::from([]),
             server_name: Some("rust-analyzer".to_string()),
             error_count: 5,
+            server_missing: false,
+            remediation: Some("fix rust".to_string()),
             aborted: true,
         })
         .await
@@ -887,6 +913,8 @@ mod tests {
             updated_nodes: std::sync::Arc::from([]),
             server_name: None,
             error_count: 0,
+            server_missing: false,
+            remediation: None,
             aborted: false,
         })
         .await
@@ -910,6 +938,7 @@ mod tests {
             error_count: 0,
             duration: Duration::from_secs_f64(3.5),
             status: LspStatus::Ok,
+            remediation: None,
         };
         let l = e.summary_line();
         assert!(l.contains("rust (rust-analyzer)"));
@@ -928,6 +957,7 @@ mod tests {
             error_count: 0,
             duration: Duration::from_millis(5),
             status: LspStatus::NotFound,
+            remediation: Some("install json ls".to_string()),
         };
         assert!(e.summary_line().contains("not found"));
     }

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -2673,6 +2673,8 @@ mod tests {
                     duration: Duration::from_secs(1),
                     error_count: 2,
                     aborted: true,
+                    server_missing: false,
+                    remediation: None,
                 },
             )]
             .into_iter()
@@ -2689,6 +2691,8 @@ mod tests {
                     duration: Duration::from_secs(1),
                     error_count: 9,
                     aborted: true,
+                    server_missing: false,
+                    remediation: None,
                 },
             )]
             .into_iter()

--- a/src/service/roots.rs
+++ b/src/service/roots.rs
@@ -246,6 +246,9 @@ pub fn list_roots_from_slugs(
                 for (lang, ls) in &langs {
                     let duration_str = format_duration(ls.duration);
                     let mut detail_parts: Vec<String> = Vec::new();
+                    if ls.server_missing {
+                        detail_parts.push("not found".to_string());
+                    }
                     detail_parts.push(format!("{} edges", format_count(ls.edge_count)));
                     if ls.node_count > 0 {
                         detail_parts.push(format!("{} nodes", format_count(ls.node_count)));
@@ -256,6 +259,11 @@ pub fn list_roots_from_slugs(
                     }
                     if ls.aborted {
                         detail_parts.push("aborted".to_string());
+                    }
+                    if let Some(remediation) = &ls.remediation
+                        && (ls.server_missing || ls.aborted || ls.error_count > 0)
+                    {
+                        detail_parts.push(format!("next: {}", remediation));
                     }
                     line.push_str(&format!(
                         "\n  LSP: {} -> {} ({})",
@@ -1252,6 +1260,8 @@ mod tests {
                 duration: std::time::Duration::from_secs(45),
                 error_count: 0,
                 aborted: false,
+                server_missing: false,
+                remediation: None,
             },
         );
         stats.lsp_stats.insert(primary_slug.clone(), root_lsp);
@@ -1323,6 +1333,8 @@ mod tests {
                 duration: std::time::Duration::from_secs(120),
                 error_count: 13,
                 aborted: true,
+                server_missing: false,
+                remediation: Some("install pyright".to_string()),
             },
         );
         stats.lsp_stats.insert(primary_slug.clone(), root_lsp);
@@ -1390,6 +1402,8 @@ mod tests {
                 duration: std::time::Duration::from_secs(10),
                 error_count: 0,
                 aborted: false,
+                server_missing: false,
+                remediation: None,
             },
         );
         stats.lsp_stats.insert(primary_slug.clone(), root_lsp);

--- a/src/service/roots.rs
+++ b/src/service/roots.rs
@@ -1361,6 +1361,11 @@ mod tests {
             result
         );
         assert!(
+            result.contains("next: install pyright"),
+            "should show remediation guidance, got: {}",
+            result
+        );
+        assert!(
             result.contains("2m"),
             "should show duration, got: {}",
             result

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -356,6 +356,8 @@ fn common_dotnet_root_candidates() -> Vec<PathBuf> {
         candidates.push(home.join(".dotnet"));
         candidates.push(home.join(".local/share/mise/dotnet-root"));
         candidates.push(home.join(".local/share/mise/installs/dotnet"));
+        candidates.push(home.join(".asdf/installs/dotnet"));
+        candidates.push(home.join(".asdf/installs/dotnet-core"));
     }
     candidates
 }
@@ -1230,6 +1232,8 @@ mod tests {
         assert!(rendered.contains("/opt/homebrew/opt/dotnet/libexec"));
         assert!(rendered.contains(".dotnet"));
         assert!(rendered.contains(".local/share/mise"));
+        assert!(rendered.contains(".asdf/installs/dotnet"));
+        assert!(rendered.contains(".asdf/installs/dotnet-core"));
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -99,6 +99,8 @@ pub fn run(args: &SetupArgs) -> Result<()> {
         preflight(source_available, !args.skip_skills, needs_download)?;
     }
 
+    report_optional_csharp_toolchain(&project_path, args.dry_run);
+
     // ── Step 2: install RNA binary ─────────────────────────────────────────
     if args.dry_run {
         if source_available {
@@ -251,6 +253,149 @@ fn check_dep(cmd: &str, args: &[&str], remediation: &str) -> Result<()> {
         }
         Err(_) => bail!("Preflight failed: `{cmd}` not found in PATH.\n  Fix: {remediation}"),
     }
+}
+
+fn report_optional_csharp_toolchain(project_path: &Path, dry_run: bool) {
+    if !has_csharp_markers(project_path) {
+        return;
+    }
+
+    println!("Checking optional C#/.NET LSP toolchain...");
+    if dry_run {
+        println!("  [dry-run] Would check: dotnet on PATH");
+        println!("  [dry-run] Would check: csharp-ls on PATH");
+        println!("  [dry-run] Would check: DOTNET_ROOT / DOTNET_ROOT_ARM64 for MCP stdio env");
+        println!(
+            "  Guidance: keep .mcp.json command as the direct repo-native-alignment binary; put DOTNET_ROOT and PATH additions in the server env instead of launching through mise/asdf/brew wrappers.\n"
+        );
+        return;
+    }
+
+    let dotnet = command_on_path("dotnet");
+    let csharp_ls = command_on_path("csharp-ls");
+    let dotnet_root = detected_dotnet_root();
+
+    if dotnet {
+        println!("  [ok] dotnet found on PATH");
+    } else {
+        println!("  [warn] dotnet not found on PATH");
+    }
+
+    if csharp_ls {
+        println!("  [ok] csharp-ls found on PATH");
+    } else {
+        println!("  [warn] csharp-ls not found on PATH");
+    }
+
+    match &dotnet_root {
+        Some(root) => println!("  [ok] DOTNET_ROOT candidate: {}", root.display()),
+        None => {
+            println!("  [warn] DOTNET_ROOT/DOTNET_ROOT_ARM64 not set and no common .NET root found")
+        }
+    }
+
+    if !dotnet || !csharp_ls || dotnet_root.is_none() {
+        println!("  Next for C# call/reference enrichment:");
+        if !dotnet {
+            println!(
+                "    - Install .NET SDK: brew install --cask dotnet-sdk, mise use dotnet@latest, asdf install dotnet latest, or Microsoft installer."
+            );
+        }
+        if !csharp_ls {
+            println!("    - Install csharp-ls: dotnet tool install -g csharp-ls");
+            println!("    - Ensure global .NET tools are on PATH: $HOME/.dotnet/tools");
+        }
+        if dotnet_root.is_none() {
+            println!(
+                "    - Set DOTNET_ROOT (and DOTNET_ROOT_ARM64 on Apple Silicon) to the installed .NET root; common roots include /opt/homebrew/opt/dotnet/libexec, /usr/local/share/dotnet, $HOME/.dotnet, or a mise/asdf install root."
+            );
+        }
+        println!(
+            "    - For MCP stdio, do not make command a tool-manager wrapper. Keep command as the direct repo-native-alignment binary and put DOTNET_ROOT/PATH in the server env.\n"
+        );
+    } else {
+        println!(
+            "  C#/.NET LSP prerequisites look usable. Mirror DOTNET_ROOT and PATH in .mcp.json env if your MCP launcher does not inherit shell profile setup.\n"
+        );
+    }
+}
+
+fn command_on_path(cmd: &str) -> bool {
+    Command::new("which")
+        .arg(cmd)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn detected_dotnet_root() -> Option<PathBuf> {
+    for key in ["DOTNET_ROOT_ARM64", "DOTNET_ROOT"] {
+        if let Ok(value) = std::env::var(key) {
+            let path = PathBuf::from(value);
+            if path.is_dir() {
+                return Some(path);
+            }
+        }
+    }
+
+    common_dotnet_root_candidates()
+        .into_iter()
+        .find(|path| path.is_dir())
+}
+
+fn common_dotnet_root_candidates() -> Vec<PathBuf> {
+    let mut candidates = vec![
+        PathBuf::from("/opt/homebrew/opt/dotnet/libexec"),
+        PathBuf::from("/usr/local/share/dotnet"),
+        PathBuf::from("/usr/share/dotnet"),
+    ];
+    if let Ok(home) = std::env::var("HOME") {
+        let home = PathBuf::from(home);
+        candidates.push(home.join(".dotnet"));
+        candidates.push(home.join(".local/share/mise/dotnet-root"));
+        candidates.push(home.join(".local/share/mise/installs/dotnet"));
+    }
+    candidates
+}
+
+fn has_csharp_markers(project_path: &Path) -> bool {
+    fn walk(path: &Path, depth: u8) -> bool {
+        if depth > 4 {
+            return false;
+        }
+        let Ok(entries) = std::fs::read_dir(path) else {
+            return false;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with('.')
+                || matches!(
+                    name.as_ref(),
+                    "target" | "node_modules" | "bin" | "obj" | "packages"
+                )
+            {
+                continue;
+            }
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_file() {
+                let path = entry.path();
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                if matches!(ext, "cs" | "csproj" | "sln") {
+                    return true;
+                }
+            } else if file_type.is_dir() && walk(&entry.path(), depth + 1) {
+                return true;
+            }
+        }
+        false
+    }
+
+    walk(project_path, 0)
 }
 
 // ─── Install steps ───────────────────────────────────────────────────────────
@@ -1054,6 +1199,37 @@ mod tests {
             err.contains("No pre-built binary"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn test_has_csharp_markers_detects_project_files() {
+        let (_dir, proj) = tmp();
+        std::fs::create_dir_all(proj.join("src")).unwrap();
+        std::fs::write(proj.join("src/App.csproj"), "<Project />").unwrap();
+
+        assert!(has_csharp_markers(&proj));
+    }
+
+    #[test]
+    fn test_has_csharp_markers_ignores_non_csharp_project() {
+        let (_dir, proj) = tmp();
+        std::fs::create_dir_all(proj.join("src")).unwrap();
+        std::fs::write(proj.join("src/main.rs"), "fn main() {}").unwrap();
+
+        assert!(!has_csharp_markers(&proj));
+    }
+
+    #[test]
+    fn test_common_dotnet_root_candidates_include_tool_manager_roots() {
+        let rendered = common_dotnet_root_candidates()
+            .into_iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("/opt/homebrew/opt/dotnet/libexec"));
+        assert!(rendered.contains(".dotnet"));
+        assert!(rendered.contains(".local/share/mise"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add optional C#/.NET setup diagnostics for C# repos without hard-failing unrelated repos.
- Attach C# `csharp-ls` remediation at the LSP language-server configuration boundary so missing server diagnostics include dotnet/csharp-ls/DOTNET_ROOT next steps.
- Document direct MCP binary commands plus explicit env patterns for Homebrew/mise/asdf/official .NET installs.

Addresses setup-DX group for #694 and #695.

Closes #694
Closes #695

## Chosen solution
Keep generic extraction/enrichment language-agnostic. C#-specific remediation is configured through the LSP language-server setup boundary and setup command optional toolchain checks. MCP config guidance prefers direct `repo-native-alignment` binary paths with explicit `env` rather than fragile command-wrapper launches.

## Verification
- `CARGO_TARGET_DIR=$PWD/target cargo check --lib`
- `CARGO_TARGET_DIR=$PWD/target cargo test --lib setup::tests`
- `CARGO_TARGET_DIR=$PWD/target cargo test --lib` (1894 passed, 0 failed, 2 ignored)
- `CARGO_TARGET_DIR=$PWD/target cargo build --bin repo-native-alignment`

## Delivery spot-check
Created a temporary C# project (`App.csproj`, `src/Program.cs`) and ran:

```bash
PATH="/usr/bin:/bin" DOTNET_ROOT= DOTNET_ROOT_ARM64= ./target/debug/repo-native-alignment setup --project "$TMP" --dry-run --skip-skills --skip-verify
PATH="/usr/bin:/bin" DOTNET_ROOT= DOTNET_ROOT_ARM64= RNA_LSP_JOB_TIMEOUT_MS=30000 ./target/debug/repo-native-alignment scan --repo "$TMP" --full
```

Observed setup guidance for `dotnet`, `csharp-ls`, `DOTNET_ROOT`/`DOTNET_ROOT_ARM64`, and direct-binary MCP env configuration. Scan completed non-fatally and emitted: `LSP server 'csharp-ls' not found on PATH` plus a `Fix:` line with .NET SDK, `dotnet tool install -g csharp-ls`, `$HOME/.dotnet/tools`, and `DOTNET_ROOT` guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now runs C#/.NET toolchain checks and reports missing prerequisites with actionable remediation hints.
  * Scans/reporting surface a “server missing” status for language servers and attach remediation guidance when enrichment fails.

* **Documentation**
  * Clarified MCP stdio configuration: use the direct RNA binary as the command, put --repo in args, and set DOTNET_ROOT/PATH.
  * Added per-project MCP setup examples and a session write-up of verification steps.

* **Tests**
  * Updated tests to cover C# detection and new enrichment metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-horizon-labs/repo-native-alignment/pull/705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->