### PR TITLE
Draft: Add repo-local knowledge graph extension slice

### DIFF
--- a/.oh/metis/local-knowledge-graph-slice.md
+++ b/.oh/metis/local-knowledge-graph-slice.md
@@ -1,0 +1,21 @@
+---
+title: Local knowledge graph slice
+date: 2026-06-26
+outcome: context-assembly
+---
+
+# Local Knowledge Graph Slice
+
+The first experimental RNA local-knowledge graph slice should extend graph mechanics, not hardcode domain ontology.
+
+Implementation learning:
+
+- `NodeKind::Other(String)` was already enough for repo-local/domain-specific node kinds.
+- `EdgeKind` needed the same escape hatch: repo-local relationships must survive as true edges, not metadata.
+- Persist/load was the risk point because LanceDB stores `edge_type` as a string but unknown strings were previously dropped by `parse_edge_kind`.
+- A minimal source-first convention works for the first slice: markdown YAML frontmatter can declare `rna.kind`, `rna.id`, optional metadata, and relationships to other local knowledge nodes.
+- The fixture that matters is not just node creation. It must answer a review question: what supports this claim, and which manuscript node consumes it?
+
+Guardrail reinforced:
+
+Do not add book-specific concepts such as `Quote`, `Claim`, `Chapter`, or `Supports` as RNA core enum variants. Keep vocabulary local; keep graph persistence/traversal/search mechanics generic.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -217,6 +217,10 @@ Key metadata keys stored in `Node.metadata` (all optional):
 | `diagnostic_message` | Full diagnostic text |
 | `http_method` | For `NodeKind::ApiEndpoint` nodes |
 | `http_path` | HTTP path for API endpoint nodes (full path after router prefix resolution) |
+| `local_knowledge` | `"true"` for repo-local knowledge nodes emitted from markdown `rna` frontmatter |
+| `rna.kind` | Repo-local knowledge kind declared in markdown frontmatter (for example `quote`, `claim`, `manuscript_section`) |
+| `rna.id` | Repo-local stable knowledge ID |
+| `rna.name` | Human-readable local knowledge label |
 | `http_path_local` | Original local path fragment before router prefix concatenation (e.g., `"/list"` when a FastAPI `APIRouter(prefix="/orders")` is applied) — set once on first prefix application; subsequent applications read this value instead of re-prefixing |
 
 ### NodeKind
@@ -287,6 +291,7 @@ The stable edge ID is `from_stable_id->kind->to_stable_id`. Edges are directiona
 | `UsesFramework` | `uses_framework` | subsystem/symbol → framework node | A subsystem or symbol uses a detected framework |
 | `Produces` | `produces` | producer → channel | A symbol/handler produces events to a channel/topic |
 | `Consumes` | `consumes` | consumer → channel | A symbol/handler consumes events from a channel/topic |
+| `Other(String)` | custom label | repo-local | Repo-local/domain-specific relationship kind that is not hardcoded in RNA core |
 
 **PageRank weights by edge kind** (used for importance scoring):
 
@@ -297,6 +302,7 @@ The stable edge ID is `from_stable_id->kind->to_stable_id`. Edges are directiona
 | DependsOn, ReferencedBy, References | 0.5 |
 | TestedBy, BelongsTo, ReExports, ConnectsTo | 0.2–0.3 |
 | Produces, Consumes | 0.4 |
+| Other(_) | 0.3 default until a relationship registry supplies a more specific weight |
 | Defines, HasField, UsesFramework | 0.1 |
 | Evolves, TopologyBoundary, Modified, Affected, Serves | 0.05 |
 

