### PR TITLE
Support repo-local custom relationship edge kinds

### DIFF
--- a/.oh/friction-logs/710-ship.md
+++ b/.oh/friction-logs/710-ship.md
@@ -1,0 +1,13 @@
+---
+date: "2026-07-14"
+pipeline_issue: "/ship PR #710"
+pr: 710
+phase: ship
+---
+
+# PR #710 ship friction
+
+| Date | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-07-14 | RNA `search("parse_edge_kind")` | minor | Exact search returned no result for an existing function in the refreshed worktree; broader searches found only related tests and constants. | The review could not use RNA traversal for the parser and relied on the PR diff instead. | Improve indexing of private functions in refreshed worktrees. |
+| 2026-07-14 | RNA `search("test_edge_weight_values")` | minor | Exact and broader PageRank searches did not find the existing private unit test. | Used one narrow `sed`/`rg` fallback to place the independent review's required policy assertion. | Make private test functions reliably discoverable by exact name. |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -287,6 +287,7 @@ The stable edge ID is `from_stable_id->kind->to_stable_id`. Edges are directiona
 | `UsesFramework` | `uses_framework` | subsystem/symbol → framework node | A subsystem or symbol uses a detected framework |
 | `Produces` | `produces` | producer → channel | A symbol/handler produces events to a channel/topic |
 | `Consumes` | `consumes` | consumer → channel | A symbol/handler consumes events from a channel/topic |
+| `Other(String)` | repo-local label (for example, `supports`) | repo-defined | Repo-local/domain-specific relationship preserved without adding a core enum variant |
 
 **PageRank weights by edge kind** (used for importance scoring):
 
@@ -299,6 +300,7 @@ The stable edge ID is `from_stable_id->kind->to_stable_id`. Edges are directiona
 | Produces, Consumes | 0.4 |
 | Defines, HasField, UsesFramework | 0.1 |
 | Evolves, TopologyBoundary, Modified, Affected, Serves | 0.05 |
+| Other (repo-local relationship) | 0.05 |
 
 ### Confidence
 

--- a/src/graph/index.rs
+++ b/src/graph/index.rs
@@ -2172,6 +2172,9 @@ mod tests {
         assert!((edge_weight(&EdgeKind::UsesFramework) - 0.1).abs() < f64::EPSILON);
         assert!((edge_weight(&EdgeKind::Produces) - 0.4).abs() < f64::EPSILON);
         assert!((edge_weight(&EdgeKind::Consumes) - 0.4).abs() < f64::EPSILON);
+        assert!(
+            (edge_weight(&EdgeKind::Other("supports".to_string())) - 0.05).abs() < f64::EPSILON
+        );
     }
 
     // ==================== neighbors_grouped tests ====================

--- a/src/graph/index.rs
+++ b/src/graph/index.rs
@@ -49,6 +49,9 @@ fn edge_weight(kind: &EdgeKind) -> f64 {
         EdgeKind::UsesFramework => 0.1,
         // Pub/sub edges carry moderate signal (async coupling)
         EdgeKind::Produces | EdgeKind::Consumes => 0.4,
+        // Repo-local relationship semantics are unknown to RNA core; keep a conservative
+        // weak structural signal while preserving the custom label for traversal/search.
+        EdgeKind::Other(_) => 0.05,
     }
 }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -145,8 +145,7 @@ impl NodeKind {
 // ---------------------------------------------------------------------------
 
 /// The kind of relationship between two nodes.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum EdgeKind {
     Calls,
     Implements,
@@ -183,6 +182,12 @@ pub enum EdgeKind {
     /// A symbol/handler consumes events from a channel/topic.
     /// Direction: consumer → channel
     Consumes,
+    /// Repo-local/domain-specific relationship kind.
+    ///
+    /// Custom edges use the persisted edge label directly (for example,
+    /// `supports` or `requires_verification`) and intentionally share the
+    /// conservative low default PageRank weight used by weak structural edges.
+    Other(String),
 }
 
 impl fmt::Display for EdgeKind {
@@ -207,7 +212,61 @@ impl fmt::Display for EdgeKind {
             EdgeKind::UsesFramework => write!(f, "uses_framework"),
             EdgeKind::Produces => write!(f, "produces"),
             EdgeKind::Consumes => write!(f, "consumes"),
+            EdgeKind::Other(s) => write!(f, "{}", s),
         }
+    }
+}
+
+impl EdgeKind {
+    /// Parse an edge label into a built-in or repo-local edge kind.
+    pub fn from_label(s: &str) -> Option<Self> {
+        let s = s.trim();
+        if s.is_empty() {
+            return None;
+        }
+
+        Some(match s {
+            "calls" => EdgeKind::Calls,
+            "implements" => EdgeKind::Implements,
+            "depends_on" => EdgeKind::DependsOn,
+            "connects_to" => EdgeKind::ConnectsTo,
+            "defines" => EdgeKind::Defines,
+            "has_field" => EdgeKind::HasField,
+            "evolves" => EdgeKind::Evolves,
+            "referenced_by" => EdgeKind::ReferencedBy,
+            "references" => EdgeKind::References,
+            "topology_boundary" => EdgeKind::TopologyBoundary,
+            "modified" => EdgeKind::Modified,
+            "affected" => EdgeKind::Affected,
+            "serves" => EdgeKind::Serves,
+            "tested_by" => EdgeKind::TestedBy,
+            "belongs_to" => EdgeKind::BelongsTo,
+            "re_exports" => EdgeKind::ReExports,
+            "uses_framework" => EdgeKind::UsesFramework,
+            "produces" => EdgeKind::Produces,
+            "consumes" => EdgeKind::Consumes,
+            other => EdgeKind::Other(other.to_string()),
+        })
+    }
+}
+
+impl Serialize for EdgeKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for EdgeKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        EdgeKind::from_label(&s)
+            .ok_or_else(|| serde::de::Error::custom("edge kind must not be empty"))
     }
 }
 
