### PR TITLE
Remove number_prefix from the Metal feature chain

### DIFF
--- a/.github/fixtures/rustsec/current-policy.json
+++ b/.github/fixtures/rustsec/current-policy.json
@@ -14,11 +14,6 @@
     "unmaintained": [
       {
         "kind": "unmaintained",
-        "package": {"name": "number_prefix", "version": "0.4.0"},
-        "advisory": {"id": "RUSTSEC-2025-0119"}
-      },
-      {
-        "kind": "unmaintained",
         "package": {"name": "paste", "version": "1.0.15"},
         "advisory": {"id": "RUSTSEC-2024-0436"}
       }

--- a/.github/fixtures/rustsec/vulnerability.json
+++ b/.github/fixtures/rustsec/vulnerability.json
@@ -19,11 +19,6 @@
     "unmaintained": [
       {
         "kind": "unmaintained",
-        "package": {"name": "number_prefix", "version": "0.4.0"},
-        "advisory": {"id": "RUSTSEC-2025-0119"}
-      },
-      {
-        "kind": "unmaintained",
         "package": {"name": "paste", "version": "1.0.15"},
         "advisory": {"id": "RUSTSEC-2024-0436"}
       }

--- a/.oh/friction-logs/747-ship.md
+++ b/.oh/friction-logs/747-ship.md
@@ -1,0 +1,14 @@
+---
+date: "2026-07-15"
+pipeline_issue: "/ship PR #747"
+pr: 747
+phase: ship
+---
+
+# PR #747 ship friction
+
+| Date | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-07-15 | RNA worktree search | minor | The new #735 worktree had no persisted Lance cache, so RNA could not query it yet. | Queried the adjacent, already-indexed #734 worktree for unchanged code and test context without falling back to a source scan. | Make a new worktree immediately queryable from its parent branch index. |
+| 2026-07-15 | RNA JSON artifact body | moderate | The #734 RNA index returned the pre-migration RustSec policy body after the branch had moved, which would have reintroduced a removed `lru` record if trusted. | Diagnosed the stale index explicitly and used `git show issue/734:<path>` for the authoritative committed policy and fixtures. | Attach indexed artifact content to its commit identity and surface staleness before returning bodies. |
+| 2026-07-15 | metal-candle prerequisite PR #6 | moderate | The repo exposed no Actions runs for the fork branch, and its first merge attempt conflicted with a newly merged parent PR. | Rebased onto current `main`, reran Rust 1.88 all-feature checks and all 457 executable tests locally, then merged the prerequisite after real CPU/Metal output parity passed. | Enable fork-branch CI and require the verified Rust floor in metal-candle. |

--- a/.oh/metis/repo-owned-forks-must-carry-the-parent-fix.md
+++ b/.oh/metis/repo-owned-forks-must-carry-the-parent-fix.md
@@ -1,0 +1,25 @@
+---
+title: Repo-owned forks must carry the parent fix
+date: 2026-07-15
+outcome: context-assembly
+source_issue: 735
+---
+
+When an advisory is selected inside a repo-owned fork, the consuming repository
+should not hide the feature or force the leaf package. Move the owning parent in
+the fork, verify the real platform capability there, merge it, and pin the
+reviewed merge commit downstream.
+
+For `number_prefix`, upgrading metal-candle from hf-hub 0.4 to 0.5 moved
+indicatif from 0.17 to 0.18 and replaced the leaf with `unit-prefix`. In RNA's
+resolved graph, that upgrade also deduplicated metal-candle onto the hf-hub 0.5
+already used by fastembed, removing 17 obsolete lockfile packages rather than
+adding another parallel HTTP/progress stack.
+
+The fork verification exposed a second contract issue: its declared Rust 1.75
+floor was not compatible with a fresh resolution of its existing `main`
+dependencies. The prerequisite PR made Rust 1.88 explicit, verified its full
+suite and real Metal inference at that floor, and remained below RNA's Rust
+1.91 boundary. Dependency security work should make adjacent version contracts
+more truthful, not preserve a nominal MSRV that current consumers cannot
+resolve.

--- a/.oh/sessions/735-execute.md
+++ b/.oh/sessions/735-execute.md
@@ -1,0 +1,72 @@
+# Issue #735 — Remove number_prefix from the Metal feature chain
+
+## Aim
+
+Remove `RUSTSEC-2025-0119` from RNA's optional Metal dependency graph while
+preserving the real Metal rerank capability and keeping the feature optional.
+
+## Problem statement
+
+`number_prefix 0.4.0` is selected by `indicatif 0.17.11` through `hf-hub
+0.4.3` in RNA's repo-owned `metal-candle 1.3.0` fork. RNA cannot safely patch
+the leaf crate: the owning `indicatif` requirement must move, and the real
+Metal inference path must continue to compile and execute.
+
+## Before path
+
+`number_prefix 0.4.0 -> indicatif 0.17.11 -> hf-hub 0.4.3 -> metal-candle 1.3.0 -> repo-native-alignment (feature: metal)`
+
+## Solution space
+
+### A. Skip Metal in audit or remove the feature
+
+This hides the advisory by deleting coverage or capability. It violates the
+issue's risk-retirement condition. Rejected.
+
+### B. Force number_prefix or indicatif in RNA
+
+RNA does not own either requirement, and a direct dependency cannot change
+`hf-hub`'s incompatible `indicatif 0.17` selection. Rejected.
+
+### C. Upgrade the repo-owned metal-candle fork to hf-hub 0.5
+
+`hf-hub 0.5` moves to `indicatif 0.18`, which uses `unit-prefix` instead of
+`number_prefix`. This is the smallest owning-parent migration and avoids the
+larger hf-hub 1.0 API jump. Update and verify the fork first, then pin RNA to
+the reviewed fork commit and remove the exact RustSec policy/fixture record.
+Selected.
+
+### D. Replace metal-candle or the Candle stack
+
+This would redesign the Metal inference boundary to remove one transitive
+warning. It has much larger API, model-compatibility, and performance risk.
+Rejected.
+
+## Selected plan
+
+1. Open a draft prerequisite PR in `open-horizon-labs/metal-candle` before code.
+2. Upgrade only `hf-hub` 0.4 to 0.5 and adapt bounded API changes if the
+   compiler identifies any.
+3. Verify the fork's embeddings/rerank paths on Apple Silicon and its MSRV.
+4. Point RNA's git dependency at the reviewed fork commit.
+5. Remove the exact `number_prefix` policy and fixtures, then prove the package
+   is absent from the all-feature/all-target graph.
+6. Verify RNA no-default, default, embeddings, and Metal feature boundaries at
+   Rust 1.97 and Rust 1.91, followed by exact-head CI and Metal integration.
+
+## Acceptance evidence
+
+- [ ] `cargo tree --all-features --target all -i number_prefix@0.4.0` finds no
+  package.
+- [ ] Default and no-default graphs do not gain the optional Metal stack.
+- [ ] Rust 1.97 no-default, default, embeddings, and Metal checks pass.
+- [ ] Rust 1.91 remains the verified MSRV.
+- [ ] The real Metal rerank integration passes on the macOS runner.
+- [ ] RustSec passes without a number_prefix policy record or ignore.
+
+## Stop / pivot triggers
+
+- Stop if hf-hub 0.5 breaks the real Metal inference path or requires a Rust
+  version above 1.91.
+- Return to solution space if the fork migration expands beyond its hf-hub
+  boundary into a Candle/model redesign.

--- a/.oh/sessions/735-execute.md
+++ b/.oh/sessions/735-execute.md
@@ -1,3 +1,9 @@
+---
+title: Issue #735 - Remove number_prefix from the Metal feature chain
+date: 2026-07-15
+issue: 735
+---
+
 # Issue #735 — Remove number_prefix from the Metal feature chain
 
 ## Aim
@@ -47,7 +53,8 @@ Rejected.
 1. Open a draft prerequisite PR in `open-horizon-labs/metal-candle` before code.
 2. Upgrade only `hf-hub` 0.4 to 0.5 and adapt bounded API changes if the
    compiler identifies any.
-3. Verify the fork's embeddings/rerank paths on Apple Silicon and its MSRV.
+3. Verify the fork's embeddings paths on Apple Silicon and make its actual
+   resolved MSRV explicit.
 4. Point RNA's git dependency at the reviewed fork commit.
 5. Remove the exact `number_prefix` policy and fixtures, then prove the package
    is absent from the all-feature/all-target graph.
@@ -56,13 +63,32 @@ Rejected.
 
 ## Acceptance evidence
 
-- [ ] `cargo tree --all-features --target all -i number_prefix@0.4.0` finds no
+- [x] `cargo tree --all-features --target all -i number_prefix@0.4.0` finds no
   package.
-- [ ] Default and no-default graphs do not gain the optional Metal stack.
-- [ ] Rust 1.97 no-default, default, embeddings, and Metal checks pass.
-- [ ] Rust 1.91 remains the verified MSRV.
-- [ ] The real Metal rerank integration passes on the macOS runner.
-- [ ] RustSec passes without a number_prefix policy record or ignore.
+- [x] Default and no-default graphs do not gain the optional Metal stack.
+- [x] Rust 1.97 no-default, default, embeddings, and Metal checks pass.
+- [x] Rust 1.91 remains the verified MSRV.
+- [x] The real Metal embeddings integration passes on Apple Silicon.
+- [x] RustSec passes without a number_prefix policy record or ignore.
+
+## Implementation evidence
+
+- metal-candle PR #6 merged as
+  `9966033a92befe0d760813e3a61152271ecd2822`; RNA pins that reviewed commit.
+- The fork's fresh dependency graph made its stale Rust 1.75 declaration
+  explicit as Rust 1.88. At that floor, all-feature check and 457 executable
+  tests passed, with 9 documentation tests ignored.
+- The release-mode Metal embeddings example produced `[3, 384]` on CPU and
+  Metal with a maximum output difference of `0.000000`.
+- RNA's lockfile removed hf-hub 0.4.3, indicatif 0.17.11, number_prefix 0.4.0,
+  ureq 2.12.1, and their obsolete platform packages; metal-candle now shares
+  hf-hub 0.5 with fastembed.
+- The live RustSec gate reports 778 locked packages, zero vulnerabilities, and
+  only #736's declared `paste` warning.
+- Rust 1.91 and Rust 1.97 each pass no-default, default, embeddings, and Metal
+  library checks with the pinned fork commit.
+- RNA's ignored product-level rerank integration passed with Rust 1.97 and the
+  full embeddings feature graph: 1 passed, 0 failed, 2,002 filtered out.
 
 ## Stop / pivot triggers
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,19 +1142,6 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
@@ -2447,7 +2434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545e4fb17fc48768ff36c2a3854aa5b0b809d0ed595ab5530fa8ac94f31bd0ea"
 dependencies = [
  "anyhow",
- "hf-hub 0.5.0",
+ "hf-hub",
  "image",
  "ndarray 0.17.2",
  "ort",
@@ -3177,14 +3164,14 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hf-hub"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs 6.0.0",
  "futures",
  "http",
- "indicatif 0.17.11",
+ "indicatif",
  "libc",
  "log",
  "native-tls",
@@ -3195,28 +3182,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "ureq 2.12.1",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "hf-hub"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
-dependencies = [
- "dirs 6.0.0",
- "http",
- "indicatif 0.18.6",
- "libc",
- "log",
- "native-tls",
- "rand 0.9.5",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "ureq 3.3.0",
+ "ureq",
  "windows-sys 0.61.2",
 ]
 
@@ -3313,7 +3279,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3564,24 +3530,11 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console 0.15.11",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
- "web-time",
-]
-
-[[package]]
-name = "indicatif"
 version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
- "console 0.16.4",
+ "console",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -4752,14 +4705,14 @@ dependencies = [
 [[package]]
 name = "metal-candle"
 version = "1.3.0"
-source = "git+https://github.com/open-horizon-labs/metal-candle#66fa2b5e3a70b8ce6d393c59e563c6f1452eac8a"
+source = "git+https://github.com/open-horizon-labs/metal-candle?rev=9966033a92befe0d760813e3a61152271ecd2822#9966033a92befe0d760813e3a61152271ecd2822"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
  "candle-nn",
  "candle-transformers",
  "dirs 5.0.1",
- "hf-hub 0.4.3",
+ "hf-hub",
  "objc2-metal",
  "rand 0.8.7",
  "safetensors 0.7.0",
@@ -5098,12 +5051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5312,7 +5259,7 @@ dependencies = [
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq 3.3.0",
+ "ureq",
 ]
 
 [[package]]
@@ -5323,7 +5270,7 @@ checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
- "ureq 3.3.0",
+ "ureq",
 ]
 
 [[package]]
@@ -6319,7 +6266,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -8066,26 +8013,6 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "native-tls",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "socks",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
@@ -8105,7 +8032,7 @@ dependencies = [
  "ureq-proto",
  "utf8-zero",
  "webpki-root-certs",
- "webpki-roots 1.0.8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -8330,15 +8257,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.8",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
@@ -8473,24 +8391,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -8522,28 +8422,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -8559,12 +8442,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8575,12 +8452,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8595,22 +8466,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8625,12 +8484,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8641,12 +8494,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8661,12 +8508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8677,12 +8518,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ arrow-array = "58"
 arrow-schema = "58"
 
 # Optional local embeddings — Metal GPU on Apple Silicon, CPU fallback
-metal-candle = { git = "https://github.com/open-horizon-labs/metal-candle", default-features = false, features = ["embeddings"], optional = true }
+metal-candle = { git = "https://github.com/open-horizon-labs/metal-candle", rev = "9966033a92befe0d760813e3a61152271ecd2822", default-features = false, features = ["embeddings"], optional = true }
 candle-core = { version = "0.9", optional = true }
 
 # Optional cross-encoder reranking (ONNX runtime, CPU inference)

--- a/security/rustsec-policy.json
+++ b/security/rustsec-policy.json
@@ -2,26 +2,6 @@
   "schema_version": 1,
   "warnings": [
     {
-      "advisory_id": "RUSTSEC-2025-0119",
-      "package": "number_prefix",
-      "version": "0.4.0",
-      "kind": "unmaintained",
-      "dependency_paths": [
-        "number_prefix 0.4.0 -> indicatif 0.17.11 -> hf-hub 0.4.3 -> metal-candle 1.3.0 -> repo-native-alignment (feature: metal)"
-      ],
-      "rationale": "The warning is confined to the optional Metal feature through the repo-owned metal-candle fork. The capability remains supported while its parent chain is upgraded in the linked P1.",
-      "owner": "@muness",
-      "removal_issue": "https://github.com/open-horizon-labs/repo-native-alignment/issues/735",
-      "review_triggers": [
-        "any metal-candle, hf-hub, or indicatif dependency change",
-        "the removal issue changes state",
-        "the expiry date is reached"
-      ],
-      "expires": "2026-09-30",
-      "approved_by": "@muness",
-      "approval_evidence": "User-directed execution of the complete P1 RustSec remediation batch on 2026-07-15; exact dependency-path evidence is recorded in PR #743."
-    },
-    {
       "advisory_id": "RUSTSEC-2024-0436",
       "package": "paste",
       "version": "1.0.15",
@@ -31,11 +11,11 @@
         "paste 1.0.15 -> gemm / Candle / tokenizers -> metal-candle 1.3.0 -> repo-native-alignment (feature: metal)",
         "paste 1.0.15 -> tokenizers 0.22.2 -> fastembed 5.17.2 -> repo-native-alignment (feature: embeddings)"
       ],
-      "rationale": "The Lance migration removed the lru advisory but DataFusion 53.1.0 and the optional embedding/Metal parents still use the unmaintained macro crate. The residual graph must be recomputed after the Metal migration before choosing removal or a narrower exception.",
+      "rationale": "The Lance and Metal parent migrations removed the lru and number_prefix advisories, but DataFusion 53.1.0 and the embedding/Metal parents still use the unmaintained macro crate. Issue #736 owns the final residual-path convergence decision.",
       "owner": "@muness",
       "removal_issue": "https://github.com/open-horizon-labs/repo-native-alignment/issues/736",
       "review_triggers": [
-        "completion of issue #735 or any later Lance parent migration",
+        "any later Lance, Metal, Candle, tokenizers, or fastembed parent migration",
         "any LanceDB, DataFusion, Candle, tokenizers, fastembed, or metal-candle dependency change",
         "the expiry date is reached"
       ],


### PR DESCRIPTION
Closes #735\nDepends on #744.\nPrerequisite: https://github.com/open-horizon-labs/metal-candle/pull/6 (merged at 9966033a92befe0d760813e3a61152271ecd2822)\n\n## Problem\n\nThe optional Metal graph selected number_prefix 0.4.0 through indicatif 0.17.11 -> hf-hub 0.4.3 -> metal-candle 1.3.0. Hiding or removing the Metal feature would not fix the supported capability.\n\n## Chosen solution\n\nUpgrade the repo-owned metal-candle fork from hf-hub 0.4 to 0.5, verify it at its actual Rust 1.88 floor and with real Apple Metal inference, merge that prerequisite, then pin RNA to the reviewed merge commit. This moves indicatif to 0.18 and unit-prefix, deduplicates metal-candle onto the hf-hub 0.5 already used by fastembed, and removes the exact number_prefix RustSec policy entry and fixtures.\n\n## Implementation\n\n- pins metal-candle to merged commit 9966033a92befe0d760813e3a61152271ecd2822\n- removes hf-hub 0.4.3, indicatif 0.17.11, number_prefix 0.4.0, ureq 2.12.1, and 17 obsolete lockfile packages\n- keeps Metal optional and leaves default/no-default feature boundaries unchanged\n- removes only the number_prefix warning record; #736 retains ownership of the residual paste paths\n- records the fork-boundary learning and ship friction\n\n## Verification\n\n- number_prefix is absent from the all-feature/all-target dependency graph\n- default and no-default graphs do not contain metal-candle\n- Rust 1.97: no-default, default, embeddings, and Metal checks pass\n- Rust 1.91: no-default, default, embeddings, and Metal checks pass\n- metal-candle Rust 1.88 all-feature check and 457 executable tests pass\n- release-mode Apple Metal embeddings output matches CPU output exactly: shape [3, 384], max diff 0.000000\n- RNA ignored rerank integration passes: 1 passed, 0 failed\n- live RustSec reports zero vulnerabilities and only #736 paste as the declared warning\n- policy self-test passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Removed the unmaintained `number_prefix` advisory from the active RustSec policy and related validation fixtures.

- **Improvements**
  - Updated the optional Metal integration to a reviewed dependency revision while preserving Metal embedding and reranking capabilities.

- **Documentation**
  - Added guidance and project records covering dependency updates, security policy handling, compatibility requirements, and release-related friction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->