### PR TITLE
Measure and simplify LanceDB write serialization after the 0.31 migration

### DIFF
--- a/.oh/friction-logs/751-ship.md
+++ b/.oh/friction-logs/751-ship.md
@@ -1,0 +1,8 @@
+# PR #751 ship friction
+
+| Time | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-07-15 | RNA MCP `repo_map` / `search` / `outcome_progress` | skipped | No RNA MCP tools were exposed in this issue agent session. | Used the installed RNA CLI with `--repo .` after a full scan for symbol, artifact, and graph navigation. | Ensure issue agents inherit the repo's RNA MCP server. |
+| 2026-07-15 | RNA function-body navigation | skipped | RNA identified symbols, callers, and neighbors but does not render the implementation body needed for a targeted edit. | Used bounded `sed` ranges after RNA located the exact symbols. | Add source-snippet rendering for exact symbol results. |
+| 2026-07-15 | GitButler branch management | skipped | `but status -fv` reported that the checkout was not on a `gitbutler/*` branch. | Used direct Git to rebase the existing issue branch onto the newly shipped dependency. | Make the draft-PR issue branches GitButler-manageable without renaming them. |
+| 2026-07-15 | Repository-wide `cargo fmt --check` | minor | Existing unrelated files are not rustfmt-clean, producing a large unrelated diff report. | Formatted and verified only the changed Rust file; no unrelated formatting changes were made. | Restore repository-wide formatting separately. |

--- a/.oh/metis/lancedb-031-concurrency-defenses-remain-justified.md
+++ b/.oh/metis/lancedb-031-concurrency-defenses-remain-justified.md
@@ -1,0 +1,58 @@
+---
+id: lancedb-031-concurrency-defenses-remain-justified
+outcome: context-assembly
+title: LanceDB 0.31 did not justify removing RNA write serialization or retries
+source_issue: 746
+---
+
+## What was measured
+
+RNA's incremental graph persistence was exercised through genuine child
+processes sharing one local LanceDB store. The regression matrix varies two
+controls independently:
+
+| Scenario | Process scheduling | Merge retry limit | Attempted writes | Final unique rows | Elapsed |
+|---|---:|---:|---:|---:|---:|
+| serialized with retries | sequential | 3 | 24 | 25 | 500 ms |
+| serialized without retries | sequential | 0 | 24 | 25 | 163 ms |
+| concurrent with retries | parallel | 3 | 24 | 25 | 103 ms |
+| concurrent without retries | parallel | 0 | 24 | 25 | 91 ms |
+
+The extra row in each result is the baseline row. All stable IDs were unique
+and visible after reopening the store. The no-retry cases completing means the
+small incremental workload observed no merge conflict; it does not prove that
+conflicts cannot occur.
+
+## Decision
+
+Retain both safeguards.
+
+The in-process mutex covers more than incremental `merge_insert`: foreground
+full persists, background scanner finalization, schema migration fallback,
+root pruning, version-pointer flips, compaction, and embedding writes share the
+same storage boundary. The child-process matrix deliberately proves that
+incremental writes are currently robust under one reproducible pressure test,
+but it cannot make the broader full-persist and embedding races disappear.
+
+The bounded conflict retries remain cheap insurance for separate RNA processes,
+which cannot share the Tokio mutex. A zero-conflict sample is insufficient to
+retire a defense added after real failures. Removal would require a deterministic
+way to force and observe every supported writer overlap, including interrupted
+full persists and embedding delete-plus-add operations.
+
+## Reproduction
+
+Run:
+
+```text
+cargo test --lib server::store::persist::tests::cross_process_write_matrix_preserves_all_rows -- --nocapture
+```
+
+The test uses the current Rust test executable as two independent OS processes,
+not Tokio tasks, and validates final persisted rows after every scenario.
+
+## Guardrail
+
+Do not infer concurrency safety from a successful no-retry benchmark alone.
+Only remove a persistence defense when the test matrix covers every writer that
+the defense coordinates and can deterministically exercise the historical race.

--- a/.oh/metis/lancedb-031-concurrency-defenses-remain-justified.md
+++ b/.oh/metis/lancedb-031-concurrency-defenses-remain-justified.md
@@ -7,9 +7,20 @@ source_issue: 746
 
 ## What was measured
 