@@ -624,6 +683,39 @@ mod tests {
             result.unwrap().name,
             "Status",
             "Should find Enum on enum declaration line"
+        );
+    }
+
+    // -- EdgeKind tests --
+
+    #[test]
+    fn test_builtin_edge_kind_json_serialization_stays_string_label() {
+        assert_eq!(
+            serde_json::to_string(&EdgeKind::DependsOn).expect("serialize built-in edge kind"),
+            "\"depends_on\""
+        );
+        assert_eq!(
+            serde_json::from_str::<EdgeKind>("\"depends_on\"")
+                .expect("deserialize built-in edge kind"),
+            EdgeKind::DependsOn
+        );
+    }
+
+    #[test]
+    fn test_custom_edge_kind_display_and_json_serialization_use_label() {
+        let edge_kind = EdgeKind::Other("requires_verification".to_string());
+
+        assert_eq!(edge_kind.to_string(), "requires_verification");
+        assert_eq!(
+            serde_json::to_string(&edge_kind).expect("serialize custom edge kind"),
+            "\"requires_verification\"",
+            "custom edge serialization must expose the relationship label, not an opaque Other wrapper"
+        );
+        assert_eq!(
+            serde_json::from_str::<EdgeKind>("\"requires_verification\"")
+                .expect("deserialize custom edge kind"),
+            edge_kind,
+            "custom edge deserialization must preserve the relationship label"
         );
     }
 

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -905,6 +905,32 @@ mod tests {
     }
 
     #[test]
