### PR TITLE
Fix symbol search scorer crashes after worktree mapping

### DIFF
--- a/.oh/metis/scorer-isolation-must-cover-the-panic-hook.md
+++ b/.oh/metis/scorer-isolation-must-cover-the-panic-hook.md
@@ -1,0 +1,9 @@
+---
+id: scorer-isolation-must-cover-the-panic-hook
+outcome: context-assembly
+title: 'Scorer Isolation Must Cover the Panic Hook and the Delivered Path'
+---
+
+A spawned task boundary is not sufficient containment for repository-sensitive scoring. Rust invokes the process panic hook before Tokio returns a `JoinError`, so a response-safe diagnostic can coexist with a raw stderr leak unless the hook path is explicitly redacted.
+
+The regression also has to cross the real delivery seam. Separate tests for “a live worktree maps” and “a scorer panic degrades” can both pass while the mapped handler path never exercises the failure. The useful oracle maps a real worktree, fails the scorer inside the normal hybrid-search function, and proves bounded graph fallback plus a content-safe MCP diagnostic in the same execution.

--- a/.oh/sessions/721-execute.md
+++ b/.oh/sessions/721-execute.md
@@ -1,0 +1,51 @@
+---
+issue: 721
+outcome: context-assembly
+phase: execute
+---
+
+# Issue 721 execution handoff
+
+## Aim
+
+Keep RNA-first worktree navigation usable when semantic scoring fails: symbol search must return a bounded lexical result, disclose a content-safe scorer diagnostic, and leave the already-built graph intact.
+
+## Selected approach
+
+Harden the existing scorer boundary instead of replacing the search pipeline. Validate embedding and Arrow result shapes inside the embedding component, convert scorer panics or errors into a structured content-safe diagnostic at the service boundary, and preserve the existing bounded lexical fallback.
+
+## Scope
+
+- Embedding scorer input/output validation and diagnostics.
+- Service-layer isolation of scorer failure.
+- Regression coverage for map-then-search, fallback bounds, diagnostic safety, and graph preservation.
+
+Out of scope: changing embedding models, rebuilding the index format, or introducing a new search abstraction.
+
+## Success criteria
+
+- A live worktree can be mapped and searched in one regression fixture.
+- Empty/malformed scorer output cannot crash the request.
+- The returned diagnostic names component, model/index state, and fallback without repository content.
+- Fallback results are bounded by the requested limit.
+- The mapped graph remains queryable after scorer failure.
+
+## Decision basis
+
+The failure is local to the semantic scorer boundary while graph construction and lexical search already work. Preserving those native seams minimizes migration risk and directly satisfies the issue.
+
+Assumptions: scorer failures can be represented without query/source text; lexical candidates are available after a successful map; panic isolation is required because dependency code may still panic.
+
+Accepted trade-off: a degraded lexical result may rank less precisely than semantic search, but remains honest and usable.
+
+Invalidated if the reproduced failure corrupts persisted graph state before scoring. Stop/pivot if isolating the scorer requires replacing the persistence/search stack or if fallback cannot be bounded without discarding valid filters.
+
+## Execution and risk-retirement checklist
+
+- [ ] Reproduce or simulate empty/malformed scorer output after map construction.
+- [ ] Add a check that fails direct indexing/downcast panics.
+- [ ] Add a check that fails diagnostics containing query, symbol body, or repository path.
+- [ ] Add a check that fails unbounded fallback.
+- [ ] Add a check that fails graph invalidation after scorer failure.
+- [ ] Run `cargo check --lib` before focused and full tests.
+- [ ] Run staged `/review`, the project ship gate, real MCP smoke, and CI.

--- a/.oh/sessions/721-execute.md
+++ b/.oh/sessions/721-execute.md
@@ -66,6 +66,10 @@ The existing scorer seam now rejects empty query vectors and incompatible Arrow 
 - `cargo test --lib --features embeddings single_query_embedding_rejects_missing_or_malformed_output` (1 passed)
 - `cargo test --lib --features embeddings required_string_column_returns_schema_error_instead_of_panicking` (1 passed)
 
+## Independent review
+
+The required independent reviewer found that `tokio::spawn` contains a panic for the MCP response but the process panic hook can still emit its raw payload to stderr. The scorer boundary now installs a process-wide delegating hook and enables payload redaction only while polling scorer futures. Other panics still use the prior hook. Focused panic regressions verify the redacted hook runs before Tokio returns the `JoinError`.
+
 ### Risk retirement
 
 | Risk | Status | Tempting patch failed | Evidence |

--- a/.oh/sessions/721-execute.md
+++ b/.oh/sessions/721-execute.md
@@ -70,6 +70,8 @@ The existing scorer seam now rejects empty query vectors and incompatible Arrow 
 
 The required independent reviewer found that `tokio::spawn` contains a panic for the MCP response but the process panic hook can still emit its raw payload to stderr. The scorer boundary now installs a process-wide delegating hook and enables payload redaction only while polling scorer futures. Other panics still use the prior hook. Focused panic regressions verify the redacted hook runs before Tokio returns the `JoinError`.
 
+CodeRabbit then found that the live-worktree regression and scorer-failure regression exercised adjacent paths rather than one end-to-end path. A task-local test injection now fails the scorer inside `flat_code_symbol_search_with_diagnostics`; both the service regression and the real handler path prove the live mapped graph survives, fallback honors `limit`, and the delivered diagnostic omits the injected private path.
+
 ### Risk retirement
 
 | Risk | Status | Tempting patch failed | Evidence |

