### PR TITLE
Add a deterministic RustSec CI gate and warning policy

### DIFF
--- a/.github/fixtures/rustsec/current-policy.json
+++ b/.github/fixtures/rustsec/current-policy.json
@@ -1,0 +1,34 @@
+{
+  "database": {
+    "last-commit": "fixture"
+  },
+  "lockfile": {
+    "dependency-count": 829
+  },
+  "vulnerabilities": {
+    "found": false,
+    "count": 0,
+    "list": []
+  },
+  "warnings": {
+    "unmaintained": [
+      {
+        "kind": "unmaintained",
+        "package": {"name": "number_prefix", "version": "0.4.0"},
+        "advisory": {"id": "RUSTSEC-2025-0119"}
+      },
+      {
+        "kind": "unmaintained",
+        "package": {"name": "paste", "version": "1.0.15"},
+        "advisory": {"id": "RUSTSEC-2024-0436"}
+      }
+    ],
+    "unsound": [
+      {
+        "kind": "unsound",
+        "package": {"name": "lru", "version": "0.12.5"},
+        "advisory": {"id": "RUSTSEC-2026-0002"}
+      }
+    ]
+  }
+}

--- a/.github/fixtures/rustsec/vulnerability.json
+++ b/.github/fixtures/rustsec/vulnerability.json
@@ -1,0 +1,39 @@
+{
+  "database": {
+    "last-commit": "fixture"
+  },
+  "lockfile": {
+    "dependency-count": 830
+  },
+  "vulnerabilities": {
+    "found": true,
+    "count": 1,
+    "list": [
+      {
+        "package": {"name": "fixture-vulnerable", "version": "1.0.0"},
+        "advisory": {"id": "RUSTSEC-2099-9999"}
+      }
+    ]
+  },
+  "warnings": {
+    "unmaintained": [
+      {
+        "kind": "unmaintained",
+        "package": {"name": "number_prefix", "version": "0.4.0"},
+        "advisory": {"id": "RUSTSEC-2025-0119"}
+      },
+      {
+        "kind": "unmaintained",
+        "package": {"name": "paste", "version": "1.0.15"},
+        "advisory": {"id": "RUSTSEC-2024-0436"}
+      }
+    ],
+    "unsound": [
+      {
+        "kind": "unsound",
+        "package": {"name": "lru", "version": "0.12.5"},
+        "advisory": {"id": "RUSTSEC-2026-0002"}
+      }
+    ]
+  }
+}