--- a/docs/extractors.md
+++ b/docs/extractors.md
@@ -9,12 +9,13 @@ This document covers how to add new extraction capability — whether that is a 
 ## Table of Contents
 
 1. [Decision tree](#decision-tree)
-2. [Approach 1: Built-in framework extractor (Rust)](#approach-1-built-in-framework-extractor-rust)
-3. [Approach 2: Custom config extractor (.oh/extractors/*.toml)](#approach-2-custom-config-extractor-ohextractorstoml)
-4. [Approach 3: Framework detection rules](#approach-3-framework-detection-rules)
-5. [How to test an extractor](#how-to-test-an-extractor)
-6. [Known limitations](#known-limitations)
-7. [Language extractor reference](#language-extractor-reference)
+2. [Repo-local knowledge declarations](#repo-local-knowledge-declarations)
+3. [Approach 1: Built-in framework extractor (Rust)](#approach-1-built-in-framework-extractor-rust)
+4. [Approach 2: Custom config extractor (.oh/extractors/*.toml)](#approach-2-custom-config-extractor-ohextractorstoml)
+5. [Approach 3: Framework detection rules](#approach-3-framework-detection-rules)
+6. [How to test an extractor](#how-to-test-an-extractor)
+7. [Known limitations](#known-limitations)
+8. [Language extractor reference](#language-extractor-reference)
 
 ---
 
@@ -34,6 +35,45 @@ Do you just want RNA to recognise a framework from imports (no edges yet)?
 ```
 
 **Rule of thumb:** start with Approach 2 (config file). Promote to Approach 1 (built-in Rust pass) only when the pattern is common enough to include in RNA itself and requires more logic than TOML can express (e.g., the KafkaJS `{topic: "..."}` object-literal extraction).
+
+## Repo-local knowledge declarations
+
+Markdown files can opt into repo-local knowledge graph extraction by adding an `rna` object to YAML frontmatter. This is intentionally source-first: the human-editable artifact remains the source of truth, and RNA compiles the declared node and relationships into the same graph as code, markdown sections, `.oh/` artifacts, and framework boundaries.
+
+Use this for local/domain knowledge such as quote/source ledgers, claims/facts, manuscript sections, review decisions, or other repo-specific primitives. Do **not** hardcode these domain concepts into RNA core enums; they are emitted as `NodeKind::Other(<kind>)` and `EdgeKind::Other(<relationship>)`.
+
+Example:
+
+```markdown
+---
+rna:
+  kind: quote
+  id: quote.goodhart
+  name: Goodhart quote
+  metadata:
+    public_use: verified
+  relationships:
+    - kind: supports
+      confidence: confirmed
+      target:
+        kind: claim
+        id: claim.proxy-risk
+        file: .oh/knowledge/proxy-risk.md
+---
+
+# Goodhart Source
+
+When a measure becomes a target, it ceases to be a good measure.
+```
+
+This emits:
+
+- one `NodeKind::Other("quote")` node for `quote.goodhart`;
+- one `EdgeKind::Other("supports")` edge from `quote.goodhart` to `claim.proxy-risk`;
+- metadata keys such as `local_knowledge=true`, `rna.kind`, `rna.id`, `rna.name`, and `rna.metadata.public_use`.
+
+The target node does not need to be in the same file, but its `kind`, `id`, and `file` should match the artifact that declares it so traversal/search can join the graph after all files are scanned. Relationship labels are true edge kinds after reload; do not collapse support/verification/review semantics into `References`, `DependsOn`, or metadata.
+
 
 ---
 

--- a/src/extract/extractor_config.rs
+++ b/src/extract/extractor_config.rs
@@ -107,14 +107,8 @@ pub struct Boundary {
 
 impl Boundary {
     /// Resolve the declared `edge_kind` string to an `EdgeKind`.
-    ///
-    /// Returns `None` for unrecognized values.
     fn resolved_edge_kind(&self) -> Option<EdgeKind> {
-        match self.edge_kind.as_str() {
-            "Produces" => Some(EdgeKind::Produces),
-            "Consumes" => Some(EdgeKind::Consumes),
-            _ => None,
-        }
+        EdgeKind::from_label(&self.edge_kind)
     }
 }
 

--- a/src/extract/markdown.rs
+++ b/src/extract/markdown.rs
@@ -834,7 +834,12 @@ fn parse_markdown_file_from_source(source: &str, path: &Path) -> Vec<crate::type
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extract::ExtractorRegistry;
     use crate::graph::{Confidence, EdgeKind, ExtractionSource, Node, NodeId, NodeKind};
+    use crate::scanner::Scanner;
+    use crate::server::store::{load_graph_from_lance, persist_graph_to_lance};
+    use crate::service::{SearchContext, SearchParams, search};
+    use std::collections::HashSet;
     use std::path::Path;
 
     #[test]
@@ -939,6 +944,147 @@ When a measure becomes a target, it ceases to be a good measure.
         assert_eq!(edge.to.name, "claim.proxy-risk");
         assert!(matches!(&edge.to.kind, NodeKind::Other(kind) if kind == "claim"));
         assert_eq!(edge.confidence, Confidence::Confirmed);
+    }
+
+    #[tokio::test]
+    async fn test_local_knowledge_scan_persist_load_search_answers_claim_support_question() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let root = repo.path();
+        std::fs::create_dir_all(root.join(".oh/sources")).expect("create sources dir");
+        std::fs::create_dir_all(root.join(".oh/knowledge")).expect("create knowledge dir");
+        std::fs::create_dir_all(root.join("manuscript")).expect("create manuscript dir");
+
+        std::fs::write(
+            root.join(".oh/sources/goodhart.md"),
+            r#"---
+rna:
+  kind: quote
+  id: quote.goodhart
+  name: Goodhart quote
+  metadata:
+    public_use: verified
+    source_url: https://example.test/goodhart
+  relationships:
+    - kind: supports
+      confidence: confirmed
+      target:
+        kind: claim
+        id: claim.proxy-risk
+        file: .oh/knowledge/proxy-risk.md
+---
+
+# Goodhart Source
+
+When a measure becomes a target, it ceases to be a good measure.
+"#,
+        )
+        .expect("write source artifact");
+        std::fs::write(
+            root.join(".oh/knowledge/proxy-risk.md"),
+            r#"---
+rna:
+  kind: claim
+  id: claim.proxy-risk
+  name: Proxy metrics become risky when treated as targets
+---
+
+# Proxy Risk Claim
+
+Proxy metrics become unreliable when the organization optimizes the proxy rather than the underlying outcome.
+"#,
+        )
+        .expect("write claim artifact");
+        std::fs::write(
+            root.join("manuscript/chapter-01.md"),
+            r#"---
+rna:
+  kind: manuscript_section
+  id: manuscript.chapter-01.proxy-risk
+  name: Chapter 1 proxy-risk section
+  relationships:
+    - kind: consumes
+      confidence: confirmed
+      target:
+        kind: claim
+        id: claim.proxy-risk
+        file: .oh/knowledge/proxy-risk.md
+---
+
+# Chapter 1
+
+The manuscript uses the proxy-risk claim in the opening argument.
+"#,
+        )
+        .expect("write manuscript artifact");
+
+        let mut scanner = Scanner::new(root.to_path_buf()).expect("create scanner");
+        let scan = scanner.scan().expect("scan local knowledge corpus");
+        let extraction = ExtractorRegistry::with_builtins().extract_scan_result(root, &scan);
+
+        persist_graph_to_lance(root, &extraction.nodes, &extraction.edges)
+            .await
+            .expect("persist graph");
+        let loaded = load_graph_from_lance(root).await.expect("load graph");
+
+        let claim = loaded
+            .nodes
+            .iter()
+            .find(|node| node.id.name == "claim.proxy-risk")
+            .expect("claim node should survive scan/persist/load");
+        let quote = loaded
+            .nodes
+            .iter()
+            .find(|node| node.id.name == "quote.goodhart")
+            .expect("quote node should survive scan/persist/load");
+        assert_eq!(
+            quote.metadata.get("rna.metadata.public_use"),
+            Some(&"verified".to_string()),
+            "quote public-use verification must remain queryable as source metadata"
+        );
+
+        let supports = loaded.index.neighbors(
+            &claim.stable_id(),
+            Some(&[EdgeKind::Other("supports".to_string())]),
+            petgraph::Direction::Incoming,
+        );
+        assert_eq!(
+            supports,
+            vec![quote.stable_id()],
+            "claim support must be a real incoming custom edge, not metadata or a generic reference"
+        );
+
+        let ctx = SearchContext {
+            graph_state: &loaded,
+            embed_index: None,
+            repo_root: root,
+            lsp_status: None,
+            embed_status: None,
+            root_filter: None,
+            non_code_slugs: HashSet::new(),
+            enrichment_jobs: Vec::new(),
+        };
+        let answer = search(
+            &SearchParams {
+                node: Some(claim.stable_id()),
+                mode: Some("neighbors".to_string()),
+                direction: Some("incoming".to_string()),
+                edge_types: Some(vec!["supports".to_string(), "consumes".to_string()]),
+                compact: true,
+                ..Default::default()
+            },
+            &ctx,
+        )
+        .await;
+
+        assert!(
+            answer.contains("#### Supports (1)") && answer.contains("quote.goodhart"),
+            "search should answer what supports the claim: {answer}"
+        );
+        assert!(
+            answer.contains("#### Consumes (1)")
+                && answer.contains("manuscript.chapter-01.proxy-risk"),
+            "search should answer which manuscript node consumes the claim: {answer}"
+        );
     }
 
     #[test]

--- a/src/extract/markdown.rs
+++ b/src/extract/markdown.rs
@@ -3,16 +3,18 @@
 //! Reuses the existing `pulldown-cmark` parsing from `src/markdown/mod.rs`
 //! but produces graph `Node` types for the unified graph model.
 //!
-//! Emits four kinds of edges:
+//! Emits five kinds of edges:
 //! - **Hierarchy (Defines):** parent heading section -> child heading section
 //! - **Frontmatter refs (DependsOn):** .oh/ artifact -> referenced outcome/signal/guardrail
 //! - **Cross-file links (References):** section containing `[text](path)` -> target file
 //! - **ADR validation links (References):** ADR section -> exact test function declared in frontmatter
+//! - **Local knowledge relationships:** optional `rna` frontmatter nodes and custom relationship edges
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use serde::Deserialize;
 
 use crate::graph::{Confidence, Edge, EdgeKind, ExtractionSource, Node, NodeId, NodeKind};
 
@@ -171,6 +173,9 @@ impl Extractor for MarkdownExtractor {
 
         // 3. Cross-file link edges: section -> target file (References)
         emit_link_edges(&nodes, &chunks, path, &mut edges);
+
+        // 4. Local knowledge graph declarations: human-editable frontmatter -> custom nodes/edges.
+        emit_local_knowledge_graph(path, content, &mut nodes, &mut edges);
 
         Ok(ExtractionResult { nodes, edges })
     }
@@ -413,8 +418,7 @@ pub fn adr_validation_pass(all_nodes: &[Node]) -> Vec<Edge> {
             .unwrap_or(&node.id);
 
         for cargo_test in frontmatter.cargo_tests {
-            let Some(matches) =
-                rust_tests.get(&(source_id.root.as_str(), cargo_test.as_str()))
+            let Some(matches) = rust_tests.get(&(source_id.root.as_str(), cargo_test.as_str()))
             else {
                 continue;
             };
@@ -532,6 +536,183 @@ fn normalize_path(path: &Path) -> PathBuf {
     components.iter().collect()
 }
 
+#[derive(Debug, Deserialize)]
+struct LocalKnowledgeFrontmatter {
+    rna: Option<LocalKnowledgeNodeSpec>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LocalKnowledgeNodeSpec {
+    kind: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    relationships: Vec<LocalKnowledgeRelationship>,
+    #[serde(default)]
+    metadata: BTreeMap<String, serde_yaml::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LocalKnowledgeRelationship {
+    kind: String,
+    target: LocalKnowledgeTarget,
+    #[serde(default)]
+    confidence: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LocalKnowledgeTarget {
+    kind: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    file: Option<String>,
+}
+
+fn emit_local_knowledge_graph(
+    path: &Path,
+    content: &str,
+    nodes: &mut Vec<Node>,
+    edges: &mut Vec<Edge>,
+) {
+    let Some(yaml_block) = extract_frontmatter_yaml(content) else {
+        return;
+    };
+    let Ok(frontmatter) = serde_yaml::from_str::<LocalKnowledgeFrontmatter>(yaml_block) else {
+        return;
+    };
+    let Some(spec) = frontmatter.rna else {
+        return;
+    };
+
+    let Some(local_id) = spec.id.as_deref().or(spec.name.as_deref()).map(str::trim) else {
+        return;
+    };
+    if local_id.is_empty() || spec.kind.trim().is_empty() {
+        return;
+    }
+
+    let display_name = spec.name.as_deref().unwrap_or(local_id).trim();
+    let node_id = local_knowledge_node_id(path, spec.kind.trim(), local_id);
+    let mut metadata = BTreeMap::new();
+    metadata.insert("local_knowledge".to_string(), "true".to_string());
+    metadata.insert("rna.kind".to_string(), spec.kind.trim().to_string());
+    metadata.insert("rna.id".to_string(), local_id.to_string());
+    metadata.insert("rna.name".to_string(), display_name.to_string());
+    metadata.insert("rna.source_file".to_string(), path.display().to_string());
+    for (key, value) in spec.metadata {
+        metadata.insert(
+            format!("rna.metadata.{}", key),
+            yaml_value_to_string(&value),
+        );
+    }
+
+    let line_end = content.lines().count().max(1);
+    nodes.push(Node {
+        id: node_id.clone(),
+        language: "markdown".to_string(),
+        line_start: 1,
+        line_end,
+        signature: format!("{} {}", spec.kind.trim(), display_name),
+        body: strip_frontmatter(content).trim().to_string(),
+        metadata,
+        source: ExtractionSource::Markdown,
+    });
+
+    for relationship in spec.relationships {
+        let Some(kind) = EdgeKind::from_label(&relationship.kind) else {
+            continue;
+        };
+        if relationship.target.kind.trim().is_empty() {
+            continue;
+        }
+        let Some(target_id) = relationship
+            .target
+            .id
+            .as_deref()
+            .or(relationship.target.name.as_deref())
+            .map(str::trim)
+        else {
+            continue;
+        };
+        if target_id.is_empty() {
+            continue;
+        }
+
+        let target_file = relationship
+            .target
+            .file
+            .as_deref()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| path.to_path_buf());
+        let target_node =
+            local_knowledge_node_id(&target_file, relationship.target.kind.trim(), target_id);
+        let confidence = parse_local_knowledge_confidence(relationship.confidence.as_deref());
+        edges.push(Edge {
+            from: node_id.clone(),
+            to: target_node,
+            kind,
+            source: ExtractionSource::Markdown,
+            confidence,
+        });
+    }
+}
+
+fn local_knowledge_node_id(path: &Path, kind: &str, id: &str) -> NodeId {
+    NodeId {
+        root: String::new(),
+        file: path.to_path_buf(),
+        name: id.to_string(),
+        kind: NodeKind::Other(kind.to_string()),
+    }
+}
+
+fn parse_local_knowledge_confidence(value: Option<&str>) -> Confidence {
+    match value.map(str::trim) {
+        Some("confirmed") => Confidence::Confirmed,
+        _ => Confidence::Detected,
+    }
+}
+
+fn extract_frontmatter_yaml(content: &str) -> Option<&str> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return None;
+    }
+    let after_first = trimmed[3..].trim_start_matches(['\r', '\n']);
+    let end_idx = after_first.find("\n---")?;
+    Some(&after_first[..end_idx])
+}
+
+fn strip_frontmatter(content: &str) -> &str {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return content;
+    }
+    let after_first = trimmed[3..].trim_start_matches(['\r', '\n']);
+    let Some(end_idx) = after_first.find("\n---") else {
+        return content;
+    };
+    after_first[end_idx + 4..].trim_start_matches(['\r', '\n'])
+}
+
+fn yaml_value_to_string(value: &serde_yaml::Value) -> String {
+    match value {
+        serde_yaml::Value::Null => String::new(),
+        serde_yaml::Value::Bool(value) => value.to_string(),
+        serde_yaml::Value::Number(value) => value.to_string(),
+        serde_yaml::Value::String(value) => value.clone(),
+        _ => serde_yaml::to_string(value)
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+    }
+}
+
 /// Detect the artifact kind for a markdown file based on its path.
 ///
 /// Handles two families of paths:
@@ -541,6 +722,7 @@ fn normalize_path(path: &Path) -> PathBuf {
 /// - `signals` → `"signal"`
 /// - `guardrails` → `"guardrail"`
 /// - `metis` → `"metis"`
+/// - `knowledge` → `"knowledge"`
 ///
 /// **Agent memory files** — detects common AI agent rule/memory locations:
 /// - `.cursorrules` (file in repo root) → `"cursor-rule"`
@@ -567,6 +749,7 @@ fn detect_oh_kind(path: &Path) -> Option<String> {
                 "signals" => Some("signal".to_string()),
                 "guardrails" => Some("guardrail".to_string()),
                 "metis" => Some("metis".to_string()),
+                "knowledge" => Some("knowledge".to_string()),
                 _ => None,
             };
         }
@@ -651,7 +834,7 @@ fn parse_markdown_file_from_source(source: &str, path: &Path) -> Vec<crate::type
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::graph::{ExtractionSource, Node, NodeId, NodeKind};
+    use crate::graph::{Confidence, EdgeKind, ExtractionSource, Node, NodeId, NodeKind};
     use std::path::Path;
 
     #[test]
@@ -703,6 +886,59 @@ mod tests {
             first.metadata.get("frontmatter.title"),
             Some(&"Test Outcome".to_string())
         );
+    }
+
+    #[test]
+    fn test_markdown_local_knowledge_frontmatter_emits_custom_node_and_edge() {
+        let extractor = MarkdownExtractor::new();
+        let content = r#"---
+rna:
+  kind: quote
+  id: quote.goodhart
+  name: Goodhart quote
+  metadata:
+    public_use: verified
+  relationships:
+    - kind: supports
+      confidence: confirmed
+      target:
+        kind: claim
+        id: claim.proxy-risk
+        file: .oh/knowledge/proxy-risk.md
+---
+
+# Goodhart Source
+
+When a measure becomes a target, it ceases to be a good measure.
+"#;
+        let result = extractor
+            .extract(Path::new(".oh/sources/goodhart.md"), content)
+            .unwrap();
+
+        let quote = result
+            .nodes
+            .iter()
+            .find(|node| matches!(&node.id.kind, NodeKind::Other(kind) if kind == "quote"))
+            .expect("quote local knowledge node should be emitted");
+        assert_eq!(quote.id.name, "quote.goodhart");
+        assert_eq!(
+            quote.metadata.get("local_knowledge"),
+            Some(&"true".to_string())
+        );
+        assert_eq!(
+            quote.metadata.get("rna.metadata.public_use"),
+            Some(&"verified".to_string())
+        );
+
+        let edge = result
+            .edges
+            .iter()
+            .find(|edge| edge.kind == EdgeKind::Other("supports".to_string()))
+            .expect("custom supports edge should be emitted as a true edge kind");
+        assert_eq!(edge.from.name, "quote.goodhart");
+        assert_eq!(edge.to.name, "claim.proxy-risk");
+        assert!(matches!(&edge.to.kind, NodeKind::Other(kind) if kind == "claim"));
+        assert_eq!(edge.confidence, Confidence::Confirmed);
     }
 
     #[test]
@@ -1597,10 +1833,7 @@ mod tests {
                     line_end: 4,
                     signature: "[frontmatter]".to_string(),
                     body: "validate:\n  cargo_tests:\n    - mymod::tests::test_thing\n".to_string(),
-                    metadata: BTreeMap::from([(
-                        "is_frontmatter".to_string(),
-                        "true".to_string(),
-                    )]),
+                    metadata: BTreeMap::from([("is_frontmatter".to_string(), "true".to_string())]),
                     source: ExtractionSource::Markdown,
                 },
                 Node {
@@ -1722,7 +1955,6 @@ mod tests {
         }
     }
 
-    
     #[test]
     fn timing_smoke_adr_passes_100k_nodes() {
         use std::time::Instant;
@@ -1812,7 +2044,11 @@ mod tests {
         let elapsed = start.elapsed();
 
         assert_eq!(forward.len(), 1, "forward pass must produce exactly 1 edge");
-        assert_eq!(backward.len(), 1, "backward pass must produce exactly 1 edge");
+        assert_eq!(
+            backward.len(),
+            1,
+            "backward pass must produce exactly 1 edge"
+        );
         // Print elapsed for visibility but do not assert on it; wall-clock is
         // CI-flaky and the budget is enforced via the regression test in
         // `crate::extract::consumers::tests::adr_passes_timing_regression`.

--- a/src/graph/index.rs
+++ b/src/graph/index.rs
@@ -49,6 +49,8 @@ fn edge_weight(kind: &EdgeKind) -> f64 {
         EdgeKind::UsesFramework => 0.1,
         // Pub/sub edges carry moderate signal (async coupling)
         EdgeKind::Produces | EdgeKind::Consumes => 0.4,
+        // Repo-local relationship edges carry moderate default signal until a registry supplies weights.
+        EdgeKind::Other(_) => 0.3,
     }
 }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -183,6 +183,8 @@ pub enum EdgeKind {
     /// A symbol/handler consumes events from a channel/topic.
     /// Direction: consumer → channel
     Consumes,
+    /// A repo-local/domain-specific relationship kind declared outside RNA core.
+    Other(String),
 }
 
 impl fmt::Display for EdgeKind {
@@ -207,7 +209,45 @@ impl fmt::Display for EdgeKind {
             EdgeKind::UsesFramework => write!(f, "uses_framework"),
             EdgeKind::Produces => write!(f, "produces"),
             EdgeKind::Consumes => write!(f, "consumes"),
+            EdgeKind::Other(kind) => write!(f, "{}", kind),
         }
+    }
+}
+
+impl EdgeKind {
+    /// Parse a persisted or user-supplied edge label.
+    ///
+    /// Built-in labels preserve their typed variants. Any other non-empty label becomes
+    /// `Other(label)`, which lets repo-local relationship kinds survive persistence,
+    /// traversal, and search without hardcoding domain vocabulary in RNA core.
+    pub fn from_label(label: &str) -> Option<Self> {
+        let trimmed = label.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        Some(match trimmed {
+            "calls" => EdgeKind::Calls,
+            "implements" => EdgeKind::Implements,
+            "depends_on" => EdgeKind::DependsOn,
+            "connects_to" => EdgeKind::ConnectsTo,
+            "defines" => EdgeKind::Defines,
+            "has_field" => EdgeKind::HasField,
+            "evolves" => EdgeKind::Evolves,
+            "referenced_by" => EdgeKind::ReferencedBy,
+            "references" => EdgeKind::References,
+            "topology_boundary" => EdgeKind::TopologyBoundary,
+            "modified" => EdgeKind::Modified,
+            "affected" => EdgeKind::Affected,
+            "serves" => EdgeKind::Serves,
+            "tested_by" => EdgeKind::TestedBy,
+            "belongs_to" => EdgeKind::BelongsTo,
+            "re_exports" => EdgeKind::ReExports,
+            "uses_framework" => EdgeKind::UsesFramework,
+            "produces" | "Produces" => EdgeKind::Produces,
+            "consumes" | "Consumes" => EdgeKind::Consumes,
+            other => EdgeKind::Other(other.to_string()),
+        })
     }
 }
 

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -14,7 +14,7 @@ use arrow_schema::{DataType, Field, Schema};
 /// The server auto-drops and rebuilds all LanceDB tables when this mismatches
 /// the stored version. No manual cache deletion needed.
 /// Also surfaced in the index freshness footer on `search`.
-pub const SCHEMA_VERSION: u32 = 21; // persist attr_refs for import_calls_pass Step 6 on incremental scans
+pub const SCHEMA_VERSION: u32 = 22; // persist generic metadata for repo-local knowledge nodes
 
 /// Arrow schema for the `symbols` table.
 ///
@@ -90,6 +90,10 @@ pub fn symbols_schema() -> Schema {
         Field::new("parent_service", DataType::Utf8, true), // metadata["parent_service"] — owning service name
         Field::new("rpc_request_type", DataType::Utf8, true), // metadata["request_type"] — proto request message
         Field::new("rpc_response_type", DataType::Utf8, true), // metadata["response_type"] — proto response message
+        // Generic metadata JSON — persists repo-local/custom metadata keys that are
+        // not represented by typed Arrow columns. Typed metadata remains in dedicated
+        // columns for query/type stability; this column preserves extensibility.
+        Field::new("metadata_json", DataType::Utf8, true),
         // Vector column is added dynamically when embeddings are computed,
         // since the dimension depends on the model. See `symbols_schema_with_vector`.
         Field::new("updated_at", DataType::Int64, false),
@@ -151,6 +155,9 @@ pub fn symbols_schema_with_vector(dim: i32) -> Schema {
         Field::new("parent_service", DataType::Utf8, true),
         Field::new("rpc_request_type", DataType::Utf8, true),
         Field::new("rpc_response_type", DataType::Utf8, true),
+        // Generic metadata JSON — persists repo-local/custom metadata keys not represented
+        // by typed Arrow columns.
+        Field::new("metadata_json", DataType::Utf8, true),
         Field::new(
             "vector",
             DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),

--- a/src/server/store/batch.rs
+++ b/src/server/store/batch.rs
@@ -10,6 +10,23 @@ use crate::graph::store::{edges_schema, symbols_schema};
 use crate::graph::{Edge, Node};
 use crate::server::store::metadata_keys as mk;
 
+fn generic_metadata_json(
+    metadata: &std::collections::BTreeMap<String, String>,
+) -> anyhow::Result<Option<String>> {
+    let extra: std::collections::BTreeMap<_, _> = metadata
+        .iter()
+        .filter(|(key, _)| !mk::TYPED_KEYS.contains(&key.as_str()))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+    if extra.is_empty() {
+        Ok(None)
+    } else {
+        serde_json::to_string(&extra)
+            .map(Some)
+            .map_err(anyhow::Error::from)
+    }
+}
+
 /// Build a symbols `RecordBatch` for `nodes` tagged with `scan_version`.
 pub(super) fn build_symbols_batch(
     nodes: &[Node],
@@ -204,6 +221,10 @@ pub(super) fn build_symbols_batch(
         .iter()
         .map(|n| n.metadata.get(mk::RESPONSE_TYPE).cloned())
         .collect();
+    let metadata_jsons: Vec<Option<String>> = nodes
+        .iter()
+        .map(|n| generic_metadata_json(&n.metadata))
+        .collect::<anyhow::Result<_>>()?;
     let updated_ats: Vec<i64> = vec![now; nodes.len()];
     let scan_versions: Vec<u64> = vec![scan_version; nodes.len()];
 
@@ -251,6 +272,7 @@ pub(super) fn build_symbols_batch(
             Arc::new(StringArray::from(parent_services)),
             Arc::new(StringArray::from(rpc_request_types)),
             Arc::new(StringArray::from(rpc_response_types)),
+            Arc::new(StringArray::from(metadata_jsons)),
             Arc::new(Int64Array::from(updated_ats)),
             Arc::new(UInt64Array::from(scan_versions)),
         ],

--- a/src/server/store/load.rs
+++ b/src/server/store/load.rs
@@ -118,6 +118,9 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 .as_any()
                 .downcast_ref::<StringArray>()
                 .unwrap();
+            let metadata_json_col = batch
+                .column_by_name("metadata_json")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
             // Typed metadata columns -- Arrow type safety, no JSON blobs for known fields.
             let meta_virtual_col = batch
                 .column_by_name("meta_virtual")
@@ -229,6 +232,21 @@ pub async fn load_graph_from_lance(repo_root: &Path) -> anyhow::Result<GraphStat
                 let file_path = PathBuf::from(file_paths.value(i));
                 let language = infer_language_from_path(&file_path);
                 let mut metadata: BTreeMap<String, String> = BTreeMap::new();
+                if let Some(col) = metadata_json_col
+                    && !col.is_null(i)
+                {
+                    let raw = col.value(i);
+                    if !raw.is_empty() {
+                        match serde_json::from_str::<BTreeMap<String, String>>(raw) {
+                            Ok(extra) => metadata.extend(extra),
+                            Err(err) => tracing::warn!(
+                                "load_graph_from_lance: ignoring invalid metadata_json for {}: {}",
+                                file_path.display(),
+                                err
+                            ),
+                        }
+                    }
+                }
                 if let Some(col) = meta_virtual_col
                     && !col.is_null(i)
                     && col.value(i)

--- a/src/server/store/metadata_keys.rs
+++ b/src/server/store/metadata_keys.rs
@@ -56,3 +56,38 @@ pub const HTTP_PATH: &str = "http_path";
 pub const PARENT_SERVICE: &str = "parent_service";
 pub const REQUEST_TYPE: &str = "request_type";
 pub const RESPONSE_TYPE: &str = "response_type";
+
+pub const TYPED_KEYS: &[&str] = &[
+    VIRTUAL,
+    PACKAGE,
+    NAME_COL,
+    VALUE,
+    SYNTHETIC,
+    CYCLOMATIC,
+    IMPORTANCE,
+    STORAGE,
+    MUTABLE,
+    DECORATORS,
+    PARENT_SCOPE,
+    PARENT_SCOPE_KIND,
+    FRAMEWORK_HOOK,
+    TYPE_PARAMS,
+    PATTERN_HINT,
+    IS_STATIC,
+    IS_ASYNC,
+    IS_TEST,
+    VISIBILITY,
+    EXPORTED,
+    DOC_COMMENT,
+    ATTR_REFS,
+    DIAG_SEVERITY,
+    DIAG_SOURCE,
+    DIAG_MESSAGE,
+    DIAG_RANGE,
+    DIAG_TIMESTAMP,
+    HTTP_METHOD,
+    HTTP_PATH,
+    PARENT_SERVICE,
+    REQUEST_TYPE,
+    RESPONSE_TYPE,
+];

--- a/src/server/store/mod.rs
+++ b/src/server/store/mod.rs
@@ -65,28 +65,7 @@ pub(crate) fn parse_node_kind(s: &str) -> NodeKind {
 
 /// Parse an EdgeKind from its string representation.
 pub fn parse_edge_kind(s: &str) -> Option<EdgeKind> {
-    Some(match s {
-        "calls" => EdgeKind::Calls,
-        "implements" => EdgeKind::Implements,
-        "depends_on" => EdgeKind::DependsOn,
-        "connects_to" => EdgeKind::ConnectsTo,
-        "defines" => EdgeKind::Defines,
-        "has_field" => EdgeKind::HasField,
-        "evolves" => EdgeKind::Evolves,
-        "referenced_by" => EdgeKind::ReferencedBy,
-        "references" => EdgeKind::References,
-        "topology_boundary" => EdgeKind::TopologyBoundary,
-        "modified" => EdgeKind::Modified,
-        "affected" => EdgeKind::Affected,
-        "serves" => EdgeKind::Serves,
-        "tested_by" => EdgeKind::TestedBy,
-        "belongs_to" => EdgeKind::BelongsTo,
-        "re_exports" => EdgeKind::ReExports,
-        "uses_framework" => EdgeKind::UsesFramework,
-        "produces" => EdgeKind::Produces,
-        "consumes" => EdgeKind::Consumes,
-        _ => return None,
-    })
+    EdgeKind::from_label(s)
 }
 
 /// Parse an ExtractionSource from its string representation.
@@ -198,5 +177,77 @@ pub(crate) fn infer_language_from_path(path: &Path) -> String {
         Some("toml") => "toml".to_string(),
         Some("yaml") | Some("yml") => "yaml".to_string(),
         _ => "unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use crate::graph::{Confidence, Edge, EdgeKind, ExtractionSource, Node, NodeId, NodeKind};
+
+    use super::{load_graph_from_lance, parse_edge_kind, persist_graph_to_lance};
+
+    fn node(kind: &str, name: &str, file: &str) -> Node {
+        Node {
+            id: NodeId {
+                root: "repo".to_string(),
+                file: PathBuf::from(file),
+                name: name.to_string(),
+                kind: NodeKind::Other(kind.to_string()),
+            },
+            language: "markdown".to_string(),
+            line_start: 1,
+            line_end: 1,
+            signature: format!("{} {}", kind, name),
+            body: String::new(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::Markdown,
+        }
+    }
+
+    #[test]
+    fn parse_edge_kind_preserves_unknown_labels_as_custom_edges() {
+        assert_eq!(parse_edge_kind("calls"), Some(EdgeKind::Calls));
+        assert_eq!(
+            parse_edge_kind("supports"),
+            Some(EdgeKind::Other("supports".to_string()))
+        );
+        assert_eq!(parse_edge_kind("  "), None);
+    }
+
+    #[tokio::test]
+    async fn custom_edge_kind_survives_persist_load_and_traversal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = node("quote", "quote.goodhart", ".oh/sources/goodhart.md");
+        let claim = node("claim", "claim.proxy-risk", ".oh/knowledge/proxy-risk.md");
+        let edge = Edge {
+            from: source.id.clone(),
+            to: claim.id.clone(),
+            kind: EdgeKind::Other("supports".to_string()),
+            source: ExtractionSource::Markdown,
+            confidence: Confidence::Confirmed,
+        };
+
+        persist_graph_to_lance(dir.path(), &[source.clone(), claim.clone()], &[edge])
+            .await
+            .expect("persist graph");
+        let state = load_graph_from_lance(dir.path()).await.expect("load graph");
+
+        assert_eq!(
+            state.edges.len(),
+            1,
+            "custom edge must not be dropped on load"
+        );
+        assert_eq!(state.edges[0].kind, EdgeKind::Other("supports".to_string()));
+        assert_eq!(state.edges[0].confidence, Confidence::Confirmed);
+
+        let neighbors = state.index.neighbors(
+            &source.stable_id(),
+            Some(&[EdgeKind::Other("supports".to_string())]),
+            petgraph::Direction::Outgoing,
+        );
+        assert_eq!(neighbors, vec![claim.stable_id()]);
     }
 }

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -2027,6 +2027,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_search_neighbors_displays_custom_edge_label() {
+        let quote = make_node(
+            "quote.goodhart",
+            NodeKind::Other("quote".to_string()),
+            ".oh/sources/goodhart.md",
+        );
+        let claim = make_node(
+            "claim.proxy-risk",
+            NodeKind::Other("claim".to_string()),
+            ".oh/knowledge/proxy-risk.md",
+        );
+        let edge = make_edge(
+            &quote,
+            &claim,
+            crate::graph::EdgeKind::Other("supports".to_string()),
+        );
+        let gs = make_graph_state_with_edges(vec![quote.clone(), claim], vec![edge]);
+        let repo_root = PathBuf::from("/tmp/test");
+        let ctx = make_search_context(&gs, &repo_root);
+        let params = SearchParams {
+            node: Some(quote.stable_id()),
+            mode: Some("neighbors".into()),
+            edge_types: Some(vec!["supports".to_string()]),
+            compact: true,
+            ..Default::default()
+        };
+
+        let result = search(&params, &ctx).await;
+
+        assert!(
+            result.contains("#### Supports (1)"),
+            "custom edge label should render: {}",
+            result
+        );
+        assert!(result.contains("claim.proxy-risk"));
+    }
+
+    #[tokio::test]
     async fn test_verbose_readiness_uses_persisted_lsp_edges_without_live_status() {
         let caller = make_node("caller", NodeKind::Function, "src/caller.rs");
         let callee = make_node("callee", NodeKind::Function, "src/callee.rs");


### PR DESCRIPTION
## Summary

Draft implementation home for the experimental RNA local-knowledge graph slice.

Selected approach from `open-horizon-labs/book` solution-space:

- keep one repo graph surface;
- add generic repo-local/custom relationship mechanics upstream in RNA;
- keep book vocabulary local to the book repo;
- prove the mechanism with one quote/source → claim/fact → manuscript section/paragraph corpus shape.

Closes #707.
Targets #708.

## Execution constraints

This PR must fail the tempting shortcuts:

- mapping `supports`/`requires_verification` onto `References` or `DependsOn`;
- storing relationship semantics only in metadata;
- hardcoding book-specific core enum variants such as `Quote`, `Claim`, `Chapter`, or `Supports`.

## Planned verification

- `cargo check --lib`
- targeted tests for custom edge persist/load/traversal/search behavior
- targeted fixture for local knowledge artifact extraction

## Notes

Draft PR created before implementation per repo workflow. This is intentionally experimental until the custom relationship mechanics and first extractor slice prove themselves.