--- a/.oh/sessions/721-execute.md
+++ b/.oh/sessions/721-execute.md
@@ -42,10 +42,54 @@ Invalidated if the reproduced failure corrupts persisted graph state before scor
 
 ## Execution and risk-retirement checklist
 
-- [ ] Reproduce or simulate empty/malformed scorer output after map construction.
-- [ ] Add a check that fails direct indexing/downcast panics.
-- [ ] Add a check that fails diagnostics containing query, symbol body, or repository path.
-- [ ] Add a check that fails unbounded fallback.
-- [ ] Add a check that fails graph invalidation after scorer failure.
-- [ ] Run `cargo check --lib` before focused and full tests.
-- [ ] Run staged `/review`, the project ship gate, real MCP smoke, and CI.
+- [x] Reproduce or simulate empty/malformed scorer output after map construction.
+- [x] Add a check that fails direct indexing/downcast panics.
+- [x] Add a check that fails diagnostics containing query, symbol body, or repository path.
+- [x] Add a check that fails unbounded fallback.
+- [x] Add a check that fails graph invalidation after scorer failure.
+- [x] Run `cargo check --lib` before focused tests.
+- [x] Run staged `/review`.
+- [ ] Run the project ship gate, real MCP smoke, full tests, and CI.
+
+## Execute
+
+### Execution complete
+
+The existing scorer seam now rejects empty query vectors and incompatible Arrow columns as errors. Both code-symbol and artifact scoring execute behind a Tokio task boundary; scorer errors, panics, and cancellations produce a bounded lexical/graph fallback plus a content-safe agent-facing diagnostic. A real temporary worktree is scanned through `build_full_graph` and searched through the MCP handler, while adversarial fixtures prove scorer failure cannot mutate the mapped graph or exceed the requested result limit.
+
+### Verification
+
+- `cargo check --lib`
+- `cargo check --lib --features embeddings`
+- `cargo test --lib scorer_` (3 passed)
+- `cargo test --lib test_symbol_search_after_successful_live_worktree_map` (1 passed)
+- `cargo test --lib --features embeddings single_query_embedding_rejects_missing_or_malformed_output` (1 passed)
+- `cargo test --lib --features embeddings required_string_column_returns_schema_error_instead_of_panicking` (1 passed)
+
+### Risk retirement
+
+| Risk | Status | Tempting patch failed | Evidence |
+|---|---|---|---|
+| Empty scorer output still indexes element zero | Retired | Catch only service errors | Shape validation and feature-enabled test |
+| Lance result schema still panics | Retired | Guard column presence but keep unchecked downcasts | Typed column helper and feature-enabled test |
+| Panic escapes async search | Retired | Handle `Result` only | Tokio task isolation panic fixture |
+| Diagnostic leaks repository content | Retired | Echo raw `anyhow` or panic payload | Error and panic redaction fixtures |
+| Artifact search re-enters failed scorer | Retired | Isolate only code-symbol search | Shared isolation boundary for both scoring calls |
+| Fallback corrupts or replaces mapped graph | Retired | Rebuild/reset graph on scorer failure | Stable-ID preservation and bounded fallback fixture |
+| Test claims a map without scanning | Retired | Construct `GraphState` directly | Temp worktree `build_full_graph` plus handler search |
+
+## Review
+
+**Aim:** Keep RNA-first worktree navigation usable and honest when semantic scoring fails.
+
+**Status:** Continue
+
+- Necessary: yes; the unguarded scorer could crash the primary discovery path.
+- Aligned: yes; changes remain inside scorer validation, service isolation, and regression coverage.
+- Sufficient: yes after two adjustments found in review: artifact scoring now shares the isolation boundary, and the map/search regression uses a real scanner-built graph.
+- Mechanism clear: invalid scorer shapes become errors; task failure becomes a safe diagnostic; existing lexical/graph ranking supplies bounded results.
+- Risks retired: all model-checkable risks from the handoff have adversarial evidence.
+- Frame check: intact. The graph remains valid; the failure belongs at the scorer boundary.
+- Drift detected: none. No model, index-format, or search-framework redesign was introduced.
+
+Needs human verification: final delivery through the installed CI artifact and real MCP client remains in the ship gate.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ This explores your codebase, asks about your aims, writes `AGENTS.md`, scaffolds
 
 **Index-updating indicator:** When the background scanner is actively rebuilding the index (triggered by a HEAD change), `search`, `repo_map`, and `outcome_progress` responses append: `_Index updating in background — results reflect last complete scan._` No note appears when the index is current. This is informational — results are still valid, just from the previous complete scan.
 
+**Search degradation:** If semantic scoring fails after a graph is mapped, `search` keeps the graph available, returns bounded lexical/graph results, and appends content-safe component/model/index diagnostics. Rebuild the embeddings capability for that root and retry semantic search; the diagnostic deliberately omits query text, file paths, and panic payloads.
+
 ### CLI ↔ MCP Equivalence
 
 CLI and MCP share the same index. Run `scan --full` from the CLI to build the complete index, then query via either interface.

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -5,6 +5,8 @@ mod real;
 #[cfg(feature = "embeddings")]
 pub use real::*;
 
