### PR TITLE
Deduplicate repo-map and make ADR compile idempotent

### DIFF
--- a/.oh/adr-validation/004-operation-report-telemetry.json
+++ b/.oh/adr-validation/004-operation-report-telemetry.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "004-operation-report-telemetry",
-  "title": "ADR-004: OperationReport telemetry control plane",
+  "title": "OperationReport telemetry control plane",
   "status": "implemented",
   "source": "docs/ADRs/004-operation-report-telemetry.md",
   "validate": {

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -12,4 +12,4 @@ repo-native-alignment adr validate --repo .
 | [001](001-event-bus-extraction-pipeline.md) | RNA Event Bus Architecture | Implemented |
 | [002](002-arcswap-graph-concurrency.md) | ArcSwap for Graph Concurrency | Implementing |
 | [003](003-durable-enrichment-control-plane.md) | Durable Enrichment Control Plane | Implementing |
-| [004](004-operation-report-telemetry.md) | ADR-004: OperationReport telemetry control plane | Implemented |
+| [004](004-operation-report-telemetry.md) | OperationReport telemetry control plane | Implemented |

--- a/src/adr.rs
+++ b/src/adr.rs
@@ -607,7 +607,7 @@ fn parse_adr(repo_root: &Path, path: &Path, raw: &str) -> Result<ParsedAdr> {
         );
     }
 