-RNA's incremental graph persistence was exercised through genuine child
-processes sharing one local LanceDB store. The regression matrix varies two
-controls independently:
+RNA's incremental graph persistence was exercised both with Tokio tasks that
+share the same mutex and with genuine child processes sharing one local
+LanceDB store. The in-process matrix toggles the actual equivalent of RNA's
+serialization boundary independently from its retry limit:
+
+| Scenario | Mutex | Retry limit | Successful mutations | Conflicts | Lock wait | Table version | Final rows |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| mutex on, retries on | on | 3 | 24 | 0 | 169 ms | 26 | 25 |
+| mutex on, retries off | on | 0 | 24 | 0 | 149 ms | 26 | 25 |
+| mutex off, retries on | off | 3 | 24 | 0 | 0 | 26 | 25 |
+| mutex off, retries off | off | 0 | 24 | 0 | 0 | 26 | 25 |
+
+The separate-process matrix varies process scheduling and retry limit. It does
+not claim that scheduling toggles the in-process mutex:
 
 | Scenario | Process scheduling | Merge retry limit | Attempted writes | Final unique rows | Elapsed |
 |---|---:|---:|---:|---:|---:|
@@ -39,6 +50,18 @@ which cannot share the Tokio mutex. A zero-conflict sample is insufficient to
 retire a defense added after real failures. Removal would require a deterministic
 way to force and observe every supported writer overlap, including interrupted
 full persists and embedding delete-plus-add operations.
+
+The full-persist overlap supplies the decisive serialization evidence. With
+the mutex, foreground and background full writers committed scan versions 2
+then 3 and the reopened store exposed exactly one complete snapshot. Without
+the mutex, both selected scan version 2 and the reopened store exposed the
+union of both snapshots (two rows). That violates full-snapshot semantics even
+though the store remained readable, so serialization is required.
+
+An interrupted separate-process incremental writer is also killed mid-run and
+the store is reopened. The last committed baseline remains visible and stable
+IDs remain unique. Typed delete, edge delete, scan-version filtering, and stale
+version compaction remain covered by the adjacent persistence regression suite.
 
 ## Reproduction
 

--- a/.oh/sessions/751-ship.md
+++ b/.oh/sessions/751-ship.md
@@ -1,0 +1,31 @@
+## Ship Pipeline — PR #751
+**Started:** 2026-07-15
+
+### Pre-flight
+- PR: #751 `Measure and simplify LanceDB write serialization after the 0.31 migration`
+- Branch: `issue/746`
+- Issue: #746
+- Dependency #745: shipped on `main` via #750 before execution resumed.
+- RNA scan gate: full scan refreshed a schema-v23 index with 22,360 symbols.
+- Initial CodeRabbit state: draft review skipped; explicit final review required after ready.
+- Delivery classification: no agent-visible data or MCP contract changes; MCP delivery checklist is N/A, but real persisted-read verification remains required.
+
+### Step 1: RNA-Grounded Review
+**Verdict:** CONTINUE
+**Metis checked:** concurrency-defense evidence, durable logical serialization, computed-but-not-delivered
+**Guardrails checked:** repo-native, no-parallel-cargo, dogfood-rna-tools, computed-but-not-delivered, CodeRabbit approval
+**Findings:** 4; production safeguards retained, experimental no-retry flakiness bounded, inference limits documented
+
+### Step 2: Independent Code Review
+**Initial verdict:** REQUEST CHANGES
+Critical finding: the first matrix varied process scheduling rather than RNA's
+actual mutex boundary. Major findings also required broader writer coverage,
+metrics, and recovery validation.
+
+### Step 3: Fix
+- Added an in-process matrix that independently toggles a shared persistence mutex and retry limit.
+- Instrumented lock wait, observed conflicts, successful Lance mutations, elapsed time, table version, and final rows.
+- Added foreground/background full-persist overlap; the unprotected leg reproduces snapshot-union corruption while the protected leg preserves one snapshot.
+- Added killed child-process recovery and mandatory reopened-store validation.
+- Corrected the metis evidence and superseded the overstated initial acceptance assessment.
+- Re-review pending before the PR can be marked ready.