--- a/.github/scripts/check-rustsec-policy.py
+++ b/.github/scripts/check-rustsec-policy.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Fail closed on RustSec vulnerabilities and undeclared warning decisions."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CARGO_AUDIT_VERSION = "0.22.2"
+REQUIRED_FIELDS = {
+    "advisory_id",
+    "package",
+    "version",
+    "kind",
+    "dependency_paths",
+    "rationale",
+    "owner",
+    "removal_issue",
+    "review_triggers",
+    "expires",
+    "approved_by",
+    "approval_evidence",
+}
+ADVISORY_ID = re.compile(r"^RUSTSEC-\d{4}-\d{4}$")
+ISSUE_URL = re.compile(
+    r"^https://github\.com/open-horizon-labs/repo-native-alignment/issues/\d+$"
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read JSON from {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def finding_key(finding: dict[str, Any], kind: str) -> tuple[str, str, str, str]:
+    advisory = finding.get("advisory", {})
+    package = finding.get("package", {})
+    if not isinstance(advisory, dict):
+        advisory = {}
+    if not isinstance(package, dict):
+        package = {}
+    return (
+        str(advisory.get("id", "")),
+        str(package.get("name", "")),
+        str(package.get("version", "")),
+        kind,
+    )
+
+
+def policy_key(entry: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(entry.get("advisory_id", "")),
+        str(entry.get("package", "")),
+        str(entry.get("version", "")),
+        str(entry.get("kind", "")),
+    )
+
+
+def validate_policy(policy: dict[str, Any], today: dt.date) -> list[str]:
+    errors: list[str] = []
+    if policy.get("schema_version") != 1:
+        errors.append("policy schema_version must equal 1")
+    entries = policy.get("warnings")
+    if not isinstance(entries, list):
+        return errors + ["policy warnings must be a list"]
+
+    seen: set[tuple[str, str, str, str]] = set()
+    for index, entry in enumerate(entries):
+        prefix = f"policy warnings[{index}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        missing = sorted(REQUIRED_FIELDS - entry.keys())
+        if missing:
+            errors.append(f"{prefix} is missing: {', '.join(missing)}")
+        key = policy_key(entry)
+        if key in seen:
+            errors.append(f"{prefix} duplicates {' / '.join(key)}")
+        seen.add(key)
+        advisory, package, version, kind = key
+        if not ADVISORY_ID.fullmatch(advisory):
+            errors.append(f"{prefix} has invalid advisory_id {advisory!r}")
+        if not package or not version or "*" in version:
+            errors.append(f"{prefix} must name an exact package version")
+        if kind not in {"unmaintained", "unsound", "notice"}:
+            errors.append(f"{prefix} has unsupported warning kind {kind!r}")
+        for field in ("dependency_paths", "review_triggers"):
+            values = entry.get(field)
+            if not isinstance(values, list) or not values or not all(
+                isinstance(value, str) and value.strip() for value in values
+            ):
+                errors.append(f"{prefix} {field} must be a non-empty string list")
+        for field in ("rationale", "owner", "approved_by", "approval_evidence"):
+            if not isinstance(entry.get(field), str) or not entry[field].strip():
+                errors.append(f"{prefix} {field} must be non-empty")
+        if kind == "unsound" and not str(entry.get("approval_evidence", "")).strip():
+            errors.append(f"{prefix} unsound exception requires human approval evidence")
+        if not ISSUE_URL.fullmatch(str(entry.get("removal_issue", ""))):
+            errors.append(f"{prefix} removal_issue must link an RNA GitHub issue")
+        try:
+            expiry = dt.date.fromisoformat(str(entry.get("expires", "")))
+            if expiry < today:
+                errors.append(f"{prefix} expired on {expiry.isoformat()}")
+        except ValueError:
+            errors.append(f"{prefix} expires must be an ISO date")
+    return errors
+
+
+def evaluate(report: dict[str, Any], policy: dict[str, Any], today: dt.date) -> list[str]:
+    errors = validate_policy(policy, today)
+    vulnerability_block = report.get("vulnerabilities")
+    if not isinstance(vulnerability_block, dict):
+        return errors + ["audit report is missing vulnerabilities"]
+    vulnerabilities = vulnerability_block.get("list")
+    if not isinstance(vulnerabilities, list):
+        return errors + ["audit report vulnerabilities.list must be a list"]
+    for finding in vulnerabilities:
+        if not isinstance(finding, dict):
+            errors.append("audit report contains a malformed vulnerability")
+            continue
+        advisory, package, version, _ = finding_key(finding, "vulnerability")
+        errors.append(f"vulnerability {advisory}: {package} {version}")
+
+    warning_block = report.get("warnings")
+    if not isinstance(warning_block, dict):
+        return errors + ["audit report is missing warnings"]
+    findings: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    for kind, group in warning_block.items():
+        if not isinstance(group, list):
+            errors.append(f"audit report warning group {kind!r} must be a list")
+            continue
+        for finding in group:
+            if not isinstance(finding, dict):
+                errors.append(f"audit report warning group {kind!r} is malformed")
+                continue
+            key = finding_key(finding, str(kind))
+            if key in findings:
+                errors.append(f"audit report duplicates warning {' / '.join(key)}")
+            findings[key] = finding
+
+    policy_entries = policy.get("warnings", [])
+    declared = {
+        policy_key(entry): entry for entry in policy_entries if isinstance(entry, dict)
+    }
+    for key in sorted(findings.keys() - declared.keys()):
+        errors.append(f"undeclared warning {' / '.join(key)}")
+    for key in sorted(declared.keys() - findings.keys()):
+        errors.append(f"stale policy warning {' / '.join(key)}")
+    return errors
+
+
+def print_report(report: dict[str, Any], policy: dict[str, Any]) -> None:
+    database = report.get("database", {})
+    lockfile = report.get("lockfile", {})
+    print(
+        "RustSec database "
+        f"{database.get('last-commit', 'unknown')} | "
+        f"{lockfile.get('dependency-count', 'unknown')} locked dependencies"
+    )
+    entries = policy.get("warnings", [])
+    declared = {
+        policy_key(entry): entry for entry in entries if isinstance(entry, dict)
+    }
+    findings: list[tuple[tuple[str, str, str, str], dict[str, Any]]] = []
+    warning_block = report.get("warnings", {})
+    if isinstance(warning_block, dict):
+        for kind, group in warning_block.items():
+            if isinstance(group, list):
+                findings.extend(
+                    (finding_key(finding, str(kind)), finding)
+                    for finding in group
+                    if isinstance(finding, dict)
+                )
+    for key, _ in sorted(findings):
+        advisory, package, version, kind = key
+        entry = declared.get(key)
+        expiry = entry.get("expires", "UNDECLARED") if entry else "UNDECLARED"
+        print(
+            "WARN allowed until "
+            f"{expiry}: {advisory} {package} {version} ({kind})"
+        )
+        if entry:
+            for path in entry.get("dependency_paths", []):
+                print(f"  path: {path}")
+            print(
+                f"  owner: {entry.get('owner', 'MISSING')} | "
+                f"removal: {entry.get('removal_issue', 'MISSING')}"
+            )
+
+
+def run_live() -> tuple[dict[str, Any], int]:
+    version = subprocess.run(
+        ["cargo", "audit", "--version"], capture_output=True, text=True, check=False
+    )
+    expected = re.compile(
+        rf"^cargo-audit(?:-audit)? {re.escape(CARGO_AUDIT_VERSION)}$"
+    )
+    if version.returncode != 0 or not expected.fullmatch(version.stdout.strip()):
+        raise ValueError(
+            f"expected cargo-audit {CARGO_AUDIT_VERSION}; install with: "
+            "cargo install cargo-audit "
+            f"--version {CARGO_AUDIT_VERSION} --locked"
+        )
+    audit = subprocess.run(
+        ["cargo", "audit", "--json"], capture_output=True, text=True, check=False
+    )
+    if audit.stderr:
+        print(audit.stderr, file=sys.stderr, end="")
+    try:
+        report = json.loads(audit.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"cargo audit did not return JSON: {exc}") from exc
+    if not isinstance(report, dict):
+        raise ValueError("cargo audit report must be a JSON object")
+    return report, audit.returncode
+
+
+def self_test(script_dir: Path, policy: dict[str, Any]) -> list[str]:
+    fixture_dir = script_dir.parent / "fixtures" / "rustsec"
+    current = load_json(fixture_dir / "current-policy.json")
+    vulnerable = load_json(fixture_dir / "vulnerability.json")
+    today = dt.date(2026, 7, 15)
+    failures: list[str] = []
+    if evaluate(current, policy, today):
+        failures.append("current-policy fixture should pass")
+    if not any("vulnerability" in error for error in evaluate(vulnerable, policy, today)):
+        failures.append("vulnerability fixture should fail on a vulnerability")
+
+    unknown = copy.deepcopy(current)
+    unknown["warnings"].setdefault("notice", []).append(
+        {
+            "kind": "notice",
+            "package": {"name": "surprise", "version": "1.0.0"},
+            "advisory": {"id": "RUSTSEC-2099-0001"},
+        }
+    )
+    if not any("undeclared warning" in error for error in evaluate(unknown, policy, today)):
+        failures.append("unknown warning should fail")
+
+    stale = copy.deepcopy(current)
+    stale["warnings"]["unmaintained"] = stale["warnings"]["unmaintained"][1:]
+    if not any("stale policy" in error for error in evaluate(stale, policy, today)):
+        failures.append("stale policy should fail")
+
+    expired = copy.deepcopy(policy)
+    expired["warnings"][0]["expires"] = "2026-07-14"
+    if not any("expired" in error for error in evaluate(current, expired, today)):
+        failures.append("expired policy should fail")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--policy", type=Path, default=Path("security/rustsec-policy.json")
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--live", action="store_true")
+    source.add_argument("--report", type=Path)
+    source.add_argument("--self-test", action="store_true")
+    parser.add_argument("--today", type=dt.date.fromisoformat, default=dt.date.today())
+    args = parser.parse_args()
+    try:
+        policy = load_json(args.policy)
+        if args.self_test:
+            errors = self_test(Path(__file__).resolve().parent, policy)
+            if errors:
+                for error in errors:
+                    print(f"FAIL: {error}", file=sys.stderr)
+                return 1
+            print("RustSec policy fixtures: pass")
+            return 0
+        if args.live:
+            report, audit_status = run_live()
+        else:
+            report, audit_status = load_json(args.report), 0
+        print_report(report, policy)
+        errors = evaluate(report, policy, args.today)
+        if audit_status != 0 and not any("vulnerability" in error for error in errors):
+            errors.append(f"cargo audit exited with status {audit_status}")
+        if errors:
+            for error in errors:
+                print(f"FAIL: {error}", file=sys.stderr)
+            return 1
+        print("RustSec policy decision: pass (0 vulnerabilities, all warnings declared)")
+        return 0
+    except (OSError, ValueError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/rust-main-merge.yml
+++ b/.github/workflows/rust-main-merge.yml
@@ -33,6 +33,38 @@ jobs:
               - '.github/workflows/**'
               - '.github/scripts/**'
               - '.github/fixtures/**'
+              - 'security/rustsec-policy.json'
+
+  audit:
+    needs: changes
+    runs-on: namespace-profile-cached
+    timeout-minutes: 15
+    steps:
+      - name: Skip (no Rust changes)
+        if: needs.changes.outputs.rust != 'true'
+        run: echo "No Rust changes — skipping RustSec audit"
+      - name: Checkout
+        if: needs.changes.outputs.rust == 'true'
+        uses: actions/checkout@v5
+      - name: Install Rust toolchain
+        if: needs.changes.outputs.rust == 'true'
+        uses: dtolnay/rust-toolchain@1.97.0
+      - name: Cache Cargo downloads
+        if: needs.changes.outputs.rust == 'true'
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+      - name: Install pinned cargo-audit
+        if: needs.changes.outputs.rust == 'true'
+        run: cargo install cargo-audit --version 0.22.2 --locked
+      - name: Prove RustSec policy decisions
+        if: needs.changes.outputs.rust == 'true'
+        run: python3 .github/scripts/check-rustsec-policy.py --self-test
+      - name: Audit authoritative lockfile
+        if: needs.changes.outputs.rust == 'true'
+        run: python3 .github/scripts/check-rustsec-policy.py --live
 
   lint:
     needs: changes

--- a/.github/workflows/rust-main-merge.yml
+++ b/.github/workflows/rust-main-merge.yml
@@ -39,6 +39,8 @@ jobs:
     needs: changes
     runs-on: namespace-profile-cached
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Skip (no Rust changes)
         if: needs.changes.outputs.rust != 'true'
@@ -46,6 +48,8 @@ jobs:
       - name: Checkout
         if: needs.changes.outputs.rust == 'true'
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         if: needs.changes.outputs.rust == 'true'
         uses: dtolnay/rust-toolchain@1.97.0
@@ -56,8 +60,15 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-      - name: Install pinned cargo-audit
+      - name: Cache pinned cargo-audit
         if: needs.changes.outputs.rust == 'true'
+        id: cache-cargo-audit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-${{ runner.os }}-${{ runner.arch }}-0.22.2
+      - name: Install pinned cargo-audit
+        if: needs.changes.outputs.rust == 'true' && steps.cache-cargo-audit.outputs.cache-hit != 'true'
         run: cargo install cargo-audit --version 0.22.2 --locked
       - name: Prove RustSec policy decisions
         if: needs.changes.outputs.rust == 'true'

--- a/.oh/metis/rustsec-warning-policy-is-a-lifecycle-not-an-ignore-list.md
+++ b/.oh/metis/rustsec-warning-policy-is-a-lifecycle-not-an-ignore-list.md
@@ -1,0 +1,22 @@
+---
+title: RustSec warning policy is a lifecycle, not an ignore list
+date: 2026-07-15
+outcome: context-assembly
+source_issue: 731
+---
+
+`cargo audit` already separates vulnerability findings from informational
+warnings, but a successful exit does not prove that warning-class risk has an
+owner or removal path. A repository policy should therefore join each exact
+advisory/package/version/kind tuple to its dependency paths, rationale, owner,
+removal issue, review triggers, approval evidence, and expiry.
+
+The join must be exact in both directions. A new warning without policy is an
+unreviewed decision; a policy record without a current warning is stale and
+should be removed. This makes dependency migrations close their warning records
+instead of leaving permanent suppressions behind.
+
+Deterministic report fixtures test the decision mechanism without freezing the
+live advisory database. CI can still query current RustSec data, while fixture
+tests prove that vulnerability, unknown-warning, stale-policy, and expiry paths
+fail closed.

--- a/.oh/sessions/731-execute.md
+++ b/.oh/sessions/731-execute.md
@@ -54,12 +54,25 @@ warning metadata. Rejected for this issue.
 
 ## Acceptance evidence
 
-- [ ] CI installs an exact locked cargo-audit release.
-- [ ] Vulnerability fixtures and live vulnerability reports fail.
-- [ ] Current warning decisions are explicit, complete, unexpired, and visible.
-- [ ] Unknown, stale, or expired warning policy records fail.
-- [ ] The current lockfile passes the declared policy.
-- [ ] Local reproduction is documented.
+- [x] CI installs exact locked `cargo-audit` 0.22.2.
+- [x] The vulnerability fixture exits 1 and names the advisory/package/version.
+- [x] Current warning decisions are explicit, complete, unexpired, and printed.
+- [x] Self-tests reject unknown, stale, and expired warning policy records.
+- [x] The 829-dependency current lockfile passes with 0 vulnerabilities and the
+  three exact warning records.
+- [x] README documents the fixture and live local reproduction commands.
+
+## Verification evidence
+
+- `python3 .github/scripts/check-rustsec-policy.py --self-test` — pass.
+- `python3 .github/scripts/check-rustsec-policy.py --live` — pass against
+  RustSec database commit `9f3e138091487e69144f536d36976e427a7a3307`.
+- Vulnerability fixture command — expected exit 1 with
+  `RUSTSEC-2099-9999: fixture-vulnerable 1.0.0`.
+- `cargo tree --all-features -i` evidence captured exact reverse paths for
+  `lru@0.12.5`, `number_prefix@0.4.0`, and `paste@1.0.15`.
+- Ruby YAML parse of `.github/workflows/rust-main-merge.yml` — pass.
+- `git diff --check` — pass.
 
 ## Stop / pivot triggers
 

--- a/.oh/sessions/731-execute.md
+++ b/.oh/sessions/731-execute.md
@@ -1,3 +1,10 @@
+---
+title: Issue 731 - Deterministic RustSec gate
+date: 2026-07-15
+outcome: context-assembly
+source_issue: 731
+---
+
 # Issue #731 — Deterministic RustSec gate
 
 ## Aim

--- a/.oh/sessions/731-execute.md
+++ b/.oh/sessions/731-execute.md
@@ -1,0 +1,69 @@
+# Issue #731 — Deterministic RustSec gate
+
+## Aim
+
+Make the checked-in Rust dependency graph produce a release-blocking security
+decision in CI, while keeping every non-vulnerability RustSec finding explicit,
+owned, and time-bounded.
+
+## Problem statement
+
+The repository has a recently audited `Cargo.lock`, but Rust CI does not run
+RustSec. Dependabot state therefore cannot prove that the authoritative lockfile
+is free of vulnerability-class advisories. Running bare `cargo audit` would fix
+that gap only partially: informational findings would remain visible but would
+not have a checked-in decision contract.
+
+## Solution space
+
+### A. Bare `cargo audit`
+
+Pin `cargo-audit` and run it in CI. This correctly fails vulnerability-class
+findings, but it does not require ownership, expiry, dependency-path evidence,
+or a removal issue for warning-class findings. Rejected as incomplete.
+
+### B. Put advisory IDs in `.cargo/audit.toml`
+
+This is mechanically narrow, but an ignore list cannot express or validate the
+review metadata required by the issue, and it risks turning temporary decisions
+into silent permanent suppression. Rejected.
+
+### C. Pinned scanner plus checked-in policy validator
+
+Install an exact, locked `cargo-audit` version; capture its JSON report; and
+validate that report against a checked-in warning policy. The validator fails
+on every vulnerability, unknown warning, expired exception, incomplete policy
+record, or stale exception. Deterministic JSON fixtures prove both the failing
+and passing decisions without depending on the live advisory database. Selected.
+
+### D. Replace the dependency-policy stack with `cargo-deny`
+
+This could cover more supply-chain policy, but it expands the problem beyond
+RustSec release signaling and would still need the same project-specific
+warning metadata. Rejected for this issue.
+
+## Selected plan
+
+1. Add a human-readable RustSec policy containing exact advisory IDs,
+   dependency paths, rationale, owner, removal issue, review trigger, and expiry.
+2. Add a standard-library-only validator for `cargo audit --json` reports.
+3. Add deterministic pass/fail fixtures and a self-test command.
+4. Add a pinned CI job, triggered by manifests, lockfile, toolchain, workflows,
+   scripts, fixtures, or policy changes.
+5. Document the exact local reproduction command.
+
+## Acceptance evidence
+
+- [ ] CI installs an exact locked cargo-audit release.
+- [ ] Vulnerability fixtures and live vulnerability reports fail.
+- [ ] Current warning decisions are explicit, complete, unexpired, and visible.
+- [ ] Unknown, stale, or expired warning policy records fail.
+- [ ] The current lockfile passes the declared policy.
+- [ ] Local reproduction is documented.
+
+## Stop / pivot triggers
+
+- Pivot if cargo-audit's machine report cannot distinguish vulnerability and
+  informational findings without lossy text parsing.
+- Pivot if a policy exception would need to cover an advisory version range
+  rather than the exact checked-in finding.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ cd repo-native-alignment
 cargo install --locked --path .
 ```
 
+### Reproduce the RustSec release decision
+
+Rust CI audits the authoritative `Cargo.lock` with a pinned scanner and rejects
+vulnerabilities, undeclared warnings, stale policy records, and expired warning
+decisions. Run the same decision locally:
+
+```bash
+cargo install cargo-audit --version 0.22.2 --locked
+python3 .github/scripts/check-rustsec-policy.py --self-test
+python3 .github/scripts/check-rustsec-policy.py --live
+```
+
+Warning decisions and their dependency paths, owners, removal issues, review
+triggers, and expiries live in `security/rustsec-policy.json`. The policy does
+not use cargo-audit advisory ignores.
+
 ### 2. Connect to your MCP client
 
 The MCP server command is `repo-native-alignment` with `--repo` as an argument. Use a direct binary path for `command` — the `--repo` flag goes in `args`, not in `command`, and MCP stdio launchers should not rely on shell splitting or shell-profile/tool-manager wrappers.

--- a/security/rustsec-policy.json
+++ b/security/rustsec-policy.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "warnings": [
+    {
+      "advisory_id": "RUSTSEC-2026-0002",
+      "package": "lru",
+      "version": "0.12.5",
+      "kind": "unsound",
+      "dependency_paths": [
+        "lru 0.12.5 -> tantivy 0.24.2 -> lance 2.0.0 / lance-index 2.0.0 -> lancedb 0.26.2 -> repo-native-alignment"
+      ],
+      "rationale": "RNA does not call lru directly; the affected IterMut implementation is transitive through Tantivy. No compatible parent requirement currently selects patched lru >=0.16.3. Removal is the active P1, not a permanent acceptance.",
+      "owner": "@muness",
+      "removal_issue": "https://github.com/open-horizon-labs/repo-native-alignment/issues/734",
+      "review_triggers": [
+        "any Tantivy, Lance, lance-index, or LanceDB dependency change",
+        "the removal issue changes state",
+        "the expiry date is reached"
+      ],
+      "expires": "2026-09-30",
+      "approved_by": "@muness",
+      "approval_evidence": "User-directed execution of the complete P1 RustSec remediation batch on 2026-07-15; exact dependency-path evidence is recorded in PR #743."
+    },
+    {
+      "advisory_id": "RUSTSEC-2025-0119",
+      "package": "number_prefix",
+      "version": "0.4.0",
+      "kind": "unmaintained",
+      "dependency_paths": [
+        "number_prefix 0.4.0 -> indicatif 0.17.11 -> hf-hub 0.4.3 -> metal-candle 1.3.0 -> repo-native-alignment (feature: metal)"
+      ],
+      "rationale": "The warning is confined to the optional Metal feature through the repo-owned metal-candle fork. The capability remains supported while its parent chain is upgraded in the linked P1.",
+      "owner": "@muness",
+      "removal_issue": "https://github.com/open-horizon-labs/repo-native-alignment/issues/735",
+      "review_triggers": [
+        "any metal-candle, hf-hub, or indicatif dependency change",
+        "the removal issue changes state",
+        "the expiry date is reached"
+      ],
+      "expires": "2026-09-30",
+      "approved_by": "@muness",
+      "approval_evidence": "User-directed execution of the complete P1 RustSec remediation batch on 2026-07-15; exact dependency-path evidence is recorded in PR #743."
+    },
+    {
+      "advisory_id": "RUSTSEC-2024-0436",
+      "package": "paste",
+      "version": "1.0.15",
+      "kind": "unmaintained",
+      "dependency_paths": [
+        "paste 1.0.15 -> DataFusion / Lance utilities -> lancedb 0.26.2 -> repo-native-alignment",
+        "paste 1.0.15 -> gemm / Candle / tokenizers -> metal-candle 1.3.0 -> repo-native-alignment (feature: metal)",
+        "paste 1.0.15 -> tokenizers 0.22.2 -> fastembed 5.17.2 -> repo-native-alignment (feature: embeddings)"
+      ],
+      "rationale": "Multiple base and optional parent stacks still use the unmaintained macro crate. The residual graph must be recomputed after the Lance and Metal migrations before choosing removal or a narrower exception.",
+      "owner": "@muness",
+      "removal_issue": "https://github.com/open-horizon-labs/repo-native-alignment/issues/736",
+      "review_triggers": [
+        "completion of issue #734 or #735",
+        "any LanceDB, DataFusion, Candle, tokenizers, fastembed, or metal-candle dependency change",
+        "the expiry date is reached"
+      ],
+      "expires": "2026-09-30",
+      "approved_by": "@muness",
+      "approval_evidence": "User-directed execution of the complete P1 RustSec remediation batch on 2026-07-15; all-features reverse-path evidence is recorded in PR #743."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #731

## Problem

Rust CI does not currently audit the authoritative Cargo.lock, and warning-class RustSec findings have no checked-in ownership or expiry contract.

## Chosen solution

Pin cargo-audit, capture its machine report, and validate it against a checked-in warning policy. The validator will fail vulnerabilities, unknown warnings, expired/incomplete exceptions, and stale policy entries. Deterministic fixtures will prove both rejection and acceptance independently of the live advisory database.

## Plan

- add the explicit RustSec warning policy
- add a standard-library-only policy validator and fixtures
- wire a path-filtered pinned CI job
- document the exact local reproduction command

Implementation follows in this draft PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a RustSec release-blocking security audit gate for Rust-related CI changes.
  * Introduced a fail-closed RustSec verification script with deterministic fixtures and expiry handling (self-test + live modes).
* **Bug Fixes**
  * Ensures malformed, unknown, stale, or expired RustSec findings are rejected against the defined policy.
* **Documentation**
  * Added documentation for the RustSec warning lifecycle and local reproduction steps.
  * Added a checked-in description of the deterministic release decision process.
* **Chores**
  * Added RustSec policy and fixture data used by CI to validate audit outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->