-    let title = extract_title(&parsed.content)
+    let title = extract_title(&parsed.content, &frontmatter.id)
         .with_context(|| format!("extracting title from {}", path.display()))?;
 
     let validate = AdrValidationRefs {
@@ -932,17 +932,32 @@ fn collect_rust_files(dir: &Path) -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
-fn extract_title(body: &str) -> Result<String> {
+fn extract_title(body: &str, adr_id: &str) -> Result<String> {
     for line in body.lines() {
         let trimmed = line.trim();
         if let Some(rest) = trimmed.strip_prefix("# ") {
-            let title = rest.trim();
+            let title = normalize_adr_heading_title(rest.trim(), adr_id);
             if !title.is_empty() {
-                return Ok(title.to_string());
+                return Ok(title);
             }
         }
     }
     bail!("ADR body is missing a level-1 heading")
+}
+
+fn normalize_adr_heading_title(title: &str, adr_id: &str) -> String {
+    let number = adr_id.split('-').next().unwrap_or(adr_id);
+    let dashed = format!("ADR-{}:", number);
+    let spaced = format!("ADR {}:", number);
+    for prefix in [dashed.as_str(), spaced.as_str()] {
+        if let Some(rest) = title.strip_prefix(prefix) {
+            let normalized = rest.trim();
+            if !normalized.is_empty() {
+                return normalized.to_string();
+            }
+        }
+    }
+    title.to_string()
 }
 
 fn normalize_repo_paths(repo_root: &Path, raw_paths: &[String], kind: &str) -> Result<Vec<String>> {
@@ -1183,6 +1198,46 @@ mod tests {
         assert!(err.to_string().contains("must match file stem"));
     }
 
+    #[test]
+    fn test_compile_normalizes_redundant_adr_title_prefix_idempotently() {
+        let tmp = TempDir::new().unwrap();
+        write_adr(
+            tmp.path(),
+            "004-operation-report-telemetry.md",
+            &sample_adr(
+                "004-operation-report-telemetry",
+                "implemented",
+                "ADR-004: OperationReport telemetry control plane",
+                "  cargo_tests: []\n",
+            ),
+        );
+        fs::write(
+            tmp.path().join("docs/ADRs/README.md"),
+            "# Architecture Decision Records\n\nThis index lists architecture decisions and their declared implementation status. ADRs may also include `validate.*` frontmatter; compile and run those executable references with:\n\n```bash\nrepo-native-alignment adr compile --repo .\nrepo-native-alignment adr validate --repo .\n```\n\n| ADR | Title | Status |\n|-----|-------|--------|\n| [004](004-operation-report-telemetry.md) | OperationReport telemetry control plane | Implemented |\n",
+        )
+        .unwrap();
+
+        let report = compile(tmp.path(), &tmp.path().join("docs/ADRs"), false).unwrap();
+        assert!(report.ok());
+        assert!(
+            !report.readme_updated,
+            "compile should not rewrite an already-normalized README"
+        );
+
+        let manifest = fs::read_to_string(
+            tmp.path()
+                .join(".oh/adr-validation/004-operation-report-telemetry.json"),
+        )
+        .unwrap();
+        assert!(manifest.contains("\"title\": \"OperationReport telemetry control plane\""));
+
+        let check_report = compile(tmp.path(), &tmp.path().join("docs/ADRs"), true).unwrap();
+        assert!(
+            check_report.ok(),
+            "second check should report no drift: {:?}",
+            check_report.drift
+        );
+    }
     #[test]
     fn test_normalize_repo_relative_path_rejects_escape() {
         let err = normalize_repo_relative_path("../outside.sh").unwrap_err();

--- a/src/service/repomap.rs
+++ b/src/service/repomap.rs
@@ -63,7 +63,15 @@ pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
                 }
             })
             .collect();
-        swi.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        swi.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.id.to_stable_id().cmp(&b.0.id.to_stable_id()))
+                .then_with(|| a.0.line_start.cmp(&b.0.line_start))
+                .then_with(|| a.0.line_end.cmp(&b.0.line_end))
+        });
+        let mut seen_identities = HashSet::new();
+        swi.retain(|(node, _)| seen_identities.insert(node.id.to_stable_id()));
         swi.truncate(params.top_n);
         if !swi.is_empty() {
             let single_root = params.root_filter.is_some();
@@ -488,6 +496,55 @@ mod tests {
             result.contains("[project-a]"),
             "Multi-root mode should show root slug prefix: {}",
             result
+        );
+    }
+
+    #[test]
+    fn test_repo_map_deduplicates_top_symbols_by_stable_identity() {
+        let mut duplicate_a = make_node("NodeKind", NodeKind::Enum, "src/graph/mod.rs");
+        duplicate_a
+            .metadata
+            .insert("importance".into(), "0.9".into());
+        duplicate_a.line_start = 10;
+        duplicate_a.line_end = 20;
+
+        let mut duplicate_b = make_node("NodeKind", NodeKind::Enum, "src/graph/mod.rs");
+        duplicate_b
+            .metadata
+            .insert("importance".into(), "0.8".into());
+        duplicate_b.line_start = 10;
+        duplicate_b.line_end = 20;
+
+        let mut distinct_same_name = make_node("NodeKind", NodeKind::Enum, "src/extract/mod.rs");
+        distinct_same_name
+            .metadata
+            .insert("importance".into(), "0.7".into());
+        distinct_same_name.line_start = 30;
+        distinct_same_name.line_end = 40;
+
+        let gs = make_graph_state(vec![duplicate_a, duplicate_b, distinct_same_name]);
+        let repo_root = PathBuf::from("/tmp/test");
+        let ctx = RepoMapContext {
+            graph_state: &gs,
+            repo_root: &repo_root,
+            lsp_status: None,
+            embed_status: None,
+        };
+        let params = RepoMapParams {
+            top_n: 15,
+            root_filter: Some("local".to_string()),
+            non_code_slugs: HashSet::new(),
+        };
+
+        let result = repo_map(&params, &ctx);
+        assert_eq!(
+            result.matches("`src/graph/mod.rs`:10-20").count(),
+            1,
+            "duplicate stable identities should be shown once: {result}"
+        );
+        assert!(
+            result.contains("`src/extract/mod.rs`:30-40"),
+            "same short name in a distinct file should remain visible: {result}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Deduplicate repo-map top symbols by stable node identity before applying the top-N cap, with deterministic tie ordering.
- Normalize redundant ADR heading prefixes such as `ADR-004:` out of compiled ADR titles.
- Update generated ADR README/manifest output for ADR-004.

Fixes #681.
Fixes #680.

## Verification

- `CARGO_TARGET_DIR=/Users/muness1/src/open-horizon-labs/rna-p2-orientation-hardening/target cargo check --lib`
- `CARGO_TARGET_DIR=/Users/muness1/src/open-horizon-labs/rna-p2-orientation-hardening/target cargo test -p repo-native-alignment service::repomap::tests -- --nocapture`
- `CARGO_TARGET_DIR=/Users/muness1/src/open-horizon-labs/rna-p2-orientation-hardening/target cargo test -p repo-native-alignment adr::tests -- --nocapture`
- `CARGO_TARGET_DIR=/Users/muness1/src/open-horizon-labs/rna-p2-orientation-hardening/target cargo build -p repo-native-alignment --bin repo-native-alignment`
- Delivery spot-check: `target/debug/repo-native-alignment repo-map --repo . --top-n 30` produced 4 top-symbol lines and 0 duplicate display identities.
- Delivery spot-check: ran `target/debug/repo-native-alignment adr compile --repo .` twice; ADR README/manifest diff hash remained stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed redundant "ADR-###:" prefix appearing in Architecture Decision Record titles.
  * Eliminated duplicate symbols from repository mapping results.

* **Improvements**
  * Enhanced repository symbol selection with deterministic ordering using multiple ranking criteria.

* **Tests**
  * Added comprehensive test coverage for ADR title normalization behavior.
  * Added test coverage for symbol deduplication in repository mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-horizon-labs/repo-native-alignment/pull/706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->