--- a/src/server/store/persist.rs
+++ b/src/server/store/persist.rs
@@ -1,6 +1,7 @@
 //! Graph persistence: full persist, incremental upsert, compaction, and root pruning.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use anyhow::Context;
@@ -16,6 +17,12 @@ use super::migrate::{
     read_committed_scan_version, write_committed_scan_version,
 };
 use super::{PREDICATE_BATCH_SIZE, graph_lance_path, string_isin};
+
+#[derive(Default)]
+struct PersistInstrumentation {
+    conflicts: AtomicU64,
+    successful_mutations: AtomicU64,
+}
 
 /// Persist graph nodes and edges to LanceDB using append-only versioned writes.
 ///
@@ -283,6 +290,7 @@ pub(crate) async fn persist_graph_incremental(
         deleted_edge_ids,
         deleted_files,
         retry_limit,
+        None,
     )
     .await
 }
@@ -294,6 +302,7 @@ async fn persist_graph_incremental_with_retry_limit(
     deleted_edge_ids: &[String],
     deleted_files: &[(String, PathBuf)],
     retry_limit: u64,
+    instrumentation: Option<&PersistInstrumentation>,
 ) -> anyhow::Result<bool> {
     let db_path = graph_lance_path(repo_root);
     std::fs::create_dir_all(&db_path)?;
@@ -364,7 +373,12 @@ async fn persist_graph_incremental_with_retry_limit(
                         // Note: no when_not_matched_by_source_delete -- we only touch changed rows.
                         // Untouched rows (unchanged files) are left alone.
                         match merge.execute(Box::new(batches)).await {
-                            Ok(_) => break,
+                            Ok(_) => {
+                                if let Some(metrics) = instrumentation {
+                                    metrics.successful_mutations.fetch_add(1, Ordering::Relaxed);
+                                }
+                                break;
+                            }
                             Err(e) => {
                                 let err = anyhow::anyhow!("{}", e);
                                 if is_schema_mismatch_error(&err) {
@@ -375,6 +389,9 @@ async fn persist_graph_incremental_with_retry_limit(
                                     drop_all_lance_tables(&db_path);
                                     return Ok(true);
                                 } else if is_conflict_error(&err) && attempts < retry_limit {
+                                    if let Some(metrics) = instrumentation {
+                                        metrics.conflicts.fetch_add(1, Ordering::Relaxed);
+                                    }
                                     attempts += 1;
                                     tracing::warn!(
                                         "LanceDB conflict on symbols merge_insert (attempt {}), retrying in {}ms",
@@ -434,7 +451,12 @@ async fn persist_graph_incremental_with_retry_limit(
                             .when_not_matched_insert_all();
                         // Note: no when_not_matched_by_source_delete -- untouched edges are preserved.
                         match merge.execute(Box::new(batches)).await {
-                            Ok(_) => break,
+                            Ok(_) => {
+                                if let Some(metrics) = instrumentation {
+                                    metrics.successful_mutations.fetch_add(1, Ordering::Relaxed);
+                                }
+                                break;
+                            }
                             Err(e) => {
                                 let err = anyhow::anyhow!("{}", e);
                                 if is_schema_mismatch_error(&err) {
@@ -445,6 +467,9 @@ async fn persist_graph_incremental_with_retry_limit(
                                     drop_all_lance_tables(&db_path);
                                     return Ok(true);
                                 } else if is_conflict_error(&err) && attempts < retry_limit {
+                                    if let Some(metrics) = instrumentation {
+                                        metrics.conflicts.fetch_add(1, Ordering::Relaxed);
+                                    }
                                     attempts += 1;
                                     tracing::warn!(
                                         "LanceDB conflict on edges merge_insert (attempt {}), retrying in {}ms",
@@ -587,6 +612,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::process::{Command, Stdio};
+    use std::sync::Arc;
     use std::time::Instant;
 
     use super::super::graph_lance_path;
@@ -640,6 +666,156 @@ mod tests {
         let (r1, r2) = tokio::join!(task1, task2);
         r1.expect("task1 panicked").expect("task1 returned error");
         r2.expect("task2 panicked").expect("task2 returned error");
+    }
+
+    #[tokio::test]
+    async fn in_process_serialization_and_retry_controls_are_independent() {
+        const WRITES_PER_TASK: usize = 12;
+
+        for (label, serialized, retry_limit) in [
+            ("mutex_on_retries_on", true, 3),
+            ("mutex_on_retries_off", true, 0),
+            ("mutex_off_retries_on", false, 3),
+            ("mutex_off_retries_off", false, 0),
+        ] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            persist_graph_to_lance(dir.path(), &[make_test_node("baseline")], &[])
+                .await
+                .expect("baseline persist");
+            let mutex = Arc::new(tokio::sync::Mutex::new(()));
+            let metrics = Arc::new(PersistInstrumentation::default());
+            let lock_wait_micros = Arc::new(AtomicU64::new(0));
+            let started = Instant::now();
+            let mut tasks = Vec::new();
+            for task_id in 0..2 {
+                let root = dir.path().to_path_buf();
+                let mutex = Arc::clone(&mutex);
+                let metrics = Arc::clone(&metrics);
+                let lock_wait_micros = Arc::clone(&lock_wait_micros);
+                tasks.push(tokio::spawn(async move {
+                    for write_id in 0..WRITES_PER_TASK {
+                        let lock_started = Instant::now();
+                        let guard = if serialized {
+                            Some(mutex.lock().await)
+                        } else {
+                            None
+                        };
+                        lock_wait_micros.fetch_add(
+                            lock_started.elapsed().as_micros() as u64,
+                            Ordering::Relaxed,
+                        );
+                        let result = persist_graph_incremental_with_retry_limit(
+                            &root,
+                            &[make_test_node(&format!("task_{task_id}_{write_id}"))],
+                            &[],
+                            &[],
+                            &[],
+                            retry_limit,
+                            Some(&metrics),
+                        )
+                        .await;
+                        drop(guard);
+                        result?;
+                    }
+                    anyhow::Ok(())
+                }));
+            }
+            for task in tasks {
+                task.await
+                    .expect("writer task panicked")
+                    .unwrap_or_else(|error| panic!("{label}: protected writer failed: {error:#}"));
+            }
+            let state = load_graph_from_lance(dir.path())
+                .await
+                .expect("reopen final graph");
+            assert_eq!(state.nodes.len(), 1 + 2 * WRITES_PER_TASK, "{label}");
+            let unique: std::collections::HashSet<_> =
+                state.nodes.iter().map(Node::stable_id).collect();
+            assert_eq!(unique.len(), state.nodes.len(), "{label}: duplicate IDs");
+            let db = lancedb::connect(graph_lance_path(dir.path()).to_str().expect("utf-8 path"))
+                .execute()
+                .await
+                .expect("connect for table version");
+            let table_version = db
+                .open_table("symbols")
+                .execute()
+                .await
+                .expect("open symbols")
+                .version()
+                .await
+                .expect("read table version");
+            eprintln!(
+                "LanceDB in-process matrix: scenario={label} serialized={serialized} retry_limit={retry_limit} lock_wait_us={} conflicts={} successful_mutations={} elapsed_ms={} table_version={table_version} final_rows={}",
+                lock_wait_micros.load(Ordering::Relaxed),
+                metrics.conflicts.load(Ordering::Relaxed),
+                metrics.successful_mutations.load(Ordering::Relaxed),
+                started.elapsed().as_millis(),
+                state.nodes.len(),
+            );
+        }
+    }
+
+    /// Foreground scans and background enrichment both perform full graph
+    /// persists. This scenario demonstrates why their shared mutex protects a
+    /// wider boundary than incremental merge conflict retries: without the
+    /// mutex, both writers may publish the same next scan version and expose a
+    /// union of snapshots rather than one complete snapshot.
+    #[tokio::test]
+    async fn full_persist_serialization_preserves_snapshot_semantics() {
+        for serialized in [true, false] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            persist_graph_to_lance(dir.path(), &[make_test_node("baseline")], &[])
+                .await
+                .expect("baseline persist");
+            let mutex = Arc::new(tokio::sync::Mutex::new(()));
+            let wait_micros = Arc::new(AtomicU64::new(0));
+            let started = Instant::now();
+            let mut tasks = Vec::new();
+            for writer in ["foreground", "background"] {
+                let root = dir.path().to_path_buf();
+                let mutex = Arc::clone(&mutex);
+                let wait_micros = Arc::clone(&wait_micros);
+                tasks.push(tokio::spawn(async move {
+                    let lock_started = Instant::now();
+                    let guard = if serialized {
+                        Some(mutex.lock().await)
+                    } else {
+                        None
+                    };
+                    wait_micros
+                        .fetch_add(lock_started.elapsed().as_micros() as u64, Ordering::Relaxed);
+                    let result =
+                        persist_graph_to_lance(&root, &[make_test_node(writer)], &[]).await;
+                    drop(guard);
+                    result
+                }));
+            }
+            for task in tasks {
+                task.await
+                    .expect("full writer panicked")
+                    .expect("full writer failed");
+            }
+            let state = load_graph_from_lance(dir.path())
+                .await
+                .expect("store must remain readable");
+            let unique: std::collections::HashSet<_> =
+                state.nodes.iter().map(Node::stable_id).collect();
+            assert_eq!(unique.len(), state.nodes.len(), "duplicate stable IDs");
+            if serialized {
+                assert_eq!(
+                    state.nodes.len(),
+                    1,
+                    "serialized full persists expose exactly one complete snapshot"
+                );
+            }
+            let committed = read_committed_scan_version(&graph_lance_path(dir.path()));
+            eprintln!(
+                "LanceDB full/background matrix: serialized={serialized} lock_wait_us={} elapsed_ms={} committed_scan_version={committed} final_rows={}",
+                wait_micros.load(Ordering::Relaxed),
+                started.elapsed().as_millis(),
+                state.nodes.len(),
+            );
+        }
     }
 
     /// Child-process entry point for the adversarial writer test below. Keeping
@@ -816,6 +992,44 @@ mod tests {
                 state.nodes.len(),
             );
         }
+    }
+
+    #[test]
+    fn interrupted_cross_process_writer_leaves_committed_store_readable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
+        runtime
+            .block_on(persist_graph_to_lance(
+                dir.path(),
+                &[make_test_node("baseline")],
+                &[],
+            ))
+            .expect("baseline persist");
+
+        let test_binary = std::env::current_exe().expect("current test binary");
+        let mut child = writer_command(&test_binary, dir.path(), "interrupted", 500, 3)
+            .spawn()
+            .expect("spawn writer");
+        std::thread::sleep(Duration::from_millis(20));
+        child.kill().expect("interrupt writer");
+        let status = child.wait().expect("reap interrupted writer");
+        assert!(!status.success(), "writer should have been interrupted");
+
+        let state = runtime
+            .block_on(load_graph_from_lance(dir.path()))
+            .expect("interrupted writer must leave store readable");
+        assert!(
+            state.nodes.iter().any(|node| node.id.name == "baseline"),
+            "last committed baseline must survive interruption"
+        );
+        let unique: std::collections::HashSet<_> =
+            state.nodes.iter().map(Node::stable_id).collect();
+        assert_eq!(unique.len(), state.nodes.len(), "no duplicate stable IDs");
+        eprintln!(
+            "LanceDB interruption: final_rows={} committed_scan_version={} store_readable=true",
+            state.nodes.len(),
+            read_committed_scan_version(&graph_lance_path(dir.path())),
+        );
     }
 
     #[tokio::test]

--- a/src/server/store/persist.rs
+++ b/src/server/store/persist.rs
@@ -24,6 +24,17 @@ struct PersistInstrumentation {
     successful_mutations: AtomicU64,
 }
 
+#[cfg(test)]
+fn signal_test_write_started() {
+    let Ok(path) = std::env::var("RNA_TEST_LANCE_READY_FILE") else {
+        return;
+    };
+    let _ = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path);
+}
+
 /// Persist graph nodes and edges to LanceDB using append-only versioned writes.
 ///
 /// Each call appends a new `scan_version` (monotonically incrementing) to the tables
@@ -372,6 +383,8 @@ async fn persist_graph_incremental_with_retry_limit(
                             .when_not_matched_insert_all();
                         // Note: no when_not_matched_by_source_delete -- we only touch changed rows.
                         // Untouched rows (unchanged files) are left alone.
+                        #[cfg(test)]
+                        signal_test_write_started();
                         match merge.execute(Box::new(batches)).await {
                             Ok(_) => {
                                 if let Some(metrics) = instrumentation {
@@ -450,6 +463,8 @@ async fn persist_graph_incremental_with_retry_limit(
                             .when_matched_update_all(None)
                             .when_not_matched_insert_all();
                         // Note: no when_not_matched_by_source_delete -- untouched edges are preserved.
+                        #[cfg(test)]
+                        signal_test_write_started();
                         match merge.execute(Box::new(batches)).await {
                             Ok(_) => {
                                 if let Some(metrics) = instrumentation {
@@ -720,15 +735,29 @@ mod tests {
                     anyhow::Ok(())
                 }));
             }
-            for task in tasks {
-                task.await
-                    .expect("writer task panicked")
-                    .unwrap_or_else(|error| panic!("{label}: protected writer failed: {error:#}"));
+            let errors: Vec<anyhow::Error> = futures::future::join_all(tasks)
+                .await
+                .into_iter()
+                .map(|result| result.expect("writer task panicked"))
+                .filter_map(Result::err)
+                .collect();
+            if !errors.is_empty() {
+                assert!(
+                    !serialized && retry_limit == 0,
+                    "{label}: protected writer failed: {errors:#?}"
+                );
+                eprintln!("{label}: expected unprotected zero-retry failures: {errors:#?}");
             }
             let state = load_graph_from_lance(dir.path())
                 .await
                 .expect("reopen final graph");
-            assert_eq!(state.nodes.len(), 1 + 2 * WRITES_PER_TASK, "{label}");
+            assert!(
+                state.nodes.iter().any(|node| node.id.name == "baseline"),
+                "{label}: committed baseline must remain visible"
+            );
+            if errors.is_empty() {
+                assert_eq!(state.nodes.len(), 1 + 2 * WRITES_PER_TASK, "{label}");
+            }
             let unique: std::collections::HashSet<_> =
                 state.nodes.iter().map(Node::stable_id).collect();
             assert_eq!(unique.len(), state.nodes.len(), "{label}: duplicate IDs");
@@ -1007,10 +1036,18 @@ mod tests {
             .expect("baseline persist");
 
         let test_binary = std::env::current_exe().expect("current test binary");
-        let mut child = writer_command(&test_binary, dir.path(), "interrupted", 500, 3)
-            .spawn()
-            .expect("spawn writer");
-        std::thread::sleep(Duration::from_millis(20));
+        let ready_file = dir.path().join("writer-entered-merge");
+        let mut command = writer_command(&test_binary, dir.path(), "interrupted", 500, 3);
+        command.env("RNA_TEST_LANCE_READY_FILE", &ready_file);
+        let mut child = command.spawn().expect("spawn writer");
+        let wait_started = Instant::now();
+        while !ready_file.exists() {
+            assert!(
+                wait_started.elapsed() < Duration::from_secs(5),
+                "writer did not reach LanceDB merge boundary"
+            );
+            std::thread::sleep(Duration::from_millis(2));
+        }
         child.kill().expect("interrupt writer");
         let status = child.wait().expect("reap interrupted writer");
         assert!(!status.success(), "writer should have been interrupted");

--- a/src/server/store/persist.rs
+++ b/src/server/store/persist.rs
@@ -268,6 +268,33 @@ pub(crate) async fn persist_graph_incremental(
     deleted_edge_ids: &[String],
     deleted_files: &[(String, PathBuf)],
 ) -> anyhow::Result<bool> {
+    #[cfg(test)]
+    let retry_limit = std::env::var("RNA_TEST_LANCE_RETRY_LIMIT")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(3);
+    #[cfg(not(test))]
+    let retry_limit = 3;
+
+    persist_graph_incremental_with_retry_limit(
+        repo_root,
+        upsert_nodes,
+        upsert_edges,
+        deleted_edge_ids,
+        deleted_files,
+        retry_limit,
+    )
+    .await
+}
+
+async fn persist_graph_incremental_with_retry_limit(
+    repo_root: &Path,
+    upsert_nodes: &[Node],
+    upsert_edges: &[Edge],
+    deleted_edge_ids: &[String],
+    deleted_files: &[(String, PathBuf)],
+    retry_limit: u64,
+) -> anyhow::Result<bool> {
     let db_path = graph_lance_path(repo_root);
     std::fs::create_dir_all(&db_path)?;
 
@@ -347,7 +374,7 @@ pub(crate) async fn persist_graph_incremental(
                                     );
                                     drop_all_lance_tables(&db_path);
                                     return Ok(true);
-                                } else if is_conflict_error(&err) && attempts < 3 {
+                                } else if is_conflict_error(&err) && attempts < retry_limit {
                                     attempts += 1;
                                     tracing::warn!(
                                         "LanceDB conflict on symbols merge_insert (attempt {}), retrying in {}ms",
@@ -417,7 +444,7 @@ pub(crate) async fn persist_graph_incremental(
                                     );
                                     drop_all_lance_tables(&db_path);
                                     return Ok(true);
-                                } else if is_conflict_error(&err) && attempts < 3 {
+                                } else if is_conflict_error(&err) && attempts < retry_limit {
                                     attempts += 1;
                                     tracing::warn!(
                                         "LanceDB conflict on edges merge_insert (attempt {}), retrying in {}ms",
@@ -559,6 +586,8 @@ pub(crate) async fn delete_nodes_for_roots(
 mod tests {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
+    use std::process::{Command, Stdio};
+    use std::time::Instant;
 
     use super::super::graph_lance_path;
     use super::super::load::load_graph_from_lance;
@@ -611,6 +640,182 @@ mod tests {
         let (r1, r2) = tokio::join!(task1, task2);
         r1.expect("task1 panicked").expect("task1 returned error");
         r2.expect("task2 panicked").expect("task2 returned error");
+    }
+
+    /// Child-process entry point for the adversarial writer test below. Keeping
+    /// this ignored prevents normal test runs from writing without a parent-
+    /// supplied shared repository and writer identity.
+    #[test]
+    #[ignore]
+    fn cross_process_incremental_writer_helper() {
+        let repo_root = PathBuf::from(
+            std::env::var("RNA_TEST_LANCE_REPO").expect("parent supplies shared repo"),
+        );
+        let writer = std::env::var("RNA_TEST_LANCE_WRITER").expect("parent supplies writer id");
+        let writes = std::env::var("RNA_TEST_LANCE_WRITES")
+            .expect("parent supplies write count")
+            .parse::<usize>()
+            .expect("write count is numeric");
+        let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
+        runtime.block_on(async {
+            for index in 0..writes {
+                persist_graph_incremental(
+                    &repo_root,
+                    &[make_test_node(&format!("writer_{writer}_{index}"))],
+                    &[],
+                    &[],
+                    &[],
+                )
+                .await
+                .unwrap_or_else(|error| panic!("writer {writer} failed at {index}: {error:#}"));
+            }
+        });
+    }
+
+    fn writer_command(
+        test_binary: &std::path::Path,
+        repo_root: &Path,
+        writer: &str,
+        writes: usize,
+        retry_limit: u64,
+    ) -> Command {
+        let mut command = Command::new(test_binary);
+        command
+            .arg("--exact")
+            .arg("server::store::persist::tests::cross_process_incremental_writer_helper")
+            .arg("--ignored")
+            .arg("--nocapture")
+            .env("RNA_TEST_LANCE_REPO", repo_root)
+            .env("RNA_TEST_LANCE_WRITER", writer)
+            .env("RNA_TEST_LANCE_WRITES", writes.to_string())
+            .env("RNA_TEST_LANCE_RETRY_LIMIT", retry_limit.to_string())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    }
+
+    /// Reproduces the historical failure boundary with genuine OS processes,
+    /// not Tokio tasks sharing an in-process mutex. The matrix varies process
+    /// serialization and merge-conflict retries independently and verifies the
+    /// final store rather than accepting successful exit codes as correctness.
+    #[test]
+    fn cross_process_write_matrix_preserves_all_rows() {
+        const WRITES_PER_PROCESS: usize = 12;
+        let test_binary = std::env::current_exe().expect("current test binary");
+
+        for (label, concurrent, retry_limit) in [
+            ("serialized_with_retries", false, 3),
+            ("serialized_without_retries", false, 0),
+            ("concurrent_with_retries", true, 3),
+            ("concurrent_without_retries", true, 0),
+        ] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let repo_root = dir.path();
+            let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
+            runtime
+                .block_on(persist_graph_to_lance(
+                    repo_root,
+                    &[make_test_node("baseline")],
+                    &[],
+                ))
+                .expect("baseline persist");
+
+            let started = Instant::now();
+            let outputs = if concurrent {
+                let first = writer_command(
+                    &test_binary,
+                    repo_root,
+                    &format!("{label}_a"),
+                    WRITES_PER_PROCESS,
+                    retry_limit,
+                )
+                .spawn()
+                .expect("spawn first writer");
+                let second = writer_command(
+                    &test_binary,
+                    repo_root,
+                    &format!("{label}_b"),
+                    WRITES_PER_PROCESS,
+                    retry_limit,
+                )
+                .spawn()
+                .expect("spawn second writer");
+                vec![
+                    first.wait_with_output().expect("wait for first writer"),
+                    second.wait_with_output().expect("wait for second writer"),
+                ]
+            } else {
+                vec![
+                    writer_command(
+                        &test_binary,
+                        repo_root,
+                        &format!("{label}_a"),
+                        WRITES_PER_PROCESS,
+                        retry_limit,
+                    )
+                    .output()
+                    .expect("run first writer"),
+                    writer_command(
+                        &test_binary,
+                        repo_root,
+                        &format!("{label}_b"),
+                        WRITES_PER_PROCESS,
+                        retry_limit,
+                    )
+                    .output()
+                    .expect("run second writer"),
+                ]
+            };
+            let elapsed = started.elapsed();
+
+            let all_writers_succeeded = outputs.iter().all(|output| output.status.success());
+            if !all_writers_succeeded {
+                assert_eq!(
+                    retry_limit,
+                    0,
+                    "{label}: a protected writer failed: {}",
+                    outputs
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, output)| !output.status.success())
+                        .map(|(index, output)| format!(
+                            "writer {index}\nstdout:\n{}\nstderr:\n{}",
+                            String::from_utf8_lossy(&output.stdout),
+                            String::from_utf8_lossy(&output.stderr),
+                        ))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                );
+                assert!(
+                    concurrent,
+                    "{label}: serialized writers must not need conflict retries"
+                );
+                eprintln!(
+                    "LanceDB write matrix: scenario={label} observed an unprotected concurrent-writer failure after {}ms",
+                    elapsed.as_millis()
+                );
+                continue;
+            }
+
+            let state = runtime
+                .block_on(load_graph_from_lance(repo_root))
+                .expect("load final graph");
+            let expected = 1 + 2 * WRITES_PER_PROCESS;
+            assert_eq!(
+                state.nodes.len(),
+                expected,
+                "{label}: every stable ID must remain unique and visible"
+            );
+            let unique_ids: std::collections::HashSet<_> =
+                state.nodes.iter().map(Node::stable_id).collect();
+            assert_eq!(unique_ids.len(), expected, "{label}: duplicate stable IDs");
+            eprintln!(
+                "LanceDB write matrix: scenario={label} processes=2 writes={} retry_limit={retry_limit} elapsed_ms={} final_rows={}",
+                2 * WRITES_PER_PROCESS,
+                elapsed.as_millis(),
+                state.nodes.len(),
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #746

## Problem
RNA cannot safely simplify historical write serialization and merge-conflict retries without reproducible evidence from the LanceDB 0.31 persistence path, including genuine multi-process writers.

## Chosen solution
First validate that the required LanceDB 0.31 migration from #745 is available on the selected base. If it is not, preserve this draft PR as the issue home, document the dependency blocker, and do not run misleading measurements against the pre-migration path. Once #745 ships, measure the controls independently under adversarial scenarios and remove or narrow only defenses proven redundant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for concurrent persistence writes by enforcing safer serialization behavior and bounded conflict retries.
  - Enhanced correctness and readability of persisted data after interrupted write operations, avoiding duplicate stable IDs.
- **Documentation**
  - Added decision and session records explaining why existing concurrency defenses remain necessary after the latest migration, including validation and shipping notes.
- **Tests**
  - Expanded in-process and cross-process concurrency and interruption coverage, including merge-outcome instrumentation and persistence overlap/recovery checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->