### PR TITLE
Make RNA setup guidance minimal by default and gate .NET env config

### DIFF
--- a/.oh/friction-logs/754-ship.md
+++ b/.oh/friction-logs/754-ship.md
@@ -1,0 +1,13 @@
+---
+id: pr-754-ship
+outcome: context-assembly
+severity: mixed
+---
+
+# PR #754 ship friction
+
+| Time | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-07-15 | RNA MCP tools | skipped | RNA MCP tools were not exposed to the issue agent. | Repository context and source inspection required targeted `rg`/`sed` fallback. | Preserve this evidence for RNA tool-delivery debugging. |
+| 2026-07-15 | `rg`/`sed` fallback | skipped | Targeted reads of `README.md`, `plugin/skills/setup/SKILL.md`, `src/setup.rs`, and workflow instructions were used after RNA MCP was unavailable. | The issue was still reviewable, but not through the mandated dogfood path. | Use RNA MCP when it is available to the agent session. |
+| 2026-07-15 | `repo-native-alignment scan --repo . --full` | blocking for graph review | The mandatory ship scan remained sleeping with no output and 0% CPU for roughly nine minutes during LSP enrichment and was interrupted. | Graph impact analysis is unavailable for this documentation/setup-guidance change. Diff review and targeted setup tests remain available. | Investigate the scan/LSP no-progress path separately; do not represent this run as a successful full scan. |

--- a/.oh/friction-logs/754-ship.md
+++ b/.oh/friction-logs/754-ship.md
@@ -8,6 +8,6 @@ severity: mixed
 
 | Time | Tool path | Severity | Friction | Impact | Follow-up |
 |---|---|---|---|---|---|
-| 2026-07-15 | RNA MCP tools | skipped | RNA MCP tools were not exposed to the issue agent. | Repository context and source inspection required targeted `rg`/`sed` fallback. | Preserve this evidence for RNA tool-delivery debugging. |
+| 2026-07-15 | RNA MCP tools | skipped | RNA MCP tools were not exposed to the issue agent. | Repository context and source inspection required a targeted `rg`/`sed` fallback. | Preserve this evidence for RNA tool-delivery debugging. |
 | 2026-07-15 | `rg`/`sed` fallback | skipped | Targeted reads of `README.md`, `plugin/skills/setup/SKILL.md`, `src/setup.rs`, and workflow instructions were used after RNA MCP was unavailable. | The issue was still reviewable, but not through the mandated dogfood path. | Use RNA MCP when it is available to the agent session. |
 | 2026-07-15 | `repo-native-alignment scan --repo . --full` | blocking for graph review | The mandatory ship scan remained sleeping with no output and 0% CPU for roughly nine minutes during LSP enrichment and was interrupted. | Graph impact analysis is unavailable for this documentation/setup-guidance change. Diff review and targeted setup tests remain available. | Investigate the scan/LSP no-progress path separately; do not represent this run as a successful full scan. |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Example `.mcp.json`:
 ```json
 {
   "mcpServers": {
-    "rna": {
+    "rna-server": {
       "type": "stdio",
       "command": "/Users/me/.cargo/bin/repo-native-alignment",
       "args": ["--repo", "/path/to/your/project"]

--- a/README.md
+++ b/README.md
@@ -141,18 +141,30 @@ Example `.mcp.json`:
     "rna": {
       "type": "stdio",
       "command": "/Users/me/.cargo/bin/repo-native-alignment",
-      "args": ["--repo", "/path/to/your/project"],
-      "env": {
-        "DOTNET_ROOT": "/opt/homebrew/opt/dotnet/libexec",
-        "DOTNET_ROOT_ARM64": "/opt/homebrew/opt/dotnet/libexec",
-        "PATH": "/Users/me/.dotnet/tools:/opt/homebrew/opt/dotnet/libexec:/Users/me/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
-      }
+      "args": ["--repo", "/path/to/your/project"]
     }
   }
 }
 ```
 
-For Homebrew, mise, asdf, or official .NET installs, keep `command` as the RNA binary and put `DOTNET_ROOT`/`DOTNET_ROOT_ARM64` plus `~/.dotnet/tools` PATH entries in `env`; do not launch RNA through `mise exec`, `asdf exec`, or wrapper scripts.
+Keep `command` as the direct RNA binary. Do not launch RNA through `mise`,
+`asdf`, `brew`, another tool-manager command, or a wrapper script.
+
+#### Optional C#/.NET LSP enrichment
+
+Only investigate or configure .NET when the repository contains C#/.NET markers
+(such as `.cs`, `.csproj`, or `.sln` files), `repo-native-alignment setup`
+reports that the optional C# toolchain is needed, or the user explicitly asks
+for C# enrichment. Other repositories need no .NET environment configuration.
+
+C# call/reference enrichment requires `dotnet` and `csharp-ls`. Install
+`csharp-ls` with `dotnet tool install -g csharp-ls` and ensure
+`~/.dotnet/tools` is on `PATH`. If the MCP launcher does not inherit the shell
+environment, add the appropriate `DOTNET_ROOT` (and `DOTNET_ROOT_ARM64` on
+Apple Silicon) plus the .NET root and `~/.dotnet/tools` to the server's `env`
+block. Homebrew, mise, asdf, and official installs use different roots; use the
+root reported by the setup command. The MCP `command` must still be the direct
+RNA binary, never `mise`, `asdf`, `brew`, or another wrapper.
 
 For HTTP transport: `repo-native-alignment --repo . --transport http --port 8382`
 

