### PR TITLE
Update sccache action to Node 24 runtime

### DIFF
--- a/.github/scripts/check-rust-toolchain-pins.sh
+++ b/.github/scripts/check-rust-toolchain-pins.sh
@@ -4,6 +4,17 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 toolchain_file="$repo_root/rust-toolchain.toml"
 
+shopt -s nullglob
+workflow_files=(
+  "$repo_root"/.github/workflows/*.yml
+  "$repo_root"/.github/workflows/*.yaml
+)
+
+if (( ${#workflow_files[@]} == 0 )); then
+  echo "FAIL: no GitHub Actions workflow files found" >&2
+  exit 1
+fi
+
 toolchain="$(
   awk -F'"' '
     $1 ~ /^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }
@@ -36,7 +47,7 @@ awk -v expected="$toolchain" '
     }
     printf "Rust toolchain pins agree at %s across %d workflow references\n", expected, count
   }
-' "$repo_root"/.github/workflows/*.yml
+' "${workflow_files[@]}"
 
 sccache_action="v0.0.10"
 
@@ -61,4 +72,4 @@ awk -v expected="$sccache_action" '
     }
     printf "sccache-action pins agree at %s across %d workflow references\n", expected, count
   }
-' "$repo_root"/.github/workflows/*.yml
+' "${workflow_files[@]}"

--- a/.github/scripts/check-rust-toolchain-pins.sh
+++ b/.github/scripts/check-rust-toolchain-pins.sh
@@ -37,3 +37,28 @@ awk -v expected="$toolchain" '
     printf "Rust toolchain pins agree at %s across %d workflow references\n", expected, count
   }
 ' "$repo_root"/.github/workflows/*.yml
+
+sccache_action="v0.0.10"
+
+awk -v expected="$sccache_action" '
+  /uses:[[:space:]]*mozilla-actions\/sccache-action@/ {
+    count++
+    actual = $0
+    sub(/^.*mozilla-actions\/sccache-action@/, "", actual)
+    sub(/[[:space:]#].*$/, "", actual)
+    if (actual != expected) {
+      printf "FAIL: %s:%d does not use sccache-action %s: %s\n", FILENAME, FNR, expected, $0 > "/dev/stderr"
+      mismatch = 1
+    }
+  }
+  END {
+    if (count == 0) {
+      print "FAIL: no mozilla-actions/sccache-action workflow references found" > "/dev/stderr"
+      exit 1
+    }
+    if (mismatch) {
+      exit 1
+    }
+    printf "sccache-action pins agree at %s across %d workflow references\n", expected, count
+  }
+' "$repo_root"/.github/workflows/*.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           targets: aarch64-apple-darwin
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure Namespace sccache cache
         run: nsc cache sccache setup --cache_name default >> "$GITHUB_ENV"
@@ -94,7 +94,7 @@ jobs:
         with:
           targets: aarch64-apple-darwin
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Configure Namespace sccache cache
         run: nsc cache sccache setup --cache_name default >> "$GITHUB_ENV"
       - name: Cache Rust
@@ -137,7 +137,7 @@ jobs:
         with:
           targets: x86_64-unknown-linux-gnu
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Configure Namespace sccache cache
         run: nsc cache sccache setup --cache_name default >> "$GITHUB_ENV"
       - name: Cache Rust

--- a/.github/workflows/rust-main-merge.yml
+++ b/.github/workflows/rust-main-merge.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout
         if: needs.changes.outputs.rust == 'true'
         uses: actions/checkout@v5
-      - name: Rust toolchain pins agree
+      - name: Rust workflow pins agree
         if: needs.changes.outputs.rust == 'true'
         run: bash .github/scripts/check-rust-toolchain-pins.sh
       - name: No language-specific conditionals in generic.rs
@@ -81,7 +81,7 @@ jobs:
           components: clippy
       - name: Setup sccache
         if: needs.changes.outputs.rust == 'true'
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Configure Namespace sccache cache
         if: needs.changes.outputs.rust == 'true'
         run: nsc cache sccache setup --cache_name default >> "$GITHUB_ENV"
@@ -123,7 +123,7 @@ jobs:
 
       - name: Setup sccache
         if: needs.changes.outputs.rust == 'true'
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure Namespace sccache cache
         if: needs.changes.outputs.rust == 'true'
@@ -161,7 +161,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.97.0
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure Namespace sccache cache
         run: nsc cache sccache setup --cache_name default >> "$GITHUB_ENV"
@@ -234,7 +234,7 @@ jobs:
           targets: aarch64-apple-darwin
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure Namespace sccache cache
         run: nsc cache sccache setup --cache_name default >> "$GITHUB_ENV"

--- a/.oh/friction-logs/726-ship.md
+++ b/.oh/friction-logs/726-ship.md
@@ -1,0 +1,12 @@
+---
+date: "2026-07-14"
+pipeline_issue: "/ship PR #726"
+pr: 726
+phase: ship
+---
+
+# PR #726 ship friction
+
+| Date | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-07-14 | RNA `search("mozilla-actions/sccache-action")` | minor | Exact YAML action references returned no results after a successful extract-only worktree scan. | Used a narrow `rg` fallback to enumerate all seven workflow pins and extended the repository oracle to prevent future drift. | Improve exact-value indexing for workflow YAML action references. |


### PR DESCRIPTION
Closes #725

## Problem
Rust CI and release workflows pin mozilla-actions/sccache-action@v0.0.9, which targets deprecated Node 20 and now emits a warning in every job.

## Chosen solution
- Pin every workflow reference to upstream v0.0.10, whose action metadata uses Node 24.
- Extend the existing workflow-pin oracle so this dependency cannot drift between workflows.
- Verify CI plus manual release-artifact/MCP smoke on the exact PR head.

This PR intentionally contains only the GitHub Action dependency refresh and its invariant check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated build and CI workflows to use the latest approved sccache action version.
  * Added validation to detect mismatched or missing Rust toolchain and sccache action pins, helping prevent workflow configuration drift.

* **Documentation**
  * Added a shipping friction log documenting workflow pin verification and follow-up improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->