+    fn test_format_neighbors_grouped_preserves_custom_edge_label() {
+        use crate::graph::EdgeKind;
+
+        let evidence = make_test_node("evidence");
+        let nodes = vec![evidence.clone()];
+
+        let mut index = GraphIndex::new();
+        index.ensure_node(&evidence.stable_id(), "function");
+
+        let mut groups = std::collections::BTreeMap::new();
+        groups.insert(
+            EdgeKind::Other("requires_verification".to_string()),
+            vec![evidence.stable_id()],
+        );
+
+        let result = format_neighbors_grouped(&nodes, &groups, &index, true);
+
+        assert!(
+            result.contains("#### Requires verification (1)"),
+            "custom edge label should be exposed in traversal/search output, got: {}",
+            result
+        );
+        assert!(result.contains("evidence"));
+    }
+
+    #[test]
     fn test_format_neighbors_grouped_omits_empty() {
         use crate::graph::EdgeKind;
 

--- a/src/server/store/mod.rs
+++ b/src/server/store/mod.rs
@@ -64,29 +64,12 @@ pub(crate) fn parse_node_kind(s: &str) -> NodeKind {
 }
 
 /// Parse an EdgeKind from its string representation.
+///
+/// Built-in labels map to their canonical variants. Any non-empty unknown
+/// label becomes `EdgeKind::Other(label)`, preserving repo-local relationship
+/// kinds loaded from LanceDB or accepted through MCP/search edge filters.
 pub fn parse_edge_kind(s: &str) -> Option<EdgeKind> {
-    Some(match s {
-        "calls" => EdgeKind::Calls,
-        "implements" => EdgeKind::Implements,
-        "depends_on" => EdgeKind::DependsOn,
-        "connects_to" => EdgeKind::ConnectsTo,
-        "defines" => EdgeKind::Defines,
-        "has_field" => EdgeKind::HasField,
-        "evolves" => EdgeKind::Evolves,
-        "referenced_by" => EdgeKind::ReferencedBy,
-        "references" => EdgeKind::References,
-        "topology_boundary" => EdgeKind::TopologyBoundary,
-        "modified" => EdgeKind::Modified,
-        "affected" => EdgeKind::Affected,
-        "serves" => EdgeKind::Serves,
-        "tested_by" => EdgeKind::TestedBy,
-        "belongs_to" => EdgeKind::BelongsTo,
-        "re_exports" => EdgeKind::ReExports,
-        "uses_framework" => EdgeKind::UsesFramework,
-        "produces" => EdgeKind::Produces,
-        "consumes" => EdgeKind::Consumes,
-        _ => return None,
-    })
+    EdgeKind::from_label(s)
 }
 
 /// Parse an ExtractionSource from its string representation.

--- a/src/server/store/persist.rs
+++ b/src/server/store/persist.rs
@@ -909,12 +909,12 @@ mod tests {
         let mut evidence = make_test_node("evidence");
         evidence.id.file = PathBuf::from("docs/evidence.md");
 
-        let mut metadata_only = make_test_node("metadata_only");
-        metadata_only
+        claimant
             .metadata
             .insert("relationship".to_string(), "supports".to_string());
+        let supports_kind = EdgeKind::Other("supports".to_string());
         let wrong_workaround = Edge {
-            from: metadata_only.id.clone(),
+            from: claimant.id.clone(),
             to: evidence.id.clone(),
             kind: EdgeKind::References,
             source: ExtractionSource::Markdown,
@@ -923,14 +923,14 @@ mod tests {
         let custom_edge = Edge {
             from: claimant.id.clone(),
             to: evidence.id.clone(),
-            kind: EdgeKind::Other("supports".to_string()),
+            kind: supports_kind.clone(),
             source: ExtractionSource::Markdown,
             confidence: Confidence::Detected,
         };
 
         persist_graph_to_lance(
             repo_root,
-            &[claimant.clone(), evidence.clone(), metadata_only.clone()],
+            &[claimant.clone(), evidence.clone()],
             &[custom_edge.clone(), wrong_workaround],
         )
         .await
@@ -941,7 +941,7 @@ mod tests {
         let supports_edges: Vec<_> = state
             .edges
             .iter()
-            .filter(|e| e.kind == EdgeKind::Other("supports".to_string()))
+            .filter(|e| e.kind == supports_kind)
             .collect();
         assert_eq!(
             supports_edges.len(),
@@ -956,13 +956,24 @@ mod tests {
         assert_eq!(supports_edges[0].from.name, "claimant");
         assert_eq!(supports_edges[0].to.name, "evidence");
 
-        let groups = state.index.neighbors_grouped(
+        let unfiltered = state.index.neighbors_grouped(
             &claimant.stable_id(),
             None,
             petgraph::Direction::Outgoing,
         );
+        assert!(
+            unfiltered.contains_key(&EdgeKind::References),
+            "the same-source generic-edge workaround must be present for this regression to be adversarial"
+        );
+
+        let supports_filter = [supports_kind.clone()];
+        let groups = state.index.neighbors_grouped(
+            &claimant.stable_id(),
+            Some(&supports_filter),
+            petgraph::Direction::Outgoing,
+        );
         let supports_group = groups
-            .get(&EdgeKind::Other("supports".to_string()))
+            .get(&supports_kind)
             .expect("custom supports edge missing from grouped traversal");
         assert!(
             supports_group.contains(&evidence.stable_id()),

--- a/src/server/store/persist.rs
+++ b/src/server/store/persist.rs
@@ -855,13 +855,15 @@ mod tests {
             confidence: Confidence::Detected,
         };
 
-        persist_graph_to_lance(repo_root, &[caller.clone(), callee.clone()], &[edge.clone()])
-            .await
-            .expect("persist failed");
+        persist_graph_to_lance(
+            repo_root,
+            &[caller.clone(), callee.clone()],
+            &[edge.clone()],
+        )
+        .await
+        .expect("persist failed");
 
-        let state = load_graph_from_lance(repo_root)
-            .await
-            .expect("load failed");
+        let state = load_graph_from_lance(repo_root).await.expect("load failed");
 
         let reloaded_caller = state
             .nodes
@@ -884,9 +886,91 @@ mod tests {
             .filter(|e| e.kind == EdgeKind::ReferencedBy)
             .count();
         assert_eq!(
-            referenced_by_count, 1,
+            referenced_by_count,
+            1,
             "ReferencedBy edge dropped on round-trip; got edges {:?}",
-            state.edges.iter().map(|e| e.kind.to_string()).collect::<Vec<_>>(),
+            state
+                .edges
+                .iter()
+                .map(|e| e.kind.to_string())
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_custom_edge_kind_round_trips_as_graph_edge_not_metadata() {
+        use crate::graph::{Confidence, Edge, EdgeKind};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo_root = dir.path();
+
+        let mut claimant = make_test_node("claimant");
+        claimant.id.file = PathBuf::from("docs/claim.md");
+        let mut evidence = make_test_node("evidence");
+        evidence.id.file = PathBuf::from("docs/evidence.md");
+
+        let mut metadata_only = make_test_node("metadata_only");
+        metadata_only
+            .metadata
+            .insert("relationship".to_string(), "supports".to_string());
+        let wrong_workaround = Edge {
+            from: metadata_only.id.clone(),
+            to: evidence.id.clone(),
+            kind: EdgeKind::References,
+            source: ExtractionSource::Markdown,
+            confidence: Confidence::Detected,
+        };
+        let custom_edge = Edge {
+            from: claimant.id.clone(),
+            to: evidence.id.clone(),
+            kind: EdgeKind::Other("supports".to_string()),
+            source: ExtractionSource::Markdown,
+            confidence: Confidence::Detected,
+        };
+
+        persist_graph_to_lance(
+            repo_root,
+            &[claimant.clone(), evidence.clone(), metadata_only.clone()],
+            &[custom_edge.clone(), wrong_workaround],
+        )
+        .await
+        .expect("persist failed");
+
+        let state = load_graph_from_lance(repo_root).await.expect("load failed");
+
+        let supports_edges: Vec<_> = state
+            .edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::Other("supports".to_string()))
+            .collect();
+        assert_eq!(
+            supports_edges.len(),
+            1,
+            "custom relationship must reload as an actual supports edge; got {:?}",
+            state
+                .edges
+                .iter()
+                .map(|e| e.kind.to_string())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(supports_edges[0].from.name, "claimant");
+        assert_eq!(supports_edges[0].to.name, "evidence");
+
+        let groups = state.index.neighbors_grouped(
+            &claimant.stable_id(),
+            None,
+            petgraph::Direction::Outgoing,
+        );
+        let supports_group = groups
+            .get(&EdgeKind::Other("supports".to_string()))
+            .expect("custom supports edge missing from grouped traversal");
+        assert!(
+            supports_group.contains(&evidence.stable_id()),
+            "custom supports traversal should reach evidence; groups={groups:?}"
+        );
+        assert!(
+            !groups.contains_key(&EdgeKind::References),
+            "metadata-only workaround must not satisfy supports traversal"
         );
     }
 }


### PR DESCRIPTION
Closes #707

## Summary
- Add `EdgeKind::Other(String)` with string-label serde/display parsing for repo-local relationship kinds.
- Preserve unknown edge labels through LanceDB load and edge-type filters.
- Cover custom edge round-trip, grouped traversal, and MCP/search-facing label rendering.

## Verification
- `cargo test custom_edge_kind --lib`
- `cargo test format_neighbors_grouped_preserves_custom_edge_label --lib`
- `cargo test builtin_edge_kind_json_serialization_stays_string_label --lib`
- `cargo check --lib`

## Review
- `sg review` unavailable: `error: command not found: sg`; performed manual staged-diff review instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved custom relationship/edge labels end-to-end when parsing, serializing, saving, and loading graph data (including `Other(...)` labels).
  * Unknown edge labels are now retained instead of being dropped during import/filtering.
  * Traversal/search grouped output now displays custom edge names correctly.
  * Updated graph scoring so “Other” edge types use a more conservative PageRank weight.
* **Tests**
  * Added JSON round-trip and custom edge-kind persistence/traversal coverage.
* **Documentation**
  * Extended the EdgeKind data model docs to describe `Other(String)` and its analytics weight.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->