--- a/plugin/skills/setup/SKILL.md
+++ b/plugin/skills/setup/SKILL.md
@@ -54,7 +54,7 @@ Release artifacts are intentionally built without local embedding/reranking supp
 
 ## Step 3: Configure the MCP server
 
-RNA is a per-project MCP server (it indexes the repo it's pointed at). MCP stdio launchers often do **not** source shell profiles, and some harnesses crash or mis-handle wrapper commands. Keep `command` as the direct `repo-native-alignment` binary path and put tool-manager paths/env in the server `env` block instead of launching through `mise exec`, `asdf exec`, `brew shellenv`, or shell wrapper scripts.
+RNA is a per-project MCP server (it indexes the repo it's pointed at). MCP stdio launchers often do **not** source shell profiles, and some harnesses crash or mis-handle wrapper commands. Keep `command` as the direct `repo-native-alignment` binary path. Never launch through `mise`, `asdf`, `brew`, another tool-manager command, or a shell wrapper script.
 
 Check if `.mcp.json` exists in the project root and already contains an `rna-server` entry. If it does, verify it uses a direct RNA binary command; rewrite wrapper-based entries to the direct-binary pattern below.
 
@@ -70,20 +70,32 @@ Otherwise, create or update `.mcp.json` in the project root with:
     "rna-server": {
       "type": "stdio",
       "command": "/Users/me/.cargo/bin/repo-native-alignment",
-      "args": ["--repo", "/absolute/path/to/project"],
-      "env": {
-        "DOTNET_ROOT": "/opt/homebrew/opt/dotnet/libexec",
-        "DOTNET_ROOT_ARM64": "/opt/homebrew/opt/dotnet/libexec",
-        "PATH": "/Users/me/.dotnet/tools:/opt/homebrew/opt/dotnet/libexec:/Users/me/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
-      }
+      "args": ["--repo", "/absolute/path/to/project"]
     }
   }
 }
 ```
 
-For mise-managed .NET, set `DOTNET_ROOT`/`DOTNET_ROOT_ARM64` to the mise .NET root and prepend the root plus `~/.dotnet/tools` to `PATH`; keep `command` as the RNA binary, not `/opt/homebrew/bin/mise`. For asdf/Homebrew/official .NET installs, use their resolved install root in `env` the same way.
-
 If `.mcp.json` already exists with other servers, merge the `rna-server` entry into the existing `mcpServers` object -- do not overwrite the file.
+
+### Conditional C#/.NET LSP enrichment
+
+Do **not** probe for `dotnet`, `csharp-ls`, `DOTNET_ROOT`, or .NET
+tool-manager installs by default. Only do so when at least one of these is true:
+
+- the target repository contains C#/.NET markers such as `.cs`, `.csproj`, or
+  `.sln` files;
+- `repo-native-alignment setup` reports the optional C# toolchain need; or
+- the user explicitly requests C# call/reference enrichment.
+
+For those C#/.NET repositories, install `csharp-ls` with
+`dotnet tool install -g csharp-ls` and ensure `~/.dotnet/tools` is on `PATH`.
+If the MCP launcher does not inherit shell setup, add the resolved .NET root as
+`DOTNET_ROOT` (and `DOTNET_ROOT_ARM64` on Apple Silicon), and prepend that root
+plus `~/.dotnet/tools` to the server `env` `PATH`. Use the setup command's
+reported root for mise, asdf, Homebrew, or official .NET installs. Keep
+`command` as the direct RNA binary; never make it `mise`, `asdf`, `brew`, or a
+wrapper script.
 
 ## Step 4: Pre-warm the code index
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -256,18 +256,13 @@ fn check_dep(cmd: &str, args: &[&str], remediation: &str) -> Result<()> {
 }
 
 fn report_optional_csharp_toolchain(project_path: &Path, dry_run: bool) {
-    if !has_csharp_markers(project_path) {
+    let Some(dry_run_guidance) = optional_csharp_dry_run_guidance(project_path) else {
         return;
-    }
+    };
 
     println!("Checking optional C#/.NET LSP toolchain...");
     if dry_run {
-        println!("  [dry-run] Would check: dotnet on PATH");
-        println!("  [dry-run] Would check: csharp-ls on PATH");
-        println!("  [dry-run] Would check: DOTNET_ROOT / DOTNET_ROOT_ARM64 for MCP stdio env");
-        println!(
-            "  Guidance: keep .mcp.json command as the direct repo-native-alignment binary; put DOTNET_ROOT and PATH additions in the server env instead of launching through mise/asdf/brew wrappers.\n"
-        );
+        println!("{dry_run_guidance}");
         return;
     }
 
@@ -318,6 +313,12 @@ fn report_optional_csharp_toolchain(project_path: &Path, dry_run: bool) {
             "  C#/.NET LSP prerequisites look usable. Mirror DOTNET_ROOT and PATH in .mcp.json env if your MCP launcher does not inherit shell profile setup.\n"
         );
     }
+}
+
+fn optional_csharp_dry_run_guidance(project_path: &Path) -> Option<&'static str> {
+    has_csharp_markers(project_path).then_some(
+        "  [dry-run] Would check: dotnet on PATH\n  [dry-run] Would check: csharp-ls on PATH\n  [dry-run] Would check: DOTNET_ROOT / DOTNET_ROOT_ARM64 for MCP stdio env\n  Guidance: keep .mcp.json command as the direct repo-native-alignment binary; put DOTNET_ROOT and PATH additions in the server env instead of launching through mise/asdf/brew wrappers.\n",
+    )
 }
 
 fn command_on_path(cmd: &str) -> bool {
@@ -1014,6 +1015,10 @@ mod tests {
             v["mcpServers"]["rna-server"]["timeout"],
             DEFAULT_MCP_TIMEOUT_MS
         );
+        assert!(
+            v["mcpServers"]["rna-server"].get("env").is_none(),
+            "non-.NET setup must not add optional .NET environment configuration"
+        );
     }
 
     // ── merge preserves other servers ────────────────────────────────────────
@@ -1213,12 +1218,50 @@ mod tests {
     }
 
     #[test]
+    fn test_has_csharp_markers_detects_source_files_and_solutions() {
+        for marker in ["Program.cs", "App.sln"] {
+            let (_dir, proj) = tmp();
+            std::fs::write(proj.join(marker), "marker").unwrap();
+            assert!(
+                has_csharp_markers(&proj),
+                "{marker} must activate optional C#/.NET setup guidance"
+            );
+        }
+    }
+
+    #[test]
     fn test_has_csharp_markers_ignores_non_csharp_project() {
         let (_dir, proj) = tmp();
         std::fs::create_dir_all(proj.join("src")).unwrap();
         std::fs::write(proj.join("src/main.rs"), "fn main() {}").unwrap();
 
         assert!(!has_csharp_markers(&proj));
+        assert!(
+            optional_csharp_dry_run_guidance(&proj).is_none(),
+            "non-.NET setup must not surface .NET environment guidance"
+        );
+    }
+
+    #[test]
+    fn test_csharp_setup_surfaces_optional_enrichment_prerequisites() {
+        let (_dir, proj) = tmp();
+        std::fs::write(proj.join("App.csproj"), "<Project />").unwrap();
+
+        let guidance = optional_csharp_dry_run_guidance(&proj)
+            .expect("C# setup must surface optional toolchain guidance");
+        for prerequisite in [
+            "dotnet",
+            "csharp-ls",
+            "DOTNET_ROOT",
+            "DOTNET_ROOT_ARM64",
+            "PATH",
+            "direct repo-native-alignment binary",
+        ] {
+            assert!(
+                guidance.contains(prerequisite),
+                "C# guidance must mention {prerequisite}: {guidance}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #720

## Aim
Users configuring RNA for non-.NET repositories get a minimal, immediately usable MCP entry without being sent to investigate an irrelevant .NET toolchain. C# repositories still receive precise optional enrichment prerequisites.

## Problem
The primary setup examples conflate the direct-binary requirement with optional C# LSP environment configuration. This causes agents to probe for and add .NET configuration even when the target repository has no C# markers.

## Chosen solution
Keep the default README and setup-skill MCP examples to `type`, direct `command`, and `--repo` args. Move all .NET and csharp-ls material into a clearly conditional section, explicitly prohibit probing unless C# markers, setup diagnostics, or user intent justify it, and add regression coverage for both non-.NET and .NET setup paths.

## Workflow friction
RNA MCP exploration tools were unavailable in this agent session; targeted fallback inspection will be logged here and in the implementation handoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup now detects C#/.NET projects and provides optional guidance for configuring LSP enrichment.
  * Configuration guidance supports preserving existing MCP settings while adding required .NET environment paths.

* **Documentation**
  * Clarified MCP setup requirements, including direct binary usage and optional C#/.NET tooling.
  * Added troubleshooting guidance for environment variables and tool paths.

* **Bug Fixes**
  * Avoided adding unnecessary .NET environment settings for non-.NET projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->