+pub const EMBEDDING_MODEL_NAME: &str = "MiniLM-L6-v2";
+
 #[cfg(not(feature = "embeddings"))]
 use std::path::Path;
 

--- a/src/embed/real.rs
+++ b/src/embed/real.rs
@@ -528,6 +528,35 @@ pub enum SearchOutcome {
     NotReady,
 }
 
+fn single_query_embedding(mut embeddings: Vec<Vec<f32>>) -> Result<Vec<f32>> {
+    if embeddings.len() != 1 {
+        anyhow::bail!(
+            "embedding scorer shape mismatch: expected 1 query vector, received {}",
+            embeddings.len()
+        );
+    }
+    let embedding = embeddings.pop().expect("length checked above");
+    if embedding.is_empty() {
+        anyhow::bail!("embedding scorer shape mismatch: query vector is empty");
+    }
+    Ok(embedding)
+}
+
+fn required_string_column<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray> {
+    let column = batch.column_by_name(name).ok_or_else(|| {
+        anyhow::anyhow!("embedding scorer schema mismatch: missing `{name}` column")
+    })?;
+    column
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "embedding scorer schema mismatch: `{name}` must be Utf8, received {:?}",
+                column.data_type()
+            )
+        })
+}
+
 /// A search result with the artifact and its relevance score.
 pub struct SearchResult {
     pub id: String,
@@ -1572,9 +1601,10 @@ impl EmbeddingIndex {
             }
             SearchMode::Semantic => {
                 // Pure vector search — original behavior.
-                let query_embedding = embed_texts(vec![query.to_string()]).await?;
+                let query_embedding =
+                    single_query_embedding(embed_texts(vec![query.to_string()]).await?)?;
                 let mut search = table
-                    .vector_search(query_embedding[0].clone())
+                    .vector_search(query_embedding)
                     .context("Failed to create vector search")?
                     .distance_type(lancedb::DistanceType::Cosine)
                     .limit(over_fetch);
@@ -1588,7 +1618,8 @@ impl EmbeddingIndex {
                 // Hybrid: BM25 + vector with RRF fusion.
                 // LanceDB automatically detects both FTS and vector on VectorQuery
                 // and routes through execute_hybrid with RRF reranking.
-                let query_embedding = embed_texts(vec![query.to_string()]).await?;
+                let query_embedding =
+                    single_query_embedding(embed_texts(vec![query.to_string()]).await?)?;
                 let fts_query = FullTextSearchQuery::new(query.to_string());
 
                 let mut q = table.query().full_text_search(fts_query).limit(over_fetch);
@@ -1596,7 +1627,7 @@ impl EmbeddingIndex {
                     q = q.only_if(sql.clone());
                 }
                 let hybrid_result = q
-                    .nearest_to(query_embedding[0].as_slice())
+                    .nearest_to(query_embedding.as_slice())
                     .context("Failed to create hybrid search")?
                     .distance_type(lancedb::DistanceType::Cosine)
                     .execute()
@@ -1609,7 +1640,7 @@ impl EmbeddingIndex {
                         // completes, or old cache). Fall back to pure vector search.
                         tracing::warn!("Hybrid search failed ({}), falling back to vector-only", e);
                         let mut search = table
-                            .vector_search(query_embedding[0].clone())
+                            .vector_search(query_embedding.clone())
                             .context("Failed to create fallback vector search")?
                             .distance_type(lancedb::DistanceType::Cosine)
                             .limit(over_fetch);
@@ -1657,30 +1688,10 @@ impl EmbeddingIndex {
                 continue;
             }
 
-            let ids = batch
-                .column_by_name("id")
-                .expect("checked above")
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .expect("id column is StringArray");
-            let kinds = batch
-                .column_by_name("kind")
-                .expect("checked above")
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .expect("kind column is StringArray");
-            let titles = batch
-                .column_by_name("title")
-                .expect("checked above")
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .expect("title column is StringArray");
-            let bodies = batch
-                .column_by_name("body")
-                .expect("checked above")
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .expect("body column is StringArray");
+            let ids = required_string_column(batch, "id")?;
+            let kinds = required_string_column(batch, "kind")?;
+            let titles = required_string_column(batch, "title")?;
+            let bodies = required_string_column(batch, "body")?;
 
             for i in 0..batch.num_rows() {
                 let kind = kinds.value(i).to_string();
@@ -1755,8 +1766,40 @@ mod tests {
         BACKOFF_THRESHOLD, BATCH_CEILING, BATCH_FLOOR, BATCH_YIELD_MS, CODE_EMBED_CHAR_BUDGET,
         EmbeddingIndex, SearchFilters, SearchResult, build_artifact_embedding_text,
         build_code_embedding_text, node_embedding_kind, node_embedding_text, node_embedding_title,
-        node_scalar_filters, truncate_chars,
+        node_scalar_filters, required_string_column, single_query_embedding, truncate_chars,
     };
+
+    #[test]
+    fn single_query_embedding_rejects_missing_or_malformed_output() {
+        let missing = single_query_embedding(Vec::new()).unwrap_err().to_string();
+        assert!(missing.contains("expected 1 query vector"));
+
+        let empty = single_query_embedding(vec![Vec::new()])
+            .unwrap_err()
+            .to_string();
+        assert!(empty.contains("query vector is empty"));
+
+        let multiple = single_query_embedding(vec![vec![0.1], vec![0.2]])
+            .unwrap_err()
+            .to_string();
+        assert!(multiple.contains("received 2"));
+    }
+
+    #[test]
+    fn required_string_column_returns_schema_error_instead_of_panicking() {
+        use arrow_array::{ArrayRef, Int32Array, RecordBatch};
+        use std::sync::Arc;
+
+        let batch =
+            RecordBatch::try_from_iter([("id", Arc::new(Int32Array::from(vec![1])) as ArrayRef)])
+                .unwrap();
+
+        let error = required_string_column(&batch, "id")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("`id` must be Utf8"));
+        assert!(error.contains("Int32"));
+    }
     use std::collections::BTreeMap;
 
     #[test]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1156,10 +1156,17 @@ mod tests {
     async fn test_symbol_search_after_successful_live_worktree_map() {
         let repo = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(repo.path().join("src")).unwrap();
-        let symbol = "mapped_worktree_symbol_probe";
+        let query = "mapped_worktree_symbol_probe";
+        let symbols = [
+            "mapped_worktree_symbol_probe_one",
+            "mapped_worktree_symbol_probe_two",
+        ];
         std::fs::write(
             repo.path().join("src/lib.rs"),
-            format!("pub fn {symbol}() -> &'static str {{ \"mapped\" }}\n"),
+            format!(
+                "pub fn {}() -> &'static str {{ \"mapped-one\" }}\npub fn {}() -> &'static str {{ \"mapped-two\" }}\n",
+                symbols[0], symbols[1]
+            ),
         )
         .unwrap();
 
@@ -1169,30 +1176,44 @@ mod tests {
             .await
             .expect("live worktree map should succeed");
         assert!(
-            graph.nodes.iter().any(|node| node.id.name == symbol),
-            "mapped graph should contain the probe symbol"
+            symbols
+                .iter()
+                .all(|symbol| graph.nodes.iter().any(|node| node.id.name == *symbol)),
+            "mapped graph should contain both probe symbols"
         );
         handler
             .graph
             .store(std::sync::Arc::new(Some(std::sync::Arc::new(graph))));
 
         let args: Search = serde_json::from_value(serde_json::json!({
-            "query": symbol,
+            "query": query,
             "repo": repo.path().to_string_lossy(),
             "include_markdown": false,
             "include_artifacts": false,
-            "search_mode": "keyword",
+            "search_mode": "hybrid",
+            "limit": 1,
             "compact": true,
             "verbose": false
         }))
         .unwrap();
-        let result = handler.handle_search(args).await.unwrap();
+        let result = crate::service::search::with_test_embedding_scorer_panic(
+            format!("{query} src/private/customer.rs"),
+            handler.handle_search(args),
+        )
+        .await
+        .unwrap();
         let rendered = serde_json::to_string(&result).unwrap();
 
+        let returned_symbols = symbols
+            .iter()
+            .filter(|symbol| rendered.contains(**symbol))
+            .count();
         assert!(
-            rendered.contains(symbol),
-            "symbol search should return a symbol from the successfully mapped worktree: {rendered}"
+            returned_symbols == 1,
+            "fallback should return exactly one mapped symbol at limit=1: {rendered}"
         );
+        assert!(rendered.contains("failure=task_panic"), "got: {rendered}");
+        assert!(!rendered.contains("customer.rs"), "got: {rendered}");
     }
 
     /// A path with just a slash followed by nothing is still absolute.

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1152,6 +1152,49 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_symbol_search_after_successful_live_worktree_map() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        let symbol = "mapped_worktree_symbol_probe";
+        std::fs::write(
+            repo.path().join("src/lib.rs"),
+            format!("pub fn {symbol}() -> &'static str {{ \"mapped\" }}\n"),
+        )
+        .unwrap();
+
+        let handler = make_handler(repo.path());
+        let graph = handler
+            .build_full_graph()
+            .await
+            .expect("live worktree map should succeed");
+        assert!(
+            graph.nodes.iter().any(|node| node.id.name == symbol),
+            "mapped graph should contain the probe symbol"
+        );
+        handler
+            .graph
+            .store(std::sync::Arc::new(Some(std::sync::Arc::new(graph))));
+
+        let args: Search = serde_json::from_value(serde_json::json!({
+            "query": symbol,
+            "repo": repo.path().to_string_lossy(),
+            "include_markdown": false,
+            "include_artifacts": false,
+            "search_mode": "keyword",
+            "compact": true,
+            "verbose": false
+        }))
+        .unwrap();
+        let result = handler.handle_search(args).await.unwrap();
+        let rendered = serde_json::to_string(&result).unwrap();
+
+        assert!(
+            rendered.contains(symbol),
+            "symbol search should return a symbol from the successfully mapped worktree: {rendered}"
+        );
+    }
+
     /// A path with just a slash followed by nothing is still absolute.
     #[test]
     fn test_resolve_repo_path_root_slash_is_absolute() {

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -4,7 +4,9 @@
 //! `search_flat`, `search_traversal`, or `search_batch` depending on the
 //! parameters supplied by the caller.
 
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
+use std::sync::Once;
 
 use crate::embed::{EMBEDDING_MODEL_NAME, SearchFilters, SearchMode, SearchOutcome};
 use crate::graph::index::GraphIndex;
@@ -251,6 +253,67 @@ struct EmbeddingScorerDiagnostic {
     mode: SearchMode,
 }
 
+thread_local! {
+    static REDACT_SCORER_PANIC: Cell<bool> = const { Cell::new(false) };
+}
+
+static INSTALL_SCORER_PANIC_HOOK: Once = Once::new();
+
+#[cfg(test)]
+static REDACTED_SCORER_PANICS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+fn install_scorer_panic_hook() {
+    INSTALL_SCORER_PANIC_HOOK.call_once(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic_info| {
+            let redact = REDACT_SCORER_PANIC.try_with(Cell::get).unwrap_or(false);
+            if redact {
+                #[cfg(test)]
+                REDACTED_SCORER_PANICS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                tracing::error!(
+                    component = "embedding_scorer",
+                    model = EMBEDDING_MODEL_NAME,
+                    index = "attached",
+                    failure = "task_panic",
+                    "Embedding scorer panicked; panic payload redacted"
+                );
+            } else {
+                previous(panic_info);
+            }
+        }));
+    });
+}
+
+struct ScorerPanicRedactionGuard {
+    previous: bool,
+}
+
+impl ScorerPanicRedactionGuard {
+    fn enter() -> Self {
+        let previous = REDACT_SCORER_PANIC.with(|redact| redact.replace(true));
+        Self { previous }
+    }
+}
+
+impl Drop for ScorerPanicRedactionGuard {
+    fn drop(&mut self) {
+        REDACT_SCORER_PANIC.with(|redact| redact.set(self.previous));
+    }
+}
+
+async fn poll_scorer_with_content_safe_panic_hook<F>(scorer: F) -> anyhow::Result<SearchOutcome>
+where
+    F: std::future::Future<Output = anyhow::Result<SearchOutcome>>,
+{
+    let mut scorer = Box::pin(scorer);
+    std::future::poll_fn(move |cx| {
+        let _redaction = ScorerPanicRedactionGuard::enter();
+        scorer.as_mut().poll(cx)
+    })
+    .await
+}
+
 impl EmbeddingScorerDiagnostic {
     fn render(&self) -> String {
         let mode = match self.mode {
@@ -276,7 +339,8 @@ async fn isolate_embedding_scorer<F>(
 where
     F: std::future::Future<Output = anyhow::Result<SearchOutcome>> + Send + 'static,
 {
-    match tokio::spawn(scorer).await {
+    install_scorer_panic_hook();
+    match tokio::spawn(poll_scorer_with_content_safe_panic_hook(scorer)).await {
         Ok(Ok(outcome)) => Ok(outcome),
         Ok(Err(_)) => {
             tracing::warn!(
@@ -2657,6 +2721,7 @@ mod tests {
     /// Without embed index, flat search falls back to name/signature matching.
     #[tokio::test]
     async fn test_scorer_panic_becomes_content_safe_actionable_diagnostic() {
+        let redacted_before = REDACTED_SCORER_PANICS.load(std::sync::atomic::Ordering::Relaxed);
         let repository_content = "secret-query src/private/customer.rs";
         let diagnostic = match isolate_embedding_scorer(
             async move {
@@ -2681,6 +2746,10 @@ mod tests {
         assert!(rendered.contains("bounded lexical/graph results"));
         assert!(!rendered.contains("secret-query"));
         assert!(!rendered.contains("customer.rs"));
+        assert!(
+            REDACTED_SCORER_PANICS.load(std::sync::atomic::Ordering::Relaxed) > redacted_before,
+            "the panic hook must redact the payload before Tokio converts the panic to JoinError"
+        );
     }
 
     #[tokio::test]

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -373,6 +373,29 @@ where
     }
 }
 
+#[cfg(test)]
+tokio::task_local! {
+    static TEST_EMBEDDING_SCORER_PANIC: String;
+}
+
+#[cfg(test)]
+pub(crate) async fn with_test_embedding_scorer_panic<T>(
+    payload: String,
+    future: impl std::future::Future<Output = T>,
+) -> T {
+    TEST_EMBEDDING_SCORER_PANIC.scope(payload, future).await
+}
+
+#[cfg(test)]
+fn test_embedding_scorer_panic_payload() -> Option<String> {
+    TEST_EMBEDDING_SCORER_PANIC.try_with(Clone::clone).ok()
+}
+
+#[cfg(not(test))]
+fn test_embedding_scorer_panic_payload() -> Option<String> {
+    None
+}
+
 struct FlatCodeSymbolSearch<'a> {
     matches: Vec<&'a Node>,
     scorer_diagnostic: Option<EmbeddingScorerDiagnostic>,
@@ -717,7 +740,19 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
     // the symbol name rather than a slash-delimited path string.
     let mut used_embed = false;
     let mut matches: Vec<&Node> = if !query_str.is_empty() {
-        if let Some(embed_idx) = ctx.embed_index {
+        if let Some(panic_payload) = test_embedding_scorer_panic_payload() {
+            let scorer = async move {
+                tokio::task::yield_now().await;
+                panic!("{panic_payload}");
+                #[allow(unreachable_code)]
+                Ok(SearchOutcome::NotReady)
+            };
+            match isolate_embedding_scorer(scorer, search_mode).await {
+                Err(diagnostic) => scorer_diagnostic = Some(diagnostic),
+                Ok(_) => unreachable!("injected scorer panic must degrade"),
+            }
+            Vec::new()
+        } else if let Some(embed_idx) = ctx.embed_index {
             // With scalar pre-filters active, fetch exactly rerank_over_fetch rows —
             // only matching rows are scored, so no over-fetch needed.
             // Without filters, keep the 3x over-fetch to allow for graph-side
@@ -2789,21 +2824,6 @@ mod tests {
         let gs = make_graph_state(nodes);
         let stable_ids_before: Vec<String> = gs.nodes.iter().map(Node::stable_id).collect();
 
-        let diagnostic = match isolate_embedding_scorer(
-            async {
-                panic!("simulated scorer failure after worktree map");
-                #[allow(unreachable_code)]
-                Ok(SearchOutcome::NotReady)
-            },
-            SearchMode::Hybrid,
-        )
-        .await
-        {
-            Err(diagnostic) => diagnostic,
-            Ok(_) => panic!("panicking scorer must degrade"),
-        };
-        assert_eq!(diagnostic.failure, "task_panic");
-
         let repo_root = PathBuf::from("/tmp/live-worktree-map");
         let ctx = make_search_context(&gs, &repo_root);
         let params = SearchParams {
@@ -2813,20 +2833,31 @@ mod tests {
             include_markdown: false,
             ..Default::default()
         };
-        let matches = flat_code_symbol_search(
-            "auth",
-            SearchMode::Hybrid,
-            2,
-            &params,
-            &gs,
-            &ctx,
-            false,
-            false,
+        let search = with_test_embedding_scorer_panic(
+            "auth src/private/customer.rs".to_string(),
+            flat_code_symbol_search_with_diagnostics(
+                "auth",
+                SearchMode::Hybrid,
+                2,
+                &params,
+                &gs,
+                &ctx,
+                false,
+                false,
+            ),
         )
         .await;
 
+        let diagnostic = search
+            .scorer_diagnostic
+            .expect("scorer panic should be delivered with fallback results")
+            .render();
+        assert!(diagnostic.contains("failure=task_panic"));
+        assert!(!diagnostic.contains("auth"));
+        assert!(!diagnostic.contains("customer.rs"));
+
         assert_eq!(
-            matches.len(),
+            search.matches.len(),
             2,
             "fallback must respect the requested limit"
         );

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -2725,6 +2725,7 @@ mod tests {
         let repository_content = "secret-query src/private/customer.rs";
         let diagnostic = match isolate_embedding_scorer(
             async move {
+                tokio::task::yield_now().await;
                 panic!("{repository_content}");
                 #[allow(unreachable_code)]
                 Ok(SearchOutcome::NotReady)

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::embed::{SearchFilters, SearchMode, SearchOutcome};
+use crate::embed::{EMBEDDING_MODEL_NAME, SearchFilters, SearchMode, SearchOutcome};
 use crate::graph::index::GraphIndex;
 use crate::graph::{EdgeKind, ExtractionSource, Node, NodeKind};
 use crate::ranking;
@@ -245,6 +245,75 @@ pub async fn search(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EmbeddingScorerDiagnostic {
+    failure: &'static str,
+    mode: SearchMode,
+}
+
+impl EmbeddingScorerDiagnostic {
+    fn render(&self) -> String {
+        let mode = match self.mode {
+            SearchMode::Hybrid => "hybrid",
+            SearchMode::Keyword => "keyword",
+            SearchMode::Semantic => "semantic",
+        };
+        format!(
+            "### Search degradation\n\n\
+             Embedding scorer unavailable: `component=embedding_scorer \
+             model={EMBEDDING_MODEL_NAME} index=attached mode={mode} failure={}`. \
+             RNA returned bounded lexical/graph results and kept the mapped graph available. \
+             Rebuild the embeddings capability for this root, then retry semantic search.",
+            self.failure
+        )
+    }
+}
+
+async fn isolate_embedding_scorer<F>(
+    scorer: F,
+    mode: SearchMode,
+) -> Result<SearchOutcome, EmbeddingScorerDiagnostic>
+where
+    F: std::future::Future<Output = anyhow::Result<SearchOutcome>> + Send + 'static,
+{
+    match tokio::spawn(scorer).await {
+        Ok(Ok(outcome)) => Ok(outcome),
+        Ok(Err(_)) => {
+            tracing::warn!(
+                component = "embedding_scorer",
+                model = EMBEDDING_MODEL_NAME,
+                index = "attached",
+                failure = "search_error",
+                "Embedding scorer failed; using bounded lexical/graph fallback"
+            );
+            Err(EmbeddingScorerDiagnostic {
+                failure: "search_error",
+                mode,
+            })
+        }
+        Err(join_error) => {
+            let failure = if join_error.is_cancelled() {
+                "task_cancelled"
+            } else {
+                "task_panic"
+            };
+            tracing::warn!(
+                component = "embedding_scorer",
+                model = EMBEDDING_MODEL_NAME,
+                index = "attached",
+                failure,
+                "Embedding scorer task failed; using bounded lexical/graph fallback"
+            );
+            Err(EmbeddingScorerDiagnostic { failure, mode })
+        }
+    }
+}
+
+struct FlatCodeSymbolSearch<'a> {
+    matches: Vec<&'a Node>,
+    scorer_diagnostic: Option<EmbeddingScorerDiagnostic>,
+}
+
 async fn search_flat(
     params: &SearchParams,
     query: Option<&str>,
@@ -273,7 +342,10 @@ async fn search_flat(
     let graph_state = ctx.graph_state;
 
     // Try embedding-ranked code symbol search first; fall back to name/signature matching.
-    let matches: Vec<&Node> = flat_code_symbol_search(
+    let FlatCodeSymbolSearch {
+        matches,
+        mut scorer_diagnostic,
+    } = flat_code_symbol_search_with_diagnostics(
         query_str,
         search_mode,
         limit,
@@ -312,15 +384,17 @@ async fn search_flat(
         && !query_str.is_empty()
         && let Some(embed_idx) = ctx.embed_index
     {
-        match embed_idx
-            .search_with_mode(
-                query_str,
-                params.artifact_types.as_deref(),
-                limit,
-                search_mode,
-            )
-            .await
-        {
+        let scorer = {
+            let embed_idx = embed_idx.clone();
+            let query = query_str.to_string();
+            let artifact_types = params.artifact_types.clone();
+            async move {
+                embed_idx
+                    .search_with_mode(&query, artifact_types.as_deref(), limit, search_mode)
+                    .await
+            }
+        };
+        match isolate_embedding_scorer(scorer, search_mode).await {
             Ok(SearchOutcome::Results(results)) => {
                 let filtered: Vec<_> = results
                     .into_iter()
@@ -345,8 +419,14 @@ async fn search_flat(
             Ok(SearchOutcome::NotReady) => {
                 sections.push("Embedding index: building -- artifact results will appear shortly. Retry in a few seconds.".to_string());
             }
-            Err(e) => sections.push(format!("Artifact search error: {}", e)),
+            Err(diagnostic) => {
+                scorer_diagnostic.get_or_insert(diagnostic);
+            }
         }
+    }
+
+    if let Some(diagnostic) = scorer_diagnostic {
+        sections.push(diagnostic.render());
     }
 
     if params.include_markdown
@@ -423,6 +503,7 @@ async fn search_flat(
 /// 3. Apply post-filters (kind, language, file, root, synthetic, min_complexity).
 /// 4. Apply sort_by overrides (complexity, importance) if requested; otherwise
 ///    preserve embed ranking or use name-match ranking for fallback results.
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 async fn flat_code_symbol_search<'a>(
     query_str: &str,
@@ -434,6 +515,31 @@ async fn flat_code_symbol_search<'a>(
     sort_by_complexity: bool,
     sort_by_importance: bool,
 ) -> Vec<&'a Node> {
+    flat_code_symbol_search_with_diagnostics(
+        query_str,
+        search_mode,
+        limit,
+        params,
+        graph_state,
+        ctx,
+        sort_by_complexity,
+        sort_by_importance,
+    )
+    .await
+    .matches
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn flat_code_symbol_search_with_diagnostics<'a>(
+    query_str: &str,
+    search_mode: SearchMode,
+    limit: usize,
+    params: &SearchParams,
+    graph_state: &'a GraphState,
+    ctx: &SearchContext<'_>,
+    sort_by_complexity: bool,
+    sort_by_importance: bool,
+) -> FlatCodeSymbolSearch<'a> {
     let query_lower = query_str.to_lowercase();
     let complexity_search = params.min_complexity.is_some() || sort_by_complexity;
 
@@ -540,6 +646,7 @@ async fn flat_code_symbol_search<'a>(
         min_complexity: params.min_complexity,
     };
     let has_embed_filters = embed_filters.to_sql().is_some();
+    let mut scorer_diagnostic = None;
 
     // Try embed-ranked search for code symbols when query is non-empty.
     // For path/name queries use only the name part so the embedding attends to
@@ -556,16 +663,23 @@ async fn flat_code_symbol_search<'a>(
             } else {
                 rerank_over_fetch * 3
             };
-            match embed_idx
-                .search_with_filters(
-                    embed_query_str,
-                    None,
-                    over_fetch,
-                    search_mode,
-                    &embed_filters,
-                )
-                .await
-            {
+            let scorer = {
+                let embed_idx = embed_idx.clone();
+                let embed_query = embed_query_str.to_string();
+                let embed_filters = embed_filters.clone();
+                async move {
+                    embed_idx
+                        .search_with_filters(
+                            &embed_query,
+                            None,
+                            over_fetch,
+                            search_mode,
+                            &embed_filters,
+                        )
+                        .await
+                }
+            };
+            match isolate_embedding_scorer(scorer, search_mode).await {
                 Ok(SearchOutcome::Results(results)) => {
                     used_embed = true;
                     // Keep only code results, resolve to graph nodes via HashMap (O(1)), apply filters.
@@ -580,7 +694,10 @@ async fn flat_code_symbol_search<'a>(
                 }
                 // Embedding index not ready -- fall through to name/signature fallback.
                 Ok(SearchOutcome::NotReady) => Vec::new(),
-                Err(_) => Vec::new(),
+                Err(diagnostic) => {
+                    scorer_diagnostic = Some(diagnostic);
+                    Vec::new()
+                }
             }
         } else {
             Vec::new()
@@ -770,7 +887,10 @@ async fn flat_code_symbol_search<'a>(
     }
 
     matches.truncate(limit);
-    matches
+    FlatCodeSymbolSearch {
+        matches,
+        scorer_diagnostic,
+    }
 }
 
 async fn search_traversal(
@@ -2535,6 +2655,118 @@ mod tests {
     // ── flat_code_symbol_search tests ──────────────────────────────────
 
     /// Without embed index, flat search falls back to name/signature matching.
+    #[tokio::test]
+    async fn test_scorer_panic_becomes_content_safe_actionable_diagnostic() {
+        let repository_content = "secret-query src/private/customer.rs";
+        let diagnostic = match isolate_embedding_scorer(
+            async move {
+                panic!("{repository_content}");
+                #[allow(unreachable_code)]
+                Ok(SearchOutcome::NotReady)
+            },
+            SearchMode::Semantic,
+        )
+        .await
+        {
+            Err(diagnostic) => diagnostic,
+            Ok(_) => panic!("panicking scorer must degrade"),
+        };
+
+        let rendered = diagnostic.render();
+        assert!(rendered.contains("component=embedding_scorer"));
+        assert!(rendered.contains(&format!("model={EMBEDDING_MODEL_NAME}")));
+        assert!(rendered.contains("index=attached"));
+        assert!(rendered.contains("mode=semantic"));
+        assert!(rendered.contains("failure=task_panic"));
+        assert!(rendered.contains("bounded lexical/graph results"));
+        assert!(!rendered.contains("secret-query"));
+        assert!(!rendered.contains("customer.rs"));
+    }
+
+    #[tokio::test]
+    async fn test_scorer_error_does_not_echo_repository_content() {
+        let diagnostic = match isolate_embedding_scorer(
+            async {
+                Err(anyhow::anyhow!(
+                    "failed near src/private/customer.rs for secret-query"
+                ))
+            },
+            SearchMode::Hybrid,
+        )
+        .await
+        {
+            Err(diagnostic) => diagnostic,
+            Ok(_) => panic!("failing scorer must degrade"),
+        };
+
+        let rendered = diagnostic.render();
+        assert!(rendered.contains("failure=search_error"));
+        assert!(!rendered.contains("secret-query"));
+        assert!(!rendered.contains("customer.rs"));
+    }
+
+    #[tokio::test]
+    async fn test_mapped_graph_fallback_remains_bounded_after_scorer_panic() {
+        let nodes = (0..5)
+            .map(|index| {
+                make_node(
+                    &format!("auth_handler_{index}"),
+                    NodeKind::Function,
+                    &format!("src/auth_{index}.rs"),
+                )
+            })
+            .collect();
+        let gs = make_graph_state(nodes);
+        let stable_ids_before: Vec<String> = gs.nodes.iter().map(Node::stable_id).collect();
+
+        let diagnostic = match isolate_embedding_scorer(
+            async {
+                panic!("simulated scorer failure after worktree map");
+                #[allow(unreachable_code)]
+                Ok(SearchOutcome::NotReady)
+            },
+            SearchMode::Hybrid,
+        )
+        .await
+        {
+            Err(diagnostic) => diagnostic,
+            Ok(_) => panic!("panicking scorer must degrade"),
+        };
+        assert_eq!(diagnostic.failure, "task_panic");
+
+        let repo_root = PathBuf::from("/tmp/live-worktree-map");
+        let ctx = make_search_context(&gs, &repo_root);
+        let params = SearchParams {
+            query: Some("auth".into()),
+            limit: Some(2),
+            include_artifacts: false,
+            include_markdown: false,
+            ..Default::default()
+        };
+        let matches = flat_code_symbol_search(
+            "auth",
+            SearchMode::Hybrid,
+            2,
+            &params,
+            &gs,
+            &ctx,
+            false,
+            false,
+        )
+        .await;
+
+        assert_eq!(
+            matches.len(),
+            2,
+            "fallback must respect the requested limit"
+        );
+        assert_eq!(
+            gs.nodes.iter().map(Node::stable_id).collect::<Vec<_>>(),
+            stable_ids_before,
+            "scorer failure must not invalidate the mapped graph"
+        );
+    }
+
     #[tokio::test]
     async fn test_flat_search_fallback_name_matching() {
         let nodes = vec![


### PR DESCRIPTION
Closes #721

## Problem

A live worktree map can succeed while semantic symbol scoring panics, making the primary RNA-first discovery path unusable even though the graph and lexical candidates remain valid.

## Chosen solution

Harden the existing scorer boundary: validate embedding and Arrow result shapes, convert scorer panics/errors into content-safe component diagnostics at the service boundary, and preserve the bounded lexical fallback without invalidating the graph.

## Scope

- scorer input/output validation and diagnostics
- service-layer panic/error isolation
- map-then-search, bounded fallback, diagnostic-safety, and graph-preservation regression coverage

## Validation plan

`cargo check --lib`, focused regression tests, staged `/review`, the full project `/ship` gate, MCP smoke, and CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `MiniLM-L6-v2` embedding model identifier.
* **Bug Fixes**
  * Hardened semantic/hybrid search to handle empty/malformed embedding and scorer outputs without crashing.
  * When semantic scoring degrades, preserves the mapped graph and returns bounded lexical/graph results with content-safe diagnostics (including redacted panic details).
* **Tests**
  * Added integration and Tokio tests covering panic isolation/redaction, schema validation, bounded fallback/limit behavior, and symbol search after live worktree mapping.
* **Documentation**
  * Updated README with guidance for retrying semantic search after semantic scoring failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->