### PR TITLE
Add operation-aware LSP admission and query-yield telemetry

### DIFF
--- a/.oh/friction-logs/773-ship.md
+++ b/.oh/friction-logs/773-ship.md
@@ -1,0 +1,14 @@
+---
+title: PR #773 ship friction
+date: 2026-07-16
+pr: 773
+outcome: context-assembly
+---
+
+# PR #773 ship friction
+
+| Time | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-07-16 | Ship pre-flight metis read | low | `.claude/agents/ship.md` requires `.oh/metis/computed-but-not-delivered.md`, but that file does not exist; the canonical artifact is `.oh/guardrails/computed-but-not-delivered.md`. | Pre-flight used RNA artifact search and the canonical guardrail instead. | Update the ship instruction to reference the guardrail path. |
+| 2026-07-16 | RNA scan gate | moderate | Search reported “last scan just now” and 22,545 symbols while returning no result for the newly committed `LspQueryProfile`. | Ship review could not trust graph impact until forcing a full branch scan. | Surface working-tree/index mismatch explicitly and make targeted refresh deterministic. |
+| 2026-07-16 | Ship source review | skipped | RNA CLI cannot return bounded source ranges or disambiguate same-name impl methods reliably. | Bounded `sed` reads were used after graph-first discovery to inspect changed implementations. | Add line-range retrieval and parent-qualified method identity to CLI parity. |

--- a/.oh/friction-logs/issue-767.md
+++ b/.oh/friction-logs/issue-767.md
@@ -1,0 +1,14 @@
+---
+title: Issue 767 RNA dogfood friction
+date: 2026-07-16
+issue: 767
+outcome: context-assembly
+---
+
+# Issue 767 RNA dogfood friction
+
+| Time | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-07-16 | Codex RNA MCP discovery | moderate | The dedicated issue-agent session did not expose RNA MCP `search`, `repo_map`, or `outcome_progress` tools even though the repository requires them. | Exploration used the installed `repo-native-alignment` CLI service path instead of MCP. | Verify repo-local MCP tools propagate into dedicated sub-agent sessions. |
+| 2026-07-16 | `repo-native-alignment search --nodes ... --include-body` | moderate | Multiple Rust implementations with the same function name share a colliding node ID; requesting `src/extract/lsp/mod.rs:enrich:function` returned `DummyEnricher::enrich` instead of `LspEnricher::enrich`. The CLI also has no bounded file/line retrieval parameters. | Exact implementation context requires bounded `sed` reads after graph-first exploration. | Preserve parent-qualified identities for impl methods and expose the MCP file/line retrieval seam in CLI parity. |
+| 2026-07-16 | `repo-native-alignment search "LSP query profile"` | low | The installed RNA index returned the removed `LspEligibilityPolicy` after the working tree had replaced it, so review search results were stale. | Review used the branch diff and bounded source reads for changed code rather than trusting stale graph results. | Make working-tree freshness explicit in search output and provide a targeted refresh path. |

--- a/.oh/metis/operation-aware-lsp-query-admission.md
+++ b/.oh/metis/operation-aware-lsp-query-admission.md
@@ -1,0 +1,30 @@
+---
+id: operation-aware-lsp-query-admission
+outcome: context-assembly
+title: 'Admit LSP Work by Semantic Operation, Then Measure Its Yield'
+---
+
+## Pattern
+
+An AST declaration kind is not enough evidence to schedule an LSP request. Admission should combine the semantic operation, declaration class, language/server profile, negotiated capability, and current runtime budget before a work item enters the queue.
+
+The same semantic operation should key telemetry. Counting scheduled RPCs, non-empty responses, emitted edges, latency, timeouts, and errors by operation and declaration class makes expensive or low-yield profiles visible instead of letting a broad allow-list quietly grow.
+
+## Why this matters
+
+Language servers vary by both capability and behavior. A server advertising references does not imply that references for every extractable kind are useful or bounded. Function call hierarchy and trait implementations are high-signal graph relationships; broad constant references are default-denied until measurement earns their inclusion.
+
+Keep the profile at the shared LSP construction seam and apply it before every relevant scheduling pass. Deliver the resulting measurements through the same event and status path agents already inspect; telemetry computed only inside the enricher cannot guide future policy.
+
+## Guardrails
+
+- Synthetic graph values are searchable evidence, never compiler declarations or LSP request targets.
+- Language-specific restrictions belong in `LangConfig` or the shared profile, not generic `if language == ...` branches.
+- A negotiated server capability is necessary but not sufficient for admission.
+- Runtime budgets are part of admission even when current built-in profiles use unlimited defaults.
+
+## References
+
+- Issue #767
+- `src/extract/lsp/policy.rs`
+- `docs/lsp-enrichment.md`

--- a/.oh/sessions/773-ship.md
+++ b/.oh/sessions/773-ship.md
@@ -35,4 +35,6 @@ The first follow-up found a cancellation race in aggregate timeout ownership. Te
 
 The second follow-up found that registration could race after the deadline drain. Deadline closure now occurs under the same mutex as registration; late registration returns false and the worker exits before issuing an LSP request. The timeout regression also asserts registration is rejected after closure.
 
+CodeRabbit reviewed the ready PR and requested six changes. The final fix batch projects all cross-pass planner operations, retains the warmup URI only after successful `didOpen`, deduplicates document-link work by file, uses set membership for allowed kinds, retains per-item request count/start time for cancellation metrics, and drains registered work on internal watchdog aborts. Focused regressions and library clippy pass after the fixes.
+
 Formatting-only changes are confined to files materially edited by #767 and result from applying the repository toolchain's formatter to those files. They are acknowledged as review noise but do not alter unrelated behavior.

--- a/.oh/sessions/773-ship.md
+++ b/.oh/sessions/773-ship.md
@@ -31,4 +31,6 @@ outcome: context-assembly
 
 The reviewer found three correctness gaps: changed-file planning bypassed the shared profile, outer Pass 1 deadlines omitted cancelled work from timeout metrics, and Pass 2 recorded one scheduled request instead of the observation's actual request count. All three were fixed with planner, timeout, and type-hierarchy regression tests before the PR was marked ready.
 
+The first follow-up found a cancellation race in aggregate timeout ownership. Telemetry now registers only started work by item ID; completion and deadline attribution atomically remove that ID, so late completions are ignored and queued work that never issued a request is not labeled timed out. The regression explicitly exercises a completion arriving after timeout attribution.
+
 Formatting-only changes are confined to files materially edited by #767 and result from applying the repository toolchain's formatter to those files. They are acknowledged as review noise but do not alter unrelated behavior.

--- a/.oh/sessions/773-ship.md
+++ b/.oh/sessions/773-ship.md
@@ -33,4 +33,6 @@ The reviewer found three correctness gaps: changed-file planning bypassed the sh
 
 The first follow-up found a cancellation race in aggregate timeout ownership. Telemetry now registers only started work by item ID; completion and deadline attribution atomically remove that ID, so late completions are ignored and queued work that never issued a request is not labeled timed out. The regression explicitly exercises a completion arriving after timeout attribution.
 
+The second follow-up found that registration could race after the deadline drain. Deadline closure now occurs under the same mutex as registration; late registration returns false and the worker exits before issuing an LSP request. The timeout regression also asserts registration is rejected after closure.
+
 Formatting-only changes are confined to files materially edited by #767 and result from applying the repository toolchain's formatter to those files. They are acknowledged as review noise but do not alter unrelated behavior.

--- a/.oh/sessions/773-ship.md
+++ b/.oh/sessions/773-ship.md
@@ -1,0 +1,34 @@
+---
+title: Ship Pipeline — PR #773
+date: 2026-07-16
+pr: 773
+issue: 767
+outcome: context-assembly
+---
+
+# Ship Pipeline — PR #773
+
+**Started:** 2026-07-16
+
+## Pre-flight
+
+- PR #773 on `issue/767`, closing #767.
+- Branch index was stale despite current freshness metadata; a full scan was started.
+- No CodeRabbit inline comments existed while the PR remained draft.
+- The ship document's missing metis reference was resolved to the canonical computed-but-not-delivered guardrail.
+
+## Step 1: RNA-Grounded Review
+
+**Verdict:** CONTINUE
+
+- Acceptance criteria are implemented and covered by policy, event-delivery, and rendering tests.
+- Review adjustments fixed before shipping: distinguish query-level errors in rendering assertions; update the LSP consumer event contract test; resolve new clippy findings.
+- Full library suite: 2,010 passed, 3 ignored, 0 failed.
+
+## Step 2: Independent Code Review
+
+**Verdict:** REQUEST CHANGES
+
+The reviewer found three correctness gaps: changed-file planning bypassed the shared profile, outer Pass 1 deadlines omitted cancelled work from timeout metrics, and Pass 2 recorded one scheduled request instead of the observation's actual request count. All three were fixed with planner, timeout, and type-hierarchy regression tests before the PR was marked ready.
+
+Formatting-only changes are confined to files materially edited by #767 and result from applying the repository toolchain's formatter to those files. They are acknowledged as review noise but do not alter unrelated behavior.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ When a compiler or test runner already provides a location, `search(file="src/se
 **Know which capabilities are ready**
 `scan`, `enrich`, and `list_roots` surface OperationReport summaries: ready capabilities, degraded query classes, recent enrichment jobs, and the exact follow-up command when embeddings or call/reference enrichment is missing.
 
+For LSP enrichment, `list_roots` also reports query yield by language/server, operation, and declaration class: scheduled requests, non-empty responses, emitted edges, latency, timeouts, and errors. This makes the cost and agent-visible value of each compiler query profile inspectable.
+
 **Connect code to business outcomes**
 `outcome_progress("agent-alignment")` follows tagged commits to changed files to affected symbols. Outcomes, signals, and guardrails in `.oh/` are full graph nodes — searchable, linkable, tracked.
 

--- a/docs/lsp-enrichment.md
+++ b/docs/lsp-enrichment.md
@@ -37,6 +37,12 @@ The `RootExtracted` event carries `dirty_slugs: Option<HashSet<String>>`. The `L
 
 Before requesting call hierarchy or references for a symbol, RNA sends `textDocument/didOpen` for that file once per enrichment pass. Files are marked opened only after the source read and notification succeed, so transient failures can be retried. This keeps language servers that require open documents from returning empty or stale reference results during warmup.
 
+### Operation-aware query admission
+
+Every LSP request is admitted through one shared query profile. The profile combines the requested operation, declaration class, language/server configuration, negotiated server capabilities, and the operation's runtime budget. Synthetic values are always rejected, and declared constants are default-denied for reference queries. High-signal function call hierarchy and trait implementation requests remain enabled when the server advertises those capabilities.
+
+RNA records scheduled requests, non-empty responses, emitted edges, latency, timeouts, and errors for each language/server, operation, and declaration class. `list_roots` exposes these query-yield rows beneath each language's LSP summary so operators can compare request cost with agent-visible graph value.
+
 ## Auto-detected Language Servers
 
 ### Common Servers (install for richer graphs)

--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -273,9 +273,7 @@ impl ExtractionConsumer for LanguageAccumulatorConsumer {
             if !node_is_in_lsp_scope(node, dirty_set, self.planned_node_ids.as_deref()) {
                 continue;
             }
-            if self.planned_node_ids.is_some()
-                && !emitted_planned_ids.insert(node.stable_id())
-            {
+            if self.planned_node_ids.is_some() && !emitted_planned_ids.insert(node.stable_id()) {
                 continue;
             }
             by_lang
@@ -1510,19 +1508,27 @@ impl ExtractionConsumer for LspConsumer {
                     enrichment.new_nodes.len(),
                     enrichment.updated_nodes.len(),
                 );
-                Ok(vec![ExtractionEvent::EnrichmentComplete {
-                    slug: slug.clone(),
-                    language: language.clone(),
-                    added_edges: Arc::from(enrichment.added_edges.into_boxed_slice()),
-                    new_nodes: Arc::from(enrichment.new_nodes.into_boxed_slice()),
-                    updated_nodes: Arc::from(enrichment.updated_nodes.into_boxed_slice()),
-                    server_name: Some(self.enricher.name().to_string()),
-                    error_count: enrichment.error_count,
-                    server_missing,
-                    remediation: self.enricher.toolchain_remediation().map(str::to_string),
-                    aborted: enrichment.aborted,
-                    diagnostic: enrichment.diagnostic,
-                }])
+                let metrics = Arc::from(enrichment.lsp_query_metrics.into_boxed_slice());
+                Ok(vec![
+                    ExtractionEvent::EnrichmentComplete {
+                        slug: slug.clone(),
+                        language: language.clone(),
+                        added_edges: Arc::from(enrichment.added_edges.into_boxed_slice()),
+                        new_nodes: Arc::from(enrichment.new_nodes.into_boxed_slice()),
+                        updated_nodes: Arc::from(enrichment.updated_nodes.into_boxed_slice()),
+                        server_name: Some(self.enricher.name().to_string()),
+                        error_count: enrichment.error_count,
+                        server_missing,
+                        remediation: self.enricher.toolchain_remediation().map(str::to_string),
+                        aborted: enrichment.aborted,
+                        diagnostic: enrichment.diagnostic,
+                    },
+                    ExtractionEvent::LspQueryMetrics {
+                        slug: slug.clone(),
+                        language: language.clone(),
+                        metrics,
+                    },
+                ])
             }
             Err(e) => {
                 // LSP enrichment failure is non-fatal: emit EnrichmentComplete with
@@ -1728,11 +1734,7 @@ impl ExtractionConsumer for AllEnrichmentsGate {
                     let mut seen = std::collections::HashSet::new();
                     for n in nodes.iter() {
                         if !n.language.is_empty()
-                            && node_is_in_lsp_scope(
-                                n,
-                                dirty_set,
-                                self.planned_node_ids.as_deref(),
-                            )
+                            && node_is_in_lsp_scope(n, dirty_set, self.planned_node_ids.as_deref())
                         {
                             seen.insert(n.language.clone());
                         }
@@ -1755,11 +1757,7 @@ impl ExtractionConsumer for AllEnrichmentsGate {
                     for n in nodes.iter() {
                         if !n.language.is_empty()
                             && supported.contains(&n.language)
-                            && node_is_in_lsp_scope(
-                                n,
-                                dirty_set,
-                                self.planned_node_ids.as_deref(),
-                            )
+                            && node_is_in_lsp_scope(n, dirty_set, self.planned_node_ids.as_deref())
                         {
                             seen.insert(n.language.clone());
                         }
@@ -3364,16 +3362,23 @@ mod tests {
             nodes: std::sync::Arc::from([]),
         };
         let result = consumer.on_event(&matching).await.unwrap();
-        // No tokio runtime in sync test context: the consumer falls back to the no-op path
-        // and still emits EnrichmentComplete (with empty edges).
+        // Successful LSP enrichment emits both graph completion and query-yield telemetry.
         assert_eq!(
             result.len(),
-            1,
-            "LspConsumer must emit EnrichmentComplete for its language"
+            2,
+            "LspConsumer must emit completion and query metrics for its language"
         );
         assert!(
-            matches!(result[0], ExtractionEvent::EnrichmentComplete { .. }),
+            result
+                .iter()
+                .any(|event| matches!(event, ExtractionEvent::EnrichmentComplete { .. })),
             "LspConsumer must emit EnrichmentComplete"
+        );
+        assert!(
+            result
+                .iter()
+                .any(|event| matches!(event, ExtractionEvent::LspQueryMetrics { .. })),
+            "LspConsumer must emit LspQueryMetrics"
         );
     }
 

--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -3027,17 +3027,12 @@ mod tests {
             registry_path.enrichable_kinds(),
             "both construction paths must apply the descriptor's eligibility policy"
         );
-        assert_eq!(
-            event_bus_path.enrichable_kinds(),
-            Some(
-                [
-                    crate::graph::NodeKind::Function,
-                    crate::graph::NodeKind::Trait
-                ]
-                .as_slice()
-            ),
-            "Python must retain Function/Trait eligibility in the EventBus path"
-        );
+        let python_kinds = event_bus_path
+            .enrichable_kinds()
+            .expect("Python must have an eligibility filter");
+        assert_eq!(python_kinds.len(), 2);
+        assert!(python_kinds.contains(&crate::graph::NodeKind::Function));
+        assert!(python_kinds.contains(&crate::graph::NodeKind::Trait));
         assert_eq!(
             event_bus_path.allows_declared_const_references(),
             registry_path.allows_declared_const_references(),

--- a/src/extract/event_bus.rs
+++ b/src/extract/event_bus.rs
@@ -127,6 +127,13 @@ pub enum ExtractionEvent {
         diagnostic: Option<String>,
     },
 
+    /// Query-yield measurements emitted separately from graph enrichment output.
+    LspQueryMetrics {
+        slug: String,
+        language: String,
+        metrics: Arc<[crate::extract::lsp::LspQueryMetric]>,
+    },
+
     /// A framework has been detected during post-extraction passes.
     /// Consumers that gate on a specific framework check `framework` here.
     FrameworkDetected {
@@ -226,6 +233,7 @@ pub enum ExtractionEventKind {
     RootExtracted,
     LanguageDetected,
     EnrichmentComplete,
+    LspQueryMetrics,
     FrameworkDetected,
     PassComplete,
     PassesComplete,
@@ -242,6 +250,7 @@ impl ExtractionEvent {
             ExtractionEvent::RootExtracted { .. } => ExtractionEventKind::RootExtracted,
             ExtractionEvent::LanguageDetected { .. } => ExtractionEventKind::LanguageDetected,
             ExtractionEvent::EnrichmentComplete { .. } => ExtractionEventKind::EnrichmentComplete,
+            ExtractionEvent::LspQueryMetrics { .. } => ExtractionEventKind::LspQueryMetrics,
             ExtractionEvent::FrameworkDetected { .. } => ExtractionEventKind::FrameworkDetected,
             ExtractionEvent::PassComplete { .. } => ExtractionEventKind::PassComplete,
             ExtractionEvent::PassesComplete { .. } => ExtractionEventKind::PassesComplete,
@@ -391,6 +400,38 @@ impl ExtractionEvent {
                 if let Some(diagnostic) = diagnostic {
                     buf.push(b'\n');
                     buf.extend_from_slice(diagnostic.as_bytes());
+                }
+            }
+            ExtractionEvent::LspQueryMetrics {
+                slug,
+                language,
+                metrics,
+            } => {
+                buf.extend_from_slice(slug.as_bytes());
+                buf.push(b'\t');
+                buf.extend_from_slice(language.as_bytes());
+                let mut rows = metrics
+                    .iter()
+                    .map(|metric| {
+                        format!(
+                            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+                            metric.language,
+                            metric.server,
+                            metric.operation,
+                            metric.declaration_class,
+                            metric.scheduled_requests,
+                            metric.non_empty_responses,
+                            metric.emitted_edges,
+                            metric.latency_ms,
+                            metric.timeouts,
+                            metric.errors
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                rows.sort_unstable();
+                for row in rows {
+                    buf.push(b'\n');
+                    buf.extend_from_slice(row.as_bytes());
                 }
             }
             ExtractionEvent::FrameworkDetected {
@@ -584,6 +625,7 @@ impl ExtractionEvent {
             ExtractionEvent::RootExtracted { .. } => "root_extracted",
             ExtractionEvent::LanguageDetected { .. } => "language_detected",
             ExtractionEvent::EnrichmentComplete { .. } => "enrichment_complete",
+            ExtractionEvent::LspQueryMetrics { .. } => "lsp_query_metrics",
             ExtractionEvent::FrameworkDetected { .. } => "framework_detected",
             ExtractionEvent::PassComplete { .. } => "pass_complete",
             ExtractionEvent::PassesComplete { .. } => "passes_complete",

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -20,6 +20,9 @@
 
 mod passes;
 pub(crate) use passes::requested_operations_for_node;
+mod policy;
+pub use policy::LspQueryMetric;
+use policy::{LspQueryProfile, LspServerCapabilities};
 mod transport;
 pub(crate) mod work_items;
 use transport::{LspTransport, PipelinedTransport, path_to_uri};
@@ -45,17 +48,6 @@ pub const CSHARP_TOOLCHAIN_REMEDIATION: &str = "C# LSP needs dotnet, csharp-ls, 
 
 type InitSettingsFactory = fn() -> serde_json::Value;
 
-#[derive(Clone, Copy)]
-enum LspEligibilityPolicy {
-    /// Resolve language-specific request-target kinds from the extractor's
-    /// [`LangConfig`](crate::extract::generic::LangConfig).
-    LangConfig {
-        /// Declared constants stay default-off until a measured server/language
-        /// profile explicitly earns reference enrichment (#768).
-        declared_const_references: bool,
-    },
-}
-
 /// Complete construction profile for a built-in language server.
 ///
 /// Keeping process configuration and admission policy in one descriptor means
@@ -69,7 +61,6 @@ pub(crate) struct BuiltinLspDescriptor {
     init_settings: Option<InitSettingsFactory>,
     config_file: Option<&'static str>,
     toolchain_remediation: Option<&'static str>,
-    eligibility: LspEligibilityPolicy,
 }
 
 impl BuiltinLspDescriptor {
@@ -89,17 +80,10 @@ impl BuiltinLspDescriptor {
         if let Some(remediation) = self.toolchain_remediation {
             enricher = enricher.with_toolchain_remediation(remediation);
         }
-        match self.eligibility {
-            LspEligibilityPolicy::LangConfig {
-                declared_const_references,
-            } => {
-                enricher.allow_declared_const_references = declared_const_references;
-                if let Some(kinds) = crate::extract::configs::config_for_language(self.language)
-                    .and_then(|config| config.lsp_enrichable_kinds)
-                {
-                    enricher = enricher.with_enrichable_kinds(kinds);
-                }
-            }
+        if let Some(kinds) = crate::extract::configs::config_for_language(self.language)
+            .and_then(|config| config.lsp_enrichable_kinds)
+        {
+            enricher = enricher.with_enrichable_kinds(kinds);
         }
         enricher
     }
@@ -121,9 +105,6 @@ macro_rules! builtin_lsp {
             init_settings: None,
             config_file: None,
             toolchain_remediation: None,
-            eligibility: LspEligibilityPolicy::LangConfig {
-                declared_const_references: false,
-            },
         }
     };
 }
@@ -295,12 +276,8 @@ pub struct LspEnricher {
     /// always uses `repo_root` (passed to `enrich()`), which ensures file URIs point to
     /// the correct absolute paths.
     startup_root_override: std::sync::OnceLock<PathBuf>,
-    /// Which node kinds to enrich via LSP. None = all enrichable kinds.
-    /// Configured per-language via LangConfig::lsp_enrichable_kinds.
-    lsp_enrichable_kinds: Option<Vec<NodeKind>>,
-    /// Whether declared constants may produce Pass 1 reference work.
-    /// Built-ins default to false until #768 measures a useful bounded profile.
-    allow_declared_const_references: bool,
+    /// Shared operation/declaration/server admission policy and budget factory.
+    query_profile: LspQueryProfile,
 }
 
 struct LspState {
@@ -321,6 +298,10 @@ struct LspState {
     /// When false, fall back to `textDocument/references` for function edges.
     /// Pyright supports references but not callHierarchy.
     has_call_hierarchy: bool,
+    /// Whether the language server supports textDocument/implementation.
+    has_implementation: bool,
+    /// Whether the language server supports textDocument/documentLink.
+    has_document_links: bool,
     /// Whether the language server supports pull-based diagnostics
     /// (`textDocument/diagnostic`, LSP 3.17+).
     has_pull_diagnostics: bool,
@@ -396,6 +377,8 @@ impl LspEnricher {
                 has_type_hierarchy: false,
                 has_references: false,
                 has_call_hierarchy: false,
+                has_implementation: false,
+                has_document_links: false,
                 has_pull_diagnostics: false,
                 has_inlay_hints: false,
                 was_quiescent: false,
@@ -403,8 +386,7 @@ impl LspEnricher {
                 diagnostics_sink: Arc::new(std::sync::Mutex::new(HashMap::new())),
             }),
             startup_root_override: std::sync::OnceLock::new(),
-            lsp_enrichable_kinds: None,
-            allow_declared_const_references: false,
+            query_profile: LspQueryProfile::new(language, command),
         }
     }
 
@@ -449,24 +431,43 @@ impl LspEnricher {
     /// Restrict which node kinds are enriched via LSP.
     /// When set, only nodes matching these kinds are sent for enrichment.
     pub fn with_enrichable_kinds(mut self, kinds: &'static [NodeKind]) -> Self {
-        self.lsp_enrichable_kinds = Some(kinds.to_vec());
+        self.query_profile = self.query_profile.with_allowed_kinds(kinds);
         self
     }
 
+    #[cfg(test)]
     pub(crate) fn enrichable_kinds(&self) -> Option<&[NodeKind]> {
-        self.lsp_enrichable_kinds.as_deref()
+        self.query_profile.allowed_kinds()
     }
 
+    #[cfg(test)]
     pub(crate) fn allows_declared_const_references(&self) -> bool {
-        self.allow_declared_const_references
+        self.query_profile.allows_declared_const_references()
     }
 
+    #[cfg(test)]
     pub(crate) fn admits_pass1_node(&self, node: &Node) -> bool {
-        if node.id.kind == NodeKind::Const && !self.allows_declared_const_references() {
-            return false;
-        }
-        self.enrichable_kinds()
-            .is_none_or(|kinds| kinds.contains(&node.id.kind))
+        let operation = match node.id.kind {
+            NodeKind::Function => policy::LspQueryOperation::CallHierarchy,
+            NodeKind::Trait => policy::LspQueryOperation::Implementations,
+            NodeKind::Struct | NodeKind::Enum | NodeKind::TypeAlias | NodeKind::Const => {
+                policy::LspQueryOperation::References
+            }
+            NodeKind::Other(_) => policy::LspQueryOperation::DocumentLinks,
+            _ => return false,
+        };
+        self.query_profile.admits(
+            node,
+            operation,
+            LspServerCapabilities {
+                references: true,
+                call_hierarchy: true,
+                implementations: true,
+                type_hierarchy: true,
+                document_links: true,
+            },
+            &mut self.query_profile.budget(),
+        )
     }
 
     /// Common admission boundary for every LSP pass.
@@ -475,9 +476,7 @@ impl LspEnricher {
     /// Rejecting them before `matching_nodes` is shared with any pass prevents
     /// them from becoming per-node or file-derived LSP work targets.
     pub(crate) fn admits_node(&self, node: &Node) -> bool {
-        node.language == self.language
-            && !matches!(&node.id.kind, NodeKind::Other(kind) if kind == "crate")
-            && node.metadata.get("synthetic").map(String::as_str) != Some("true")
+        self.query_profile.accepts_declaration(node)
     }
 
     /// Check if an `experimental/serverStatus` notification indicates readiness.
@@ -531,10 +530,12 @@ impl LspEnricher {
             for entry in entries.flatten() {
                 let name = entry.file_name();
                 let name_str = name.to_string_lossy();
-                if name_str.starts_with('.') || matches!(
-                    name_str.as_ref(),
-                    "node_modules" | "__pycache__" | "target" | ".venv" | "venv" | "env"
-                ) {
+                if name_str.starts_with('.')
+                    || matches!(
+                        name_str.as_ref(),
+                        "node_modules" | "__pycache__" | "target" | ".venv" | "venv" | "env"
+                    )
+                {
                     continue;
                 }
                 let ft = match entry.file_type() {
@@ -590,7 +591,6 @@ impl LspEnricher {
         walk(root, &extensions, 0)
     }
 
-
     fn lsp_language_id_for_path(&self, path: &Path) -> &'static str {
         match path.extension().and_then(|e| e.to_str()) {
             Some("py") => "python",
@@ -638,7 +638,6 @@ impl LspEnricher {
             .map(|hint| format!("\n  Fix: {hint}"))
             .unwrap_or_default()
     }
-
 
     /// Initialize the language server if not already running.
     async fn ensure_initialized(&self, repo_root: &Path) -> Result<()> {
@@ -764,53 +763,54 @@ impl LspEnricher {
         // at startup_root and inject venvPath + venv so the LSP server can resolve
         // installed packages.
         let lang_config = crate::extract::configs::config_for_language(&self.language);
-        let effective_settings = if let Some(venv_dirs) = lang_config.and_then(|c| c.venv_candidates) {
-            let found_venv = venv_dirs
-                .iter()
-                .find(|&&name| startup_root.join(name).is_dir());
-            if let Some(venv_name) = found_venv {
-                let venv_path_str = startup_root.to_string_lossy().to_string();
-                let mut merged = self
-                    .init_settings
-                    .as_ref()
-                    .cloned()
-                    .unwrap_or_else(|| serde_json::json!({}));
-                let python_obj = merged.as_object_mut().and_then(|root| {
-                    if !root.contains_key("python") {
-                        root.insert("python".into(), serde_json::json!({}));
-                    }
-                    root.get_mut("python")
-                });
-                if let Some(python_val) = python_obj {
-                    let analysis_obj = python_val.as_object_mut().and_then(|p| {
-                        if !p.contains_key("analysis") {
-                            p.insert("analysis".into(), serde_json::json!({}));
+        let effective_settings =
+            if let Some(venv_dirs) = lang_config.and_then(|c| c.venv_candidates) {
+                let found_venv = venv_dirs
+                    .iter()
+                    .find(|&&name| startup_root.join(name).is_dir());
+                if let Some(venv_name) = found_venv {
+                    let venv_path_str = startup_root.to_string_lossy().to_string();
+                    let mut merged = self
+                        .init_settings
+                        .as_ref()
+                        .cloned()
+                        .unwrap_or_else(|| serde_json::json!({}));
+                    let python_obj = merged.as_object_mut().and_then(|root| {
+                        if !root.contains_key("python") {
+                            root.insert("python".into(), serde_json::json!({}));
                         }
-                        p.get_mut("analysis")
+                        root.get_mut("python")
                     });
-                    if let Some(analysis_val) = analysis_obj
-                        && let Some(obj) = analysis_val.as_object_mut()
-                    {
-                        obj.insert("venvPath".into(), serde_json::Value::String(venv_path_str));
-                        obj.insert(
-                            "venv".into(),
-                            serde_json::Value::String(venv_name.to_string()),
-                        );
+                    if let Some(python_val) = python_obj {
+                        let analysis_obj = python_val.as_object_mut().and_then(|p| {
+                            if !p.contains_key("analysis") {
+                                p.insert("analysis".into(), serde_json::json!({}));
+                            }
+                            p.get_mut("analysis")
+                        });
+                        if let Some(analysis_val) = analysis_obj
+                            && let Some(obj) = analysis_val.as_object_mut()
+                        {
+                            obj.insert("venvPath".into(), serde_json::Value::String(venv_path_str));
+                            obj.insert(
+                                "venv".into(),
+                                serde_json::Value::String(venv_name.to_string()),
+                            );
+                        }
                     }
+                    tracing::info!(
+                        "{}: found {} at '{}', adding venvPath/venv to initializationOptions",
+                        self.server_command,
+                        venv_name,
+                        startup_root.display()
+                    );
+                    Some(merged)
+                } else {
+                    self.init_settings.clone()
                 }
-                tracing::info!(
-                    "{}: found {} at '{}', adding venvPath/venv to initializationOptions",
-                    self.server_command,
-                    venv_name,
-                    startup_root.display()
-                );
-                Some(merged)
             } else {
                 self.init_settings.clone()
-            }
-        } else {
-            self.init_settings.clone()
-        };
+            };
         if let Some(ref settings) = effective_settings {
             init_params.initialization_options = Some(settings.clone());
         }
@@ -860,19 +860,26 @@ impl LspEnricher {
             .capabilities
             .implementation_provider
             .is_some();
+        let has_document_links = init_result_parsed
+            .capabilities
+            .document_link_provider
+            .is_some();
         tracing::info!(
-            "{} capabilities: references={}, call_hierarchy={}, implementation={}, type_hierarchy={}, pull_diagnostics={}, inlay_hints={}",
+            "{} capabilities: references={}, call_hierarchy={}, implementation={}, type_hierarchy={}, document_links={}, pull_diagnostics={}, inlay_hints={}",
             self.server_command,
             has_references,
             has_call_hierarchy,
             has_implementation,
             has_type_hierarchy,
+            has_document_links,
             has_pull_diagnostics,
             has_inlay_hints
         );
 
         state.has_type_hierarchy = has_type_hierarchy;
         state.has_call_hierarchy = has_call_hierarchy;
+        state.has_implementation = has_implementation;
+        state.has_document_links = has_document_links;
         state.has_references = has_references;
         state.has_pull_diagnostics = has_pull_diagnostics;
         state.has_inlay_hints = has_inlay_hints;
@@ -887,24 +894,25 @@ impl LspEnricher {
         // context. tsserver requires at least one open file before it creates
         // a project; pyright uses it to trigger import-graph indexing.
         // Save the URI for use as a documentSymbol validation fallback.
-        let warmup_uri: Option<String> = if let Some(warmup_path) = Self::find_warmup_file(self, startup_root) {
-            let uri_str = path_to_uri(&warmup_path).ok().map(|u| u.to_string());
-            match self.send_did_open(transport, &warmup_path).await {
-                Ok(()) => tracing::info!(
-                    "{} sent didOpen for '{}'",
-                    self.server_command,
-                    warmup_path.display()
-                ),
-                Err(e) => tracing::debug!(
-                    "{} didOpen warmup failed (non-fatal): {}",
-                    self.server_command,
-                    e
-                ),
-            }
-            uri_str
-        } else {
-            None
-        };
+        let warmup_uri: Option<String> =
+            if let Some(warmup_path) = Self::find_warmup_file(self, startup_root) {
+                let uri_str = path_to_uri(&warmup_path).ok().map(|u| u.to_string());
+                match self.send_did_open(transport, &warmup_path).await {
+                    Ok(()) => tracing::info!(
+                        "{} sent didOpen for '{}'",
+                        self.server_command,
+                        warmup_path.display()
+                    ),
+                    Err(e) => tracing::debug!(
+                        "{} didOpen warmup failed (non-fatal): {}",
+                        self.server_command,
+                        e
+                    ),
+                }
+                uri_str
+            } else {
+                None
+            };
 
         tracing::info!(
             "{} initialized, waiting for indexing...",
@@ -1282,9 +1290,12 @@ impl LspEnricher {
                         if let Some(ref uri) = warmup_uri {
                             let doc_result = tokio::time::timeout(
                                 tokio::time::Duration::from_secs(10),
-                                transport.request("textDocument/documentSymbol", serde_json::json!({
-                                    "textDocument": { "uri": uri }
-                                })),
+                                transport.request(
+                                    "textDocument/documentSymbol",
+                                    serde_json::json!({
+                                        "textDocument": { "uri": uri }
+                                    }),
+                                ),
                             )
                             .await;
                             if let Ok(Ok(ref resp)) = doc_result {
@@ -1654,21 +1665,29 @@ impl LspEnricher {
         matching_nodes: &[&Node],
         root: &Path,
         result: &mut EnrichmentResult,
-    ) -> bool {
+    ) -> (bool, passes::QueryObservation) {
+        let mut observation = passes::QueryObservation::default();
+        observation.scheduled_requests += 1;
         let items = match Self::prepare_type_hierarchy_p(transport, file_uri, line, character).await
         {
-            Ok(items) if !items.is_empty() => items,
-            Ok(_) => return true, // No type hierarchy item — not a failure
+            Ok(items) if !items.is_empty() => {
+                observation.non_empty_responses += 1;
+                items
+            }
+            Ok(_) => return (true, observation), // No type hierarchy item — not a failure
             Err(e) => {
+                observation.record_error(&e);
                 tracing::debug!("prepareTypeHierarchy failed for {}: {}", node.id.name, e);
-                return false;
+                return (false, observation);
             }
         };
 
         for item in &items {
+            observation.scheduled_requests += 1;
             // Supertypes: this node implements/inherits from each supertype
             match Self::type_hierarchy_supertypes_p(transport, item).await {
                 Ok(supertypes) => {
+                    observation.non_empty_responses += usize::from(!supertypes.is_empty());
                     for supertype in &supertypes {
                         if let Some(target_id) =
                             Self::resolve_type_hierarchy_item(supertype, matching_nodes, root)
@@ -1693,6 +1712,7 @@ impl LspEnricher {
                     }
                 }
                 Err(e) => {
+                    observation.record_error(&e);
                     tracing::debug!(
                         "typeHierarchy/supertypes failed for {}: {}",
                         node.id.name,
@@ -1702,7 +1722,7 @@ impl LspEnricher {
             }
         }
 
-        true // prepare succeeded
+        (true, observation) // prepare succeeded
     }
 
     /// Resolve a TypeHierarchyItem (JSON) to a NodeId in the graph.
@@ -2555,6 +2575,8 @@ impl Enricher for LspEnricher {
             type_hierarchy_strikes,
             has_references,
             has_call_hierarchy,
+            has_implementation,
+            has_document_links,
             has_pull_diagnostics,
             has_inlay_hints,
             was_quiescent,
@@ -2578,6 +2600,8 @@ impl Enricher for LspEnricher {
                 state.type_hierarchy_strikes,
                 state.has_references,
                 state.has_call_hierarchy,
+                state.has_implementation,
+                state.has_document_links,
                 state.has_pull_diagnostics,
                 state.has_inlay_hints,
                 was_quiescent,
@@ -2618,33 +2642,48 @@ impl Enricher for LspEnricher {
             }
             Arc::new(map)
         };
+        let capabilities = LspServerCapabilities {
+            references: has_references,
+            call_hierarchy: has_call_hierarchy,
+            implementations: has_implementation,
+            type_hierarchy: has_type_hierarchy,
+            document_links: has_document_links,
+        };
+        let mut query_budget = self.query_profile.budget();
+        let query_telemetry = Arc::new(policy::LspQueryTelemetry::new(&self.query_profile));
 
         // Pass 1: call hierarchy, references, implementations, document links (concurrent)
         let pass1 = self.run_pass1_references(
-                &transport,
-                &root,
-                &matching_nodes,
-                &matching_nodes_owned,
-                &refs_by_file_shared,
-                has_references,
-                has_call_hierarchy,
-                &mut result,
-            );
-        let (attempted, errors, aborted, abort_diagnostic) =
-            match tokio::time::timeout(lsp_job_timeout(), pass1).await {
-                Ok(outcome) => outcome,
-                Err(_) => {
-                    result.aborted = true;
-                    result.error_count = result.error_count.saturating_add(1);
-                    result.diagnostic = Some(format!(
-                        "LSP enrichment timed out for {} after {}s; safely produced partial output was preserved",
-                        self.server_command,
-                        lsp_job_timeout().as_secs()
-                    ));
-                    tracing::warn!("{}", result.diagnostic.as_deref().unwrap_or_default());
-                    return Ok(result);
-                }
-            };
+            &transport,
+            &root,
+            &matching_nodes,
+            &matching_nodes_owned,
+            &refs_by_file_shared,
+            capabilities,
+            &mut query_budget,
+            &query_telemetry,
+            &mut result,
+        );
+        let (attempted, errors, aborted, abort_diagnostic) = match tokio::time::timeout(
+            lsp_job_timeout(),
+            pass1,
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(_) => {
+                result.aborted = true;
+                result.error_count = result.error_count.saturating_add(1);
+                result.diagnostic = Some(format!(
+                    "LSP enrichment timed out for {} after {}s; safely produced partial output was preserved",
+                    self.server_command,
+                    lsp_job_timeout().as_secs()
+                ));
+                tracing::warn!("{}", result.diagnostic.as_deref().unwrap_or_default());
+                result.lsp_query_metrics = query_telemetry.snapshot();
+                return Ok(result);
+            }
+        };
         if aborted {
             result.error_count = errors as usize;
             result.aborted = true;
@@ -2655,9 +2694,9 @@ impl Enricher for LspEnricher {
                 self.server_command, attempted, errors, detail
             ));
             tracing::warn!("{}", result.diagnostic.as_deref().unwrap_or_default());
+            result.lsp_query_metrics = query_telemetry.snapshot();
             return Ok(result);
         }
-
 
         // Pass 2: type hierarchy (sequential -- strike counting needs order)
         let (has_type_hierarchy, type_hierarchy_strikes) = self
@@ -2665,7 +2704,9 @@ impl Enricher for LspEnricher {
                 &transport,
                 &root,
                 &matching_nodes,
-                has_type_hierarchy,
+                capabilities,
+                &mut query_budget,
+                &query_telemetry,
                 type_hierarchy_strikes,
                 &mut result,
             )
@@ -2728,6 +2769,7 @@ impl Enricher for LspEnricher {
 
         result.error_count = errors as usize;
         result.aborted = aborted;
+        result.lsp_query_metrics = query_telemetry.snapshot();
         Ok(result)
     }
 }

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -19,7 +19,6 @@
 //!   [`PipelinedTransport`] (concurrent, enrichment-phase), plus URI helpers.
 
 mod passes;
-pub(crate) use passes::requested_operations_for_node;
 mod policy;
 pub use policy::LspQueryMetric;
 use policy::{LspQueryProfile, LspServerCapabilities};
@@ -222,6 +221,43 @@ static BUILTIN_LSP_DESCRIPTORS: &[BuiltinLspDescriptor] = &[
 
 pub(crate) fn builtin_lsp_descriptors() -> &'static [BuiltinLspDescriptor] {
     BUILTIN_LSP_DESCRIPTORS
+}
+
+/// Planner-safe projection of the shared query profile. Changed-file planning
+/// does not have negotiated server capabilities yet, so it assumes advertised
+/// support while preserving declaration, language/server, and default-deny
+/// policy. Runtime scheduling rechecks against negotiated capabilities.
+pub(crate) fn planned_operations_for_node(node: &Node) -> Vec<String> {
+    let Some(descriptor) = BUILTIN_LSP_DESCRIPTORS
+        .iter()
+        .find(|descriptor| descriptor.language == node.language)
+    else {
+        return Vec::new();
+    };
+    let enricher = descriptor.build();
+    let operation = match node.id.kind {
+        NodeKind::Function => policy::LspQueryOperation::CallHierarchy,
+        NodeKind::Trait => policy::LspQueryOperation::Implementations,
+        NodeKind::Struct | NodeKind::Enum | NodeKind::TypeAlias | NodeKind::Const => {
+            policy::LspQueryOperation::References
+        }
+        NodeKind::Other(_) => policy::LspQueryOperation::DocumentLinks,
+        _ => return Vec::new(),
+    };
+    let capabilities = LspServerCapabilities {
+        references: true,
+        call_hierarchy: true,
+        implementations: true,
+        type_hierarchy: true,
+        document_links: true,
+    };
+    let mut budget = enricher.query_profile.budget();
+    enricher
+        .query_profile
+        .admits(node, operation, capabilities, &mut budget)
+        .then(|| operation.to_string())
+        .into_iter()
+        .collect()
 }
 
 pub(crate) fn builtin_lsp_enricher(language: &str) -> Option<LspEnricher> {
@@ -2672,6 +2708,7 @@ impl Enricher for LspEnricher {
         {
             Ok(outcome) => outcome,
             Err(_) => {
+                query_telemetry.record_job_timeout(lsp_job_timeout());
                 result.aborted = true;
                 result.error_count = result.error_count.saturating_add(1);
                 result.diagnostic = Some(format!(

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -235,13 +235,18 @@ pub(crate) fn planned_operations_for_node(node: &Node) -> Vec<String> {
         return Vec::new();
     };
     let enricher = descriptor.build();
-    let operation = match node.id.kind {
-        NodeKind::Function => policy::LspQueryOperation::CallHierarchy,
-        NodeKind::Trait => policy::LspQueryOperation::Implementations,
-        NodeKind::Struct | NodeKind::Enum | NodeKind::TypeAlias | NodeKind::Const => {
-            policy::LspQueryOperation::References
-        }
-        NodeKind::Other(_) => policy::LspQueryOperation::DocumentLinks,
+    let operations: &[policy::LspQueryOperation] = match node.id.kind {
+        NodeKind::Function => &[policy::LspQueryOperation::CallHierarchy],
+        NodeKind::Trait => &[
+            policy::LspQueryOperation::Implementations,
+            policy::LspQueryOperation::TypeHierarchy,
+        ],
+        NodeKind::Struct | NodeKind::Enum => &[
+            policy::LspQueryOperation::References,
+            policy::LspQueryOperation::TypeHierarchy,
+        ],
+        NodeKind::TypeAlias | NodeKind::Const => &[policy::LspQueryOperation::References],
+        NodeKind::Other(_) => &[policy::LspQueryOperation::DocumentLinks],
         _ => return Vec::new(),
     };
     let capabilities = LspServerCapabilities {
@@ -252,11 +257,15 @@ pub(crate) fn planned_operations_for_node(node: &Node) -> Vec<String> {
         document_links: true,
     };
     let mut budget = enricher.query_profile.budget();
-    enricher
-        .query_profile
-        .admits(node, operation, capabilities, &mut budget)
-        .then(|| operation.to_string())
-        .into_iter()
+    operations
+        .iter()
+        .copied()
+        .filter(|operation| {
+            enricher
+                .query_profile
+                .admits(node, *operation, capabilities, &mut budget)
+        })
+        .map(|operation| operation.to_string())
         .collect()
 }
 
@@ -472,7 +481,7 @@ impl LspEnricher {
     }
 
     #[cfg(test)]
-    pub(crate) fn enrichable_kinds(&self) -> Option<&[NodeKind]> {
+    pub(crate) fn enrichable_kinds(&self) -> Option<&std::collections::HashSet<NodeKind>> {
         self.query_profile.allowed_kinds()
     }
 
@@ -934,18 +943,23 @@ impl LspEnricher {
             if let Some(warmup_path) = Self::find_warmup_file(self, startup_root) {
                 let uri_str = path_to_uri(&warmup_path).ok().map(|u| u.to_string());
                 match self.send_did_open(transport, &warmup_path).await {
-                    Ok(()) => tracing::info!(
-                        "{} sent didOpen for '{}'",
-                        self.server_command,
-                        warmup_path.display()
-                    ),
-                    Err(e) => tracing::debug!(
-                        "{} didOpen warmup failed (non-fatal): {}",
-                        self.server_command,
-                        e
-                    ),
+                    Ok(()) => {
+                        tracing::info!(
+                            "{} sent didOpen for '{}'",
+                            self.server_command,
+                            warmup_path.display()
+                        );
+                        uri_str
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            "{} didOpen warmup failed (non-fatal): {}",
+                            self.server_command,
+                            e
+                        );
+                        None
+                    }
                 }
-                uri_str
             } else {
                 None
             };
@@ -2708,7 +2722,7 @@ impl Enricher for LspEnricher {
         {
             Ok(outcome) => outcome,
             Err(_) => {
-                query_telemetry.record_job_timeout(lsp_job_timeout());
+                query_telemetry.record_job_timeout();
                 result.aborted = true;
                 result.error_count = result.error_count.saturating_add(1);
                 result.diagnostic = Some(format!(
@@ -2885,11 +2899,12 @@ mod tests {
         assert_eq!(python.server_command, "pyright-langserver");
         assert_eq!(python.server_args, vec!["--stdio"]);
         assert_eq!(python.config_file_hint(), Some("pyproject.toml"));
-        assert_eq!(
-            python.enrichable_kinds(),
-            Some([NodeKind::Function, NodeKind::Trait].as_slice()),
-            "the shared factory must retain Python's Function/Trait admission policy"
-        );
+        let python_kinds = python
+            .enrichable_kinds()
+            .expect("the shared factory must retain Python's admission policy");
+        assert_eq!(python_kinds.len(), 2);
+        assert!(python_kinds.contains(&NodeKind::Function));
+        assert!(python_kinds.contains(&NodeKind::Trait));
         assert!(
             !python.allows_declared_const_references(),
             "built-in profiles must keep declared-Const references default-off"

--- a/src/extract/lsp/passes.rs
+++ b/src/extract/lsp/passes.rs
@@ -788,14 +788,6 @@ impl LspEnricher {
         let (recovery_errors, recovery_aborted, recovery_diagnostic) =
             recovery_failure_state(&work_item_ledger);
         let work_items = runnable_pass1_work_items(work_items, &work_item_ledger);
-        for item in &work_items {
-            if let (Some(operation), Some(declaration)) = (
-                item.requested_operations.first().copied(),
-                LspDeclarationClass::from_kind(&item.node.id.kind),
-            ) {
-                telemetry.register_work_item(operation, declaration);
-            }
-        }
         let did_open = Arc::new(DidOpenCoordinator::new(self.server_command.clone()));
         let error_count = Arc::new(AtomicI64::new(0));
         let transport = Arc::clone(transport);
@@ -817,6 +809,12 @@ impl LspEnricher {
                 let did_open = Arc::clone(&did_open);
                 let telemetry = Arc::clone(&telemetry);
                 async move {
+                    if let (Some(operation), Some(declaration)) = (
+                        item.requested_operations.first().copied(),
+                        LspDeclarationClass::from_kind(&item.node.id.kind),
+                    ) {
+                        telemetry.register_work_item(item.id, operation, declaration);
+                    }
                     Self::run_pass1_work_item(
                         &item,
                         &transport,
@@ -1022,11 +1020,7 @@ impl LspEnricher {
                 diagnostics
                     .finish_failed(item, format!("failed to resolve file URI: {e}"))
                     .await;
-                if let (Some(operation), Some(declaration)) =
-                    (operation, LspDeclarationClass::from_kind(&node.id.kind))
-                {
-                    telemetry.record(operation, declaration, 0, 0, 0, started_at.elapsed(), 1, 0);
-                }
+                telemetry.record_work_item(item.id, 0, 0, 0, started_at.elapsed(), 1, 0);
                 return Pass1TaskResult {
                     edges: Vec::new(),
                     new_nodes: Vec::new(),
@@ -1045,22 +1039,17 @@ impl LspEnricher {
             diagnostics
                 .finish_failed(item, format!("failed to send textDocument/didOpen: {e}"))
                 .await;
-            if let (Some(operation), Some(declaration)) =
-                (operation, LspDeclarationClass::from_kind(&node.id.kind))
-            {
-                let mut observation = QueryObservation::default();
-                observation.record_error(&e);
-                telemetry.record(
-                    operation,
-                    declaration,
-                    0,
-                    0,
-                    0,
-                    started_at.elapsed(),
-                    observation.errors,
-                    observation.timeouts,
-                );
-            }
+            let mut observation = QueryObservation::default();
+            observation.record_error(&e);
+            telemetry.record_work_item(
+                item.id,
+                0,
+                0,
+                0,
+                started_at.elapsed(),
+                observation.errors,
+                observation.timeouts,
+            );
             return Pass1TaskResult {
                 edges: Vec::new(),
                 new_nodes: Vec::new(),
@@ -1144,20 +1133,15 @@ impl LspEnricher {
         };
         had_error |= observation.errors > 0;
 
-        if let (Some(operation), Some(declaration)) =
-            (operation, LspDeclarationClass::from_kind(&node.id.kind))
-        {
-            telemetry.record(
-                operation,
-                declaration,
-                observation.scheduled_requests,
-                observation.non_empty_responses,
-                edges.len(),
-                started_at.elapsed(),
-                observation.errors,
-                observation.timeouts,
-            );
-        }
+        telemetry.record_work_item(
+            item.id,
+            observation.scheduled_requests,
+            observation.non_empty_responses,
+            edges.len(),
+            started_at.elapsed(),
+            observation.errors,
+            observation.timeouts,
+        );
 
         diagnostics
             .finish(item, !had_error, &edges, &new_nodes)

--- a/src/extract/lsp/passes.rs
+++ b/src/extract/lsp/passes.rs
@@ -204,6 +204,27 @@ impl QueryObservation {
     }
 }
 
+fn record_type_hierarchy_observation(
+    telemetry: &LspQueryTelemetry,
+    node: &Node,
+    observation: QueryObservation,
+    emitted_edges: usize,
+    latency: Duration,
+) {
+    if let Some(declaration) = LspDeclarationClass::from_kind(&node.id.kind) {
+        telemetry.record(
+            LspQueryOperation::TypeHierarchy,
+            declaration,
+            observation.scheduled_requests,
+            observation.non_empty_responses,
+            emitted_edges,
+            latency,
+            observation.errors,
+            observation.timeouts,
+        );
+    }
+}
+
 fn runnable_pass1_work_items(
     work_items: Vec<LspPass1WorkItem>,
     ledger: &LspWorkItemLedger,
@@ -532,29 +553,6 @@ fn language_id_for_path(path: &Path) -> &'static str {
     }
 }
 
-pub(crate) fn requested_operations_for_node(
-    kind: &NodeKind,
-    has_references: bool,
-    has_call_hierarchy: bool,
-) -> Vec<&'static str> {
-    match kind {
-        NodeKind::Function if has_call_hierarchy => vec![
-            "requesting_call_hierarchy_prepare",
-            "requesting_call_hierarchy_incoming",
-            "requesting_call_hierarchy_outgoing",
-        ],
-        NodeKind::Function if has_references => vec!["requesting_references"],
-        NodeKind::Trait => vec!["requesting_implementations"],
-        NodeKind::Struct | NodeKind::Enum | NodeKind::TypeAlias | NodeKind::Const
-            if has_references =>
-        {
-            vec!["requesting_references"]
-        }
-        NodeKind::Other(_) => vec!["requesting_document_links"],
-        _ => vec!["skipped_no_supported_operation"],
-    }
-}
-
 fn did_open_timeout() -> Duration {
     duration_from_env("RNA_LSP_DID_OPEN_TIMEOUT_MS", DID_OPEN_DEFAULT_TIMEOUT)
 }
@@ -789,6 +787,15 @@ impl LspEnricher {
         let pass1_edge_baseline = result.added_edges.len();
         let (recovery_errors, recovery_aborted, recovery_diagnostic) =
             recovery_failure_state(&work_item_ledger);
+        let work_items = runnable_pass1_work_items(work_items, &work_item_ledger);
+        for item in &work_items {
+            if let (Some(operation), Some(declaration)) = (
+                item.requested_operations.first().copied(),
+                LspDeclarationClass::from_kind(&item.node.id.kind),
+            ) {
+                telemetry.register_work_item(operation, declaration);
+            }
+        }
         let did_open = Arc::new(DidOpenCoordinator::new(self.server_command.clone()));
         let error_count = Arc::new(AtomicI64::new(0));
         let transport = Arc::clone(transport);
@@ -1686,19 +1693,14 @@ impl LspEnricher {
             )
             .await;
 
-            if let Some(declaration) = LspDeclarationClass::from_kind(&node.id.kind) {
-                let emitted_edges = result.added_edges.len() - edges_before_query;
-                telemetry.record(
-                    LspQueryOperation::TypeHierarchy,
-                    declaration,
-                    1,
-                    observation.non_empty_responses,
-                    emitted_edges,
-                    query_started.elapsed(),
-                    observation.errors,
-                    observation.timeouts,
-                );
-            }
+            let emitted_edges = result.added_edges.len() - edges_before_query;
+            record_type_hierarchy_observation(
+                telemetry,
+                node,
+                observation,
+                emitted_edges,
+                query_started.elapsed(),
+            );
 
             Self::update_type_hierarchy_strikes(
                 ok,
@@ -2039,6 +2041,44 @@ mod tests {
     use super::*;
     use std::path::Path;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn type_hierarchy_telemetry_uses_all_observed_requests() {
+        let profile = super::super::policy::LspQueryProfile::new("rust", "rust-analyzer");
+        let telemetry = LspQueryTelemetry::new(&profile);
+        let node = Node {
+            id: NodeId {
+                root: "repo".to_string(),
+                file: PathBuf::from("src/lib.rs"),
+                name: "Child".to_string(),
+                kind: NodeKind::Struct,
+            },
+            language: "rust".to_string(),
+            line_start: 1,
+            line_end: 2,
+            signature: String::new(),
+            body: String::new(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::TreeSitter,
+        };
+
+        record_type_hierarchy_observation(
+            &telemetry,
+            &node,
+            QueryObservation {
+                scheduled_requests: 2,
+                non_empty_responses: 2,
+                ..Default::default()
+            },
+            1,
+            Duration::from_millis(5),
+        );
+
+        let metrics = telemetry.snapshot();
+        assert_eq!(metrics[0].scheduled_requests, 2);
+        assert_eq!(metrics[0].non_empty_responses, 2);
+        assert_eq!(metrics[0].emitted_edges, 1);
+    }
 
     #[tokio::test]
     async fn did_open_coordinator_dedupes_concurrent_same_file() {

--- a/src/extract/lsp/passes.rs
+++ b/src/extract/lsp/passes.rs
@@ -4,7 +4,7 @@
 //! appends results to the `EnrichmentResult`. The top-level `enrich()` orchestrates
 //! them in sequence: Pass 0 -> Pass 1 -> Pass 2 -> Pass 4 -> Pass 5 -> Pass 3.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
@@ -223,6 +223,14 @@ fn record_type_hierarchy_observation(
             observation.timeouts,
         );
     }
+}
+
+fn retain_unique_document_link_file(
+    node: &Node,
+    operation: LspQueryOperation,
+    seen_files: &mut HashSet<PathBuf>,
+) -> bool {
+    operation != LspQueryOperation::DocumentLinks || seen_files.insert(node.id.file.clone())
 }
 
 fn runnable_pass1_work_items(
@@ -679,6 +687,7 @@ impl LspEnricher {
             .copied()
             .collect();
 
+        let mut document_link_files = HashSet::new();
         let admitted_nodes: Vec<(&Node, LspQueryOperation)> = candidate_nodes
             .into_iter()
             .filter_map(|node| {
@@ -694,6 +703,9 @@ impl LspEnricher {
                     NodeKind::Other(_) => Some(LspQueryOperation::DocumentLinks),
                     _ => None,
                 }?;
+                if !retain_unique_document_link_file(node, operation, &mut document_link_files) {
+                    return None;
+                }
                 self.query_profile
                     .admits(node, operation, capabilities, budget)
                     .then_some((node, operation))
@@ -794,7 +806,7 @@ impl LspEnricher {
         let root = root.to_path_buf();
         let matching_owned = Arc::clone(matching_nodes_owned);
         let refs_by_file = Arc::clone(refs_by_file_shared);
-        let telemetry = Arc::clone(telemetry);
+        let worker_telemetry = Arc::clone(telemetry);
         let (total_nodes, diagnostics, mut join_set, mut result_rx) = spawn_pass1_workers(
             work_items,
             &work_item_ledger,
@@ -807,7 +819,7 @@ impl LspEnricher {
                 let language = language.clone();
                 let error_count = Arc::clone(&error_count);
                 let did_open = Arc::clone(&did_open);
-                let telemetry = Arc::clone(&telemetry);
+                let telemetry = Arc::clone(&worker_telemetry);
                 async move {
                     let registered = if let (Some(operation), Some(declaration)) = (
                         item.requested_operations.first().copied(),
@@ -984,6 +996,9 @@ impl LspEnricher {
                 abort_diagnostic = recovery_diagnostic;
             }
         }
+        if aborted {
+            telemetry.record_job_timeout();
+        }
 
         tracing::info!(
             "LSP Pass 1 complete in {:?}: {} edges from {} nodes ({} errors)",
@@ -1029,7 +1044,7 @@ impl LspEnricher {
                 diagnostics
                     .finish_failed(item, format!("failed to resolve file URI: {e}"))
                     .await;
-                telemetry.record_work_item(item.id, 0, 0, 0, started_at.elapsed(), 1, 0);
+                telemetry.record_work_item(item.id, 0, 0, started_at.elapsed(), 1, 0);
                 return Pass1TaskResult {
                     edges: Vec::new(),
                     new_nodes: Vec::new(),
@@ -1052,7 +1067,6 @@ impl LspEnricher {
             observation.record_error(&e);
             telemetry.record_work_item(
                 item.id,
-                0,
                 0,
                 0,
                 started_at.elapsed(),
@@ -1091,6 +1105,8 @@ impl LspEnricher {
                     language,
                     operation == Some(LspQueryOperation::References),
                     operation == Some(LspQueryOperation::CallHierarchy),
+                    item.id,
+                    telemetry,
                     &mut edges,
                     &mut new_nodes,
                     &mut had_error,
@@ -1107,6 +1123,8 @@ impl LspEnricher {
                     node,
                     matching_owned,
                     root,
+                    item.id,
+                    telemetry,
                     &mut edges,
                 )
                 .await
@@ -1121,6 +1139,8 @@ impl LspEnricher {
                         node,
                         matching_owned,
                         root,
+                        item.id,
+                        telemetry,
                         &mut edges,
                         &mut had_error,
                         error_count,
@@ -1134,7 +1154,16 @@ impl LspEnricher {
                 if matches!(node.id.kind, NodeKind::Other(_))
                     && operation == Some(LspQueryOperation::DocumentLinks)
                 {
-                    Self::enrich_document_links(transport, &file_uri, node, root, &mut edges).await
+                    Self::enrich_document_links(
+                        transport,
+                        &file_uri,
+                        node,
+                        root,
+                        item.id,
+                        telemetry,
+                        &mut edges,
+                    )
+                    .await
                 } else {
                     QueryObservation::default()
                 }
@@ -1144,7 +1173,6 @@ impl LspEnricher {
 
         telemetry.record_work_item(
             item.id,
-            observation.scheduled_requests,
             observation.non_empty_responses,
             edges.len(),
             started_at.elapsed(),
@@ -1175,6 +1203,8 @@ impl LspEnricher {
         language: &str,
         has_references: bool,
         has_call_hierarchy: bool,
+        work_item_id: usize,
+        telemetry: &LspQueryTelemetry,
         edges: &mut Vec<Edge>,
         new_nodes: &mut Vec<Node>,
         had_error: &mut bool,
@@ -1183,6 +1213,7 @@ impl LspEnricher {
         let mut observation = QueryObservation::default();
         if !has_call_hierarchy && has_references {
             observation.scheduled_requests += 1;
+            telemetry.note_requests_started(work_item_id, 1);
             match Self::find_references_p(transport, file_uri, line, col).await {
                 Ok(locations) => {
                     observation.non_empty_responses += usize::from(!locations.is_empty());
@@ -1232,10 +1263,12 @@ impl LspEnricher {
             }
         } else if has_call_hierarchy {
             observation.scheduled_requests += 1;
+            telemetry.note_requests_started(work_item_id, 1);
             match Self::prepare_call_hierarchy_p(transport, file_uri, line, col).await {
                 Ok(Some(item)) => {
                     observation.non_empty_responses += 1;
                     observation.scheduled_requests += 2;
+                    telemetry.note_requests_started(work_item_id, 2);
                     let (incoming_result, outgoing_result) = tokio::join!(
                         Self::incoming_calls_p(transport, &item),
                         Self::outgoing_calls_p(transport, &item),
@@ -1444,12 +1477,15 @@ impl LspEnricher {
         node: &Node,
         matching_owned: &Arc<Vec<Node>>,
         root: &Path,
+        work_item_id: usize,
+        telemetry: &LspQueryTelemetry,
         edges: &mut Vec<Edge>,
     ) -> QueryObservation {
         let mut observation = QueryObservation {
             scheduled_requests: 1,
             ..Default::default()
         };
+        telemetry.note_requests_started(work_item_id, 1);
         match Self::find_implementations_p(transport, file_uri, line, col).await {
             Ok(locations) => {
                 observation.non_empty_responses += usize::from(!locations.is_empty());
@@ -1498,6 +1534,8 @@ impl LspEnricher {
         node: &Node,
         matching_owned: &Arc<Vec<Node>>,
         root: &Path,
+        work_item_id: usize,
+        telemetry: &LspQueryTelemetry,
         edges: &mut Vec<Edge>,
         had_error: &mut bool,
         error_count: &AtomicI64,
@@ -1506,6 +1544,7 @@ impl LspEnricher {
             scheduled_requests: 1,
             ..Default::default()
         };
+        telemetry.note_requests_started(work_item_id, 1);
         match Self::find_references_p(transport, file_uri, line, col).await {
             Ok(locations) => {
                 observation.non_empty_responses += usize::from(!locations.is_empty());
@@ -1565,12 +1604,15 @@ impl LspEnricher {
         file_uri: &lsp_types::Uri,
         node: &Node,
         root: &Path,
+        work_item_id: usize,
+        telemetry: &LspQueryTelemetry,
         edges: &mut Vec<Edge>,
     ) -> QueryObservation {
         let mut observation = QueryObservation {
             scheduled_requests: 1,
             ..Default::default()
         };
+        telemetry.note_requests_started(work_item_id, 1);
         match Self::document_links_p(transport, file_uri).await {
             Ok(links) => {
                 observation.non_empty_responses += usize::from(!links.is_empty());
@@ -2071,6 +2113,42 @@ mod tests {
         assert_eq!(metrics[0].scheduled_requests, 2);
         assert_eq!(metrics[0].non_empty_responses, 2);
         assert_eq!(metrics[0].emitted_edges, 1);
+    }
+
+    #[test]
+    fn document_link_work_is_deduplicated_by_file() {
+        let make_node = |name: &str, file: &str| Node {
+            id: NodeId {
+                root: "repo".to_string(),
+                file: PathBuf::from(file),
+                name: name.to_string(),
+                kind: NodeKind::Other("markdown_section".to_string()),
+            },
+            language: "markdown".to_string(),
+            line_start: 1,
+            line_end: 2,
+            signature: String::new(),
+            body: String::new(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::TreeSitter,
+        };
+        let mut seen = HashSet::new();
+
+        assert!(retain_unique_document_link_file(
+            &make_node("first", "docs/one.md"),
+            LspQueryOperation::DocumentLinks,
+            &mut seen,
+        ));
+        assert!(!retain_unique_document_link_file(
+            &make_node("second", "docs/one.md"),
+            LspQueryOperation::DocumentLinks,
+            &mut seen,
+        ));
+        assert!(retain_unique_document_link_file(
+            &make_node("third", "docs/two.md"),
+            LspQueryOperation::DocumentLinks,
+            &mut seen,
+        ));
     }
 
     #[tokio::test]

--- a/src/extract/lsp/passes.rs
+++ b/src/extract/lsp/passes.rs
@@ -809,11 +809,20 @@ impl LspEnricher {
                 let did_open = Arc::clone(&did_open);
                 let telemetry = Arc::clone(&telemetry);
                 async move {
-                    if let (Some(operation), Some(declaration)) = (
+                    let registered = if let (Some(operation), Some(declaration)) = (
                         item.requested_operations.first().copied(),
                         LspDeclarationClass::from_kind(&item.node.id.kind),
                     ) {
-                        telemetry.register_work_item(item.id, operation, declaration);
+                        telemetry.register_work_item(item.id, operation, declaration)
+                    } else {
+                        false
+                    };
+                    if !registered {
+                        return Pass1TaskResult {
+                            edges: Vec::new(),
+                            new_nodes: Vec::new(),
+                            had_error: false,
+                        };
                     }
                     Self::run_pass1_work_item(
                         &item,

--- a/src/extract/lsp/passes.rs
+++ b/src/extract/lsp/passes.rs
@@ -15,6 +15,10 @@ use tokio::sync::Mutex;
 
 use crate::graph::{Confidence, Edge, EdgeKind, ExtractionSource, Node, NodeId, NodeKind};
 
+use super::policy::{
+    LspDeclarationClass, LspQueryBudget, LspQueryOperation, LspQueryTelemetry,
+    LspServerCapabilities,
+};
 use super::transport::{
     PipelinedTransport, find_enclosing_symbol, path_to_uri, uri_to_relative_path,
 };
@@ -171,7 +175,7 @@ impl DidOpenCoordinator {
 struct LspPass1WorkItem {
     id: usize,
     node: Node,
-    requested_operations: Vec<&'static str>,
+    requested_operations: Vec<LspQueryOperation>,
     attempt_count: u32,
 }
 
@@ -180,6 +184,24 @@ struct Pass1TaskResult {
     edges: Vec<Edge>,
     new_nodes: Vec<Node>,
     had_error: bool,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(super) struct QueryObservation {
+    pub(super) scheduled_requests: usize,
+    pub(super) non_empty_responses: usize,
+    pub(super) errors: usize,
+    pub(super) timeouts: usize,
+}
+
+impl QueryObservation {
+    pub(super) fn record_error(&mut self, error: &anyhow::Error) {
+        self.errors += 1;
+        let text = error.to_string().to_ascii_lowercase();
+        if text.contains("timed out") || text.contains("timeout") {
+            self.timeouts += 1;
+        }
+    }
 }
 
 fn runnable_pass1_work_items(
@@ -611,8 +633,9 @@ impl LspEnricher {
         matching_nodes: &[&Node],
         matching_nodes_owned: &Arc<Vec<Node>>,
         refs_by_file_shared: &Arc<HashMap<PathBuf, Vec<Node>>>,
-        has_references: bool,
-        has_call_hierarchy: bool,
+        capabilities: LspServerCapabilities,
+        budget: &mut LspQueryBudget,
+        telemetry: &Arc<LspQueryTelemetry>,
         result: &mut EnrichmentResult,
     ) -> (u32, u32, bool, Option<String>) {
         let pass1_start = std::time::Instant::now();
@@ -625,7 +648,7 @@ impl LspEnricher {
         // Also skip diagnostic nodes (Other("diagnostic")) to prevent them from being
         // re-enriched via the generic Other/documentLink path on subsequent passes --
         // which would generate spurious DependsOn edges from diagnostics.
-        let enrichable_nodes: Vec<&Node> = matching_nodes
+        let candidate_nodes: Vec<&Node> = matching_nodes
             .iter()
             .filter(|n| {
                 matches!(
@@ -640,11 +663,6 @@ impl LspEnricher {
                 )
             })
             .filter(|n| !matches!(&n.id.kind, NodeKind::Other(s) if s == "diagnostic"))
-            // When lsp_enrichable_kinds is set, restrict to those kinds only.
-            // This is configured per-language via LangConfig (e.g., Python restricts
-            // to Function+Trait because pyright's textDocument/references hangs on
-            // class/enum/const lookups).
-            .filter(|n| self.admits_pass1_node(n))
             .filter(|n| {
                 // Skip test functions (have #[test] or #[tokio::test] decorator)
                 if n.id.kind == NodeKind::Function {
@@ -663,9 +681,30 @@ impl LspEnricher {
             .copied()
             .collect();
 
-        let ref_eligible = enrichable_nodes
+        let admitted_nodes: Vec<(&Node, LspQueryOperation)> = candidate_nodes
+            .into_iter()
+            .filter_map(|node| {
+                let operation = match node.id.kind {
+                    NodeKind::Function if capabilities.call_hierarchy => {
+                        Some(LspQueryOperation::CallHierarchy)
+                    }
+                    NodeKind::Function => Some(LspQueryOperation::References),
+                    NodeKind::Trait => Some(LspQueryOperation::Implementations),
+                    NodeKind::Struct | NodeKind::Enum | NodeKind::TypeAlias | NodeKind::Const => {
+                        Some(LspQueryOperation::References)
+                    }
+                    NodeKind::Other(_) => Some(LspQueryOperation::DocumentLinks),
+                    _ => None,
+                }?;
+                self.query_profile
+                    .admits(node, operation, capabilities, budget)
+                    .then_some((node, operation))
+            })
+            .collect();
+
+        let ref_eligible = admitted_nodes
             .iter()
-            .filter(|n| {
+            .filter(|(n, _)| {
                 matches!(
                     n.id.kind,
                     NodeKind::Struct | NodeKind::Enum | NodeKind::TypeAlias | NodeKind::Const
@@ -674,40 +713,36 @@ impl LspEnricher {
             .count();
         tracing::info!(
             "LSP pipeline: {} enrichable nodes out of {} total ({}f, {}t, {}r, {}o) [references={}, call_hierarchy={}]",
-            enrichable_nodes.len(),
+            admitted_nodes.len(),
             matching_nodes.len(),
-            enrichable_nodes
+            admitted_nodes
                 .iter()
-                .filter(|n| n.id.kind == NodeKind::Function)
+                .filter(|(n, _)| n.id.kind == NodeKind::Function)
                 .count(),
-            enrichable_nodes
+            admitted_nodes
                 .iter()
-                .filter(|n| n.id.kind == NodeKind::Trait)
+                .filter(|(n, _)| n.id.kind == NodeKind::Trait)
                 .count(),
             ref_eligible,
-            enrichable_nodes
+            admitted_nodes
                 .iter()
-                .filter(|n| matches!(n.id.kind, NodeKind::Other(_)))
+                .filter(|(n, _)| matches!(n.id.kind, NodeKind::Other(_)))
                 .count(),
-            has_references,
-            has_call_hierarchy,
+            capabilities.references,
+            capabilities.call_hierarchy,
         );
 
         // Bounded queue substrate: materialize inspectable work items, then let a
         // fixed worker pool drain them. This avoids spawning one opaque task per
         // symbol and gives diagnostics a stable queue/in-flight model.
         const PIPELINE_MAX_CONCURRENCY: usize = 64;
-        let work_items: Vec<LspPass1WorkItem> = enrichable_nodes
+        let work_items: Vec<LspPass1WorkItem> = admitted_nodes
             .iter()
             .enumerate()
-            .map(|(id, node)| LspPass1WorkItem {
+            .map(|(id, (node, operation))| LspPass1WorkItem {
                 id,
                 node: (*node).clone(),
-                requested_operations: requested_operations_for_node(
-                    &node.id.kind,
-                    has_references,
-                    has_call_hierarchy,
-                ),
+                requested_operations: vec![*operation],
                 attempt_count: 1,
             })
             .collect();
@@ -719,7 +754,7 @@ impl LspEnricher {
                 requested_operations: item
                     .requested_operations
                     .iter()
-                    .map(|operation| (*operation).to_string())
+                    .map(|operation| operation.to_string())
                     .collect(),
                 attempt_count: item.attempt_count,
             })
@@ -760,6 +795,7 @@ impl LspEnricher {
         let root = root.to_path_buf();
         let matching_owned = Arc::clone(matching_nodes_owned);
         let refs_by_file = Arc::clone(refs_by_file_shared);
+        let telemetry = Arc::clone(telemetry);
         let (total_nodes, diagnostics, mut join_set, mut result_rx) = spawn_pass1_workers(
             work_items,
             &work_item_ledger,
@@ -772,6 +808,7 @@ impl LspEnricher {
                 let language = language.clone();
                 let error_count = Arc::clone(&error_count);
                 let did_open = Arc::clone(&did_open);
+                let telemetry = Arc::clone(&telemetry);
                 async move {
                     Self::run_pass1_work_item(
                         &item,
@@ -780,11 +817,10 @@ impl LspEnricher {
                         &matching_owned,
                         &refs_by_file,
                         &language,
-                        has_references,
-                        has_call_hierarchy,
                         &did_open,
                         &diagnostics,
                         &error_count,
+                        &telemetry,
                     )
                     .await
                 }
@@ -958,12 +994,13 @@ impl LspEnricher {
         matching_owned: &Arc<Vec<Node>>,
         refs_by_file: &Arc<HashMap<PathBuf, Vec<Node>>>,
         language: &str,
-        has_references: bool,
-        has_call_hierarchy: bool,
         did_open: &DidOpenCoordinator,
         diagnostics: &LspPass1Diagnostics,
         error_count: &AtomicI64,
+        telemetry: &LspQueryTelemetry,
     ) -> Pass1TaskResult {
+        let started_at = Instant::now();
+        let operation = item.requested_operations.first().copied();
         diagnostics.set_phase(item, "resolving_file_uri").await;
         let node = &item.node;
         let abs_path = root.join(&node.id.file);
@@ -978,6 +1015,11 @@ impl LspEnricher {
                 diagnostics
                     .finish_failed(item, format!("failed to resolve file URI: {e}"))
                     .await;
+                if let (Some(operation), Some(declaration)) =
+                    (operation, LspDeclarationClass::from_kind(&node.id.kind))
+                {
+                    telemetry.record(operation, declaration, 0, 0, 0, started_at.elapsed(), 1, 0);
+                }
                 return Pass1TaskResult {
                     edges: Vec::new(),
                     new_nodes: Vec::new(),
@@ -996,6 +1038,22 @@ impl LspEnricher {
             diagnostics
                 .finish_failed(item, format!("failed to send textDocument/didOpen: {e}"))
                 .await;
+            if let (Some(operation), Some(declaration)) =
+                (operation, LspDeclarationClass::from_kind(&node.id.kind))
+            {
+                let mut observation = QueryObservation::default();
+                observation.record_error(&e);
+                telemetry.record(
+                    operation,
+                    declaration,
+                    0,
+                    0,
+                    0,
+                    started_at.elapsed(),
+                    observation.errors,
+                    observation.timeouts,
+                );
+            }
             return Pass1TaskResult {
                 edges: Vec::new(),
                 new_nodes: Vec::new(),
@@ -1006,7 +1064,7 @@ impl LspEnricher {
         let phase = item
             .requested_operations
             .first()
-            .copied()
+            .map(|operation| operation.phase())
             .unwrap_or("requesting_lsp_operation");
         diagnostics.set_phase(item, phase).await;
 
@@ -1014,8 +1072,7 @@ impl LspEnricher {
         let mut edges = Vec::new();
         let mut new_nodes = Vec::new();
         let mut had_error = false;
-
-        match node.id.kind {
+        let observation = match node.id.kind {
             NodeKind::Function => {
                 Self::enrich_function_node(
                     transport,
@@ -1027,14 +1084,14 @@ impl LspEnricher {
                     refs_by_file,
                     root,
                     language,
-                    has_references,
-                    has_call_hierarchy,
+                    operation == Some(LspQueryOperation::References),
+                    operation == Some(LspQueryOperation::CallHierarchy),
                     &mut edges,
                     &mut new_nodes,
                     &mut had_error,
                     error_count,
                 )
-                .await;
+                .await
             }
             NodeKind::Trait => {
                 Self::enrich_trait_node(
@@ -1047,10 +1104,10 @@ impl LspEnricher {
                     root,
                     &mut edges,
                 )
-                .await;
+                .await
             }
             NodeKind::Struct | NodeKind::Enum | NodeKind::TypeAlias | NodeKind::Const => {
-                if has_references {
+                if operation == Some(LspQueryOperation::References) {
                     Self::enrich_type_references(
                         transport,
                         &file_uri,
@@ -1063,14 +1120,36 @@ impl LspEnricher {
                         &mut had_error,
                         error_count,
                     )
-                    .await;
+                    .await
+                } else {
+                    QueryObservation::default()
                 }
             }
             _ => {
-                if matches!(node.id.kind, NodeKind::Other(_)) {
-                    Self::enrich_document_links(transport, &file_uri, node, root, &mut edges).await;
+                if matches!(node.id.kind, NodeKind::Other(_))
+                    && operation == Some(LspQueryOperation::DocumentLinks)
+                {
+                    Self::enrich_document_links(transport, &file_uri, node, root, &mut edges).await
+                } else {
+                    QueryObservation::default()
                 }
             }
+        };
+        had_error |= observation.errors > 0;
+
+        if let (Some(operation), Some(declaration)) =
+            (operation, LspDeclarationClass::from_kind(&node.id.kind))
+        {
+            telemetry.record(
+                operation,
+                declaration,
+                observation.scheduled_requests,
+                observation.non_empty_responses,
+                edges.len(),
+                started_at.elapsed(),
+                observation.errors,
+                observation.timeouts,
+            );
         }
 
         diagnostics
@@ -1100,10 +1179,13 @@ impl LspEnricher {
         new_nodes: &mut Vec<Node>,
         had_error: &mut bool,
         error_count: &AtomicI64,
-    ) {
+    ) -> QueryObservation {
+        let mut observation = QueryObservation::default();
         if !has_call_hierarchy && has_references {
+            observation.scheduled_requests += 1;
             match Self::find_references_p(transport, file_uri, line, col).await {
                 Ok(locations) => {
+                    observation.non_empty_responses += usize::from(!locations.is_empty());
                     for loc in &locations {
                         let ref_path = uri_to_relative_path(&loc.uri, root);
                         let ref_line = loc.range.start.line as usize + 1;
@@ -1144,12 +1226,16 @@ impl LspEnricher {
                 Err(e) => {
                     *had_error = true;
                     error_count.fetch_add(1, Ordering::Relaxed);
+                    observation.record_error(&e);
                     tracing::debug!("references lookup failed for {}: {}", node.id.name, e);
                 }
             }
         } else if has_call_hierarchy {
+            observation.scheduled_requests += 1;
             match Self::prepare_call_hierarchy_p(transport, file_uri, line, col).await {
                 Ok(Some(item)) => {
+                    observation.non_empty_responses += 1;
+                    observation.scheduled_requests += 2;
                     let (incoming_result, outgoing_result) = tokio::join!(
                         Self::incoming_calls_p(transport, &item),
                         Self::outgoing_calls_p(transport, &item),
@@ -1168,146 +1254,172 @@ impl LspEnricher {
                     }
 
                     // Process incoming calls
-                    if let Ok(calls) = incoming_result {
-                        for call in &calls {
-                            let caller_uri = &call["from"]["uri"];
-                            let caller_name = call["from"]["name"].as_str().unwrap_or("");
-                            let caller_line =
-                                call["from"]["range"]["start"]["line"].as_u64().unwrap_or(0)
-                                    as usize
-                                    + 1;
+                    match incoming_result {
+                        Ok(calls) => {
+                            observation.non_empty_responses += usize::from(!calls.is_empty());
+                            for call in &calls {
+                                let caller_uri = &call["from"]["uri"];
+                                let caller_name = call["from"]["name"].as_str().unwrap_or("");
+                                let caller_line =
+                                    call["from"]["range"]["start"]["line"].as_u64().unwrap_or(0)
+                                        as usize
+                                        + 1;
 
-                            if let Some(uri_str) = caller_uri.as_str() {
-                                let caller_path = if let Some(p) = uri_str.strip_prefix("file://") {
-                                    let abs = PathBuf::from(p);
-                                    abs.strip_prefix(root).unwrap_or(&abs).to_path_buf()
-                                } else {
-                                    continue;
-                                };
+                                if let Some(uri_str) = caller_uri.as_str() {
+                                    let caller_path =
+                                        if let Some(p) = uri_str.strip_prefix("file://") {
+                                            let abs = PathBuf::from(p);
+                                            abs.strip_prefix(root).unwrap_or(&abs).to_path_buf()
+                                        } else {
+                                            continue;
+                                        };
 
-                                if caller_path.to_string_lossy().contains(".cargo") {
-                                    continue;
-                                }
-
-                                let key = (caller_path.clone(), caller_name.to_string());
-                                let caller_id = match refs_by_file_name.get(&key) {
-                                    Some(ids) if ids.len() == 1 => Some(ids[0].clone()),
-                                    Some(_) => find_enclosing_symbol(
-                                        &matching_refs,
-                                        &caller_path,
-                                        caller_line,
-                                    ),
-                                    None => find_enclosing_symbol(
-                                        &matching_refs,
-                                        &caller_path,
-                                        caller_line,
-                                    ),
-                                };
-
-                                if let Some(caller) = caller_id {
-                                    if caller.name == node.id.name && caller.file == node.id.file {
+                                    if caller_path.to_string_lossy().contains(".cargo") {
                                         continue;
                                     }
-                                    edges.push(Edge {
-                                        from: caller,
-                                        to: node.id.clone(),
-                                        kind: EdgeKind::Calls,
-                                        source: ExtractionSource::Lsp,
-                                        confidence: Confidence::Confirmed,
-                                    });
+
+                                    let key = (caller_path.clone(), caller_name.to_string());
+                                    let caller_id = match refs_by_file_name.get(&key) {
+                                        Some(ids) if ids.len() == 1 => Some(ids[0].clone()),
+                                        Some(_) => find_enclosing_symbol(
+                                            &matching_refs,
+                                            &caller_path,
+                                            caller_line,
+                                        ),
+                                        None => find_enclosing_symbol(
+                                            &matching_refs,
+                                            &caller_path,
+                                            caller_line,
+                                        ),
+                                    };
+
+                                    if let Some(caller) = caller_id {
+                                        if caller.name == node.id.name
+                                            && caller.file == node.id.file
+                                        {
+                                            continue;
+                                        }
+                                        edges.push(Edge {
+                                            from: caller,
+                                            to: node.id.clone(),
+                                            kind: EdgeKind::Calls,
+                                            source: ExtractionSource::Lsp,
+                                            confidence: Confidence::Confirmed,
+                                        });
+                                    }
                                 }
                             }
+                        }
+                        Err(e) => {
+                            *had_error = true;
+                            error_count.fetch_add(1, Ordering::Relaxed);
+                            observation.record_error(&e);
+                            tracing::debug!("incomingCalls failed for {}: {}", node.id.name, e);
                         }
                     }
 
                     // Process outgoing calls
-                    if let Ok(calls) = outgoing_result {
-                        for call in &calls {
-                            let callee_uri = &call["to"]["uri"];
-                            let callee_name = call["to"]["name"].as_str().unwrap_or("");
-                            let callee_line =
-                                call["to"]["range"]["start"]["line"].as_u64().unwrap_or(0) as usize
-                                    + 1;
+                    match outgoing_result {
+                        Ok(calls) => {
+                            observation.non_empty_responses += usize::from(!calls.is_empty());
+                            for call in &calls {
+                                let callee_uri = &call["to"]["uri"];
+                                let callee_name = call["to"]["name"].as_str().unwrap_or("");
+                                let callee_line =
+                                    call["to"]["range"]["start"]["line"].as_u64().unwrap_or(0)
+                                        as usize
+                                        + 1;
 
-                            if let Some(uri_str) = callee_uri.as_str() {
-                                let callee_path = if let Some(p) = uri_str.strip_prefix("file://") {
-                                    let abs = PathBuf::from(p);
-                                    abs.strip_prefix(root).unwrap_or(&abs).to_path_buf()
-                                } else {
-                                    continue;
-                                };
+                                if let Some(uri_str) = callee_uri.as_str() {
+                                    let callee_path =
+                                        if let Some(p) = uri_str.strip_prefix("file://") {
+                                            let abs = PathBuf::from(p);
+                                            abs.strip_prefix(root).unwrap_or(&abs).to_path_buf()
+                                        } else {
+                                            continue;
+                                        };
 
-                                if callee_path.to_string_lossy().contains(".cargo") {
-                                    let fqn = call["to"]["detail"]
-                                        .as_str()
-                                        .filter(|s| !s.is_empty())
-                                        .unwrap_or(callee_name);
+                                    if callee_path.to_string_lossy().contains(".cargo") {
+                                        let fqn = call["to"]["detail"]
+                                            .as_str()
+                                            .filter(|s| !s.is_empty())
+                                            .unwrap_or(callee_name);
 
-                                    if fqn.is_empty() {
+                                        if fqn.is_empty() {
+                                            continue;
+                                        }
+
+                                        let package =
+                                            fqn.split("::").next().unwrap_or(fqn).to_string();
+
+                                        let virtual_id = NodeId {
+                                            root: "external".to_string(),
+                                            file: PathBuf::new(),
+                                            name: fqn.to_string(),
+                                            kind: NodeKind::Function,
+                                        };
+
+                                        let mut meta = std::collections::BTreeMap::new();
+                                        meta.insert("package".to_string(), package.clone());
+                                        meta.insert("virtual".to_string(), "true".to_string());
+                                        new_nodes.push(Node {
+                                            id: virtual_id.clone(),
+                                            language: language.to_string(),
+                                            line_start: 0,
+                                            line_end: 0,
+                                            signature: fqn.to_string(),
+                                            body: String::new(),
+                                            metadata: meta,
+                                            source: ExtractionSource::Lsp,
+                                        });
+
+                                        edges.push(Edge {
+                                            from: node.id.clone(),
+                                            to: virtual_id,
+                                            kind: EdgeKind::Calls,
+                                            source: ExtractionSource::Lsp,
+                                            confidence: Confidence::Detected,
+                                        });
                                         continue;
                                     }
 
-                                    let package = fqn.split("::").next().unwrap_or(fqn).to_string();
-
-                                    let virtual_id = NodeId {
-                                        root: "external".to_string(),
-                                        file: PathBuf::new(),
-                                        name: fqn.to_string(),
-                                        kind: NodeKind::Function,
+                                    let key = (callee_path.clone(), callee_name.to_string());
+                                    let callee_id = match refs_by_file_name.get(&key) {
+                                        Some(ids) if ids.len() == 1 => Some(ids[0].clone()),
+                                        Some(_) => find_enclosing_symbol(
+                                            &matching_refs,
+                                            &callee_path,
+                                            callee_line,
+                                        ),
+                                        None => find_enclosing_symbol(
+                                            &matching_refs,
+                                            &callee_path,
+                                            callee_line,
+                                        ),
                                     };
 
-                                    let mut meta = std::collections::BTreeMap::new();
-                                    meta.insert("package".to_string(), package.clone());
-                                    meta.insert("virtual".to_string(), "true".to_string());
-                                    new_nodes.push(Node {
-                                        id: virtual_id.clone(),
-                                        language: language.to_string(),
-                                        line_start: 0,
-                                        line_end: 0,
-                                        signature: fqn.to_string(),
-                                        body: String::new(),
-                                        metadata: meta,
-                                        source: ExtractionSource::Lsp,
-                                    });
-
-                                    edges.push(Edge {
-                                        from: node.id.clone(),
-                                        to: virtual_id,
-                                        kind: EdgeKind::Calls,
-                                        source: ExtractionSource::Lsp,
-                                        confidence: Confidence::Detected,
-                                    });
-                                    continue;
-                                }
-
-                                let key = (callee_path.clone(), callee_name.to_string());
-                                let callee_id = match refs_by_file_name.get(&key) {
-                                    Some(ids) if ids.len() == 1 => Some(ids[0].clone()),
-                                    Some(_) => find_enclosing_symbol(
-                                        &matching_refs,
-                                        &callee_path,
-                                        callee_line,
-                                    ),
-                                    None => find_enclosing_symbol(
-                                        &matching_refs,
-                                        &callee_path,
-                                        callee_line,
-                                    ),
-                                };
-
-                                if let Some(callee) = callee_id {
-                                    if callee.name == node.id.name && callee.file == node.id.file {
-                                        continue;
+                                    if let Some(callee) = callee_id {
+                                        if callee.name == node.id.name
+                                            && callee.file == node.id.file
+                                        {
+                                            continue;
+                                        }
+                                        edges.push(Edge {
+                                            from: node.id.clone(),
+                                            to: callee,
+                                            kind: EdgeKind::Calls,
+                                            source: ExtractionSource::Lsp,
+                                            confidence: Confidence::Confirmed,
+                                        });
                                     }
-                                    edges.push(Edge {
-                                        from: node.id.clone(),
-                                        to: callee,
-                                        kind: EdgeKind::Calls,
-                                        source: ExtractionSource::Lsp,
-                                        confidence: Confidence::Confirmed,
-                                    });
                                 }
                             }
+                        }
+                        Err(e) => {
+                            *had_error = true;
+                            error_count.fetch_add(1, Ordering::Relaxed);
+                            observation.record_error(&e);
+                            tracing::debug!("outgoingCalls failed for {}: {}", node.id.name, e);
                         }
                     }
                 }
@@ -1315,10 +1427,12 @@ impl LspEnricher {
                 Err(e) => {
                     *had_error = true;
                     error_count.fetch_add(1, Ordering::Relaxed);
+                    observation.record_error(&e);
                     tracing::debug!("prepareCallHierarchy failed for {}: {}", node.id.name, e);
                 }
             }
         }
+        observation
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1331,9 +1445,14 @@ impl LspEnricher {
         matching_owned: &Arc<Vec<Node>>,
         root: &Path,
         edges: &mut Vec<Edge>,
-    ) {
+    ) -> QueryObservation {
+        let mut observation = QueryObservation {
+            scheduled_requests: 1,
+            ..Default::default()
+        };
         match Self::find_implementations_p(transport, file_uri, line, col).await {
             Ok(locations) => {
+                observation.non_empty_responses += usize::from(!locations.is_empty());
                 let matching_refs: Vec<&Node> = matching_owned.iter().collect();
                 for loc in locations {
                     let impl_path = uri_to_relative_path(&loc.uri, root);
@@ -1363,9 +1482,11 @@ impl LspEnricher {
                 }
             }
             Err(e) => {
+                observation.record_error(&e);
                 tracing::debug!("Implementation lookup failed for {}: {}", node.id.name, e);
             }
         }
+        observation
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1380,9 +1501,14 @@ impl LspEnricher {
         edges: &mut Vec<Edge>,
         had_error: &mut bool,
         error_count: &AtomicI64,
-    ) {
+    ) -> QueryObservation {
+        let mut observation = QueryObservation {
+            scheduled_requests: 1,
+            ..Default::default()
+        };
         match Self::find_references_p(transport, file_uri, line, col).await {
             Ok(locations) => {
+                observation.non_empty_responses += usize::from(!locations.is_empty());
                 let matching_refs: Vec<&Node> = matching_owned.iter().collect();
                 let mut refs_by_file: HashMap<&Path, Vec<&Node>> = HashMap::new();
                 for n in &matching_refs {
@@ -1427,9 +1553,11 @@ impl LspEnricher {
             Err(e) => {
                 *had_error = true;
                 error_count.fetch_add(1, Ordering::Relaxed);
+                observation.record_error(&e);
                 tracing::debug!("textDocument/references failed for {}: {}", node.id.name, e);
             }
         }
+        observation
     }
 
     async fn enrich_document_links(
@@ -1438,57 +1566,70 @@ impl LspEnricher {
         node: &Node,
         root: &Path,
         edges: &mut Vec<Edge>,
-    ) {
-        if let Ok(links) = Self::document_links_p(transport, file_uri).await {
-            for link in &links {
-                if let Some(target) = link.get("target").and_then(|t| t.as_str())
-                    && let Some(target_path) = target.strip_prefix("file://")
-                {
-                    let rel_target = PathBuf::from(target_path);
-                    let rel_target = rel_target
-                        .strip_prefix(root)
-                        .unwrap_or(&rel_target)
-                        .to_path_buf();
+    ) -> QueryObservation {
+        let mut observation = QueryObservation {
+            scheduled_requests: 1,
+            ..Default::default()
+        };
+        match Self::document_links_p(transport, file_uri).await {
+            Ok(links) => {
+                observation.non_empty_responses += usize::from(!links.is_empty());
+                for link in &links {
+                    if let Some(target) = link.get("target").and_then(|t| t.as_str())
+                        && let Some(target_path) = target.strip_prefix("file://")
+                    {
+                        let rel_target = PathBuf::from(target_path);
+                        let rel_target = rel_target
+                            .strip_prefix(root)
+                            .unwrap_or(&rel_target)
+                            .to_path_buf();
 
-                    if rel_target.to_string_lossy().starts_with("http") {
-                        continue;
+                        if rel_target.to_string_lossy().starts_with("http") {
+                            continue;
+                        }
+
+                        let target_id = NodeId {
+                            root: node.id.root.clone(),
+                            file: rel_target.clone(),
+                            name: rel_target
+                                .file_name()
+                                .and_then(|n| n.to_str())
+                                .unwrap_or("unknown")
+                                .to_string(),
+                            kind: NodeKind::Module,
+                        };
+
+                        edges.push(Edge {
+                            from: node.id.clone(),
+                            to: target_id,
+                            kind: EdgeKind::DependsOn,
+                            source: ExtractionSource::Lsp,
+                            confidence: Confidence::Confirmed,
+                        });
                     }
-
-                    let target_id = NodeId {
-                        root: node.id.root.clone(),
-                        file: rel_target.clone(),
-                        name: rel_target
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .unwrap_or("unknown")
-                            .to_string(),
-                        kind: NodeKind::Module,
-                    };
-
-                    edges.push(Edge {
-                        from: node.id.clone(),
-                        to: target_id,
-                        kind: EdgeKind::DependsOn,
-                        source: ExtractionSource::Lsp,
-                        confidence: Confidence::Confirmed,
-                    });
                 }
             }
+            Err(e) => observation.record_error(&e),
         }
+        observation
     }
 
     // ------------------------------------------------------------------
     // Pass 2: type hierarchy (sequential -- strike counting needs order)
     // ------------------------------------------------------------------
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn run_pass2_type_hierarchy(
         &self,
         transport: &Arc<PipelinedTransport>,
         root: &Path,
         matching_nodes: &[&Node],
-        mut has_type_hierarchy: bool,
+        capabilities: LspServerCapabilities,
+        budget: &mut LspQueryBudget,
+        telemetry: &LspQueryTelemetry,
         mut type_hierarchy_strikes: u32,
         result: &mut EnrichmentResult,
     ) -> (bool, u32) {
+        let mut has_type_hierarchy = capabilities.type_hierarchy;
         if !has_type_hierarchy {
             return (has_type_hierarchy, type_hierarchy_strikes);
         }
@@ -1499,6 +1640,14 @@ impl LspEnricher {
                 matches!(
                     n.id.kind,
                     NodeKind::Trait | NodeKind::Struct | NodeKind::Enum
+                )
+            })
+            .filter(|node| {
+                self.query_profile.admits(
+                    node,
+                    LspQueryOperation::TypeHierarchy,
+                    capabilities,
+                    budget,
                 )
             })
             .copied()
@@ -1516,6 +1665,8 @@ impl LspEnricher {
         let mut pass2_last_count = 0u64;
 
         for node in &type_nodes {
+            let query_started = Instant::now();
+            let edges_before_query = result.added_edges.len();
             let abs_path = root.join(&node.id.file);
             let file_uri = match path_to_uri(&abs_path) {
                 Ok(u) => u,
@@ -1523,7 +1674,7 @@ impl LspEnricher {
             };
             let (line, col) = Self::node_lsp_position(node);
 
-            let ok = Self::enrich_type_hierarchy_p(
+            let (ok, observation) = Self::enrich_type_hierarchy_p(
                 transport,
                 &file_uri,
                 line,
@@ -1534,6 +1685,20 @@ impl LspEnricher {
                 result,
             )
             .await;
+
+            if let Some(declaration) = LspDeclarationClass::from_kind(&node.id.kind) {
+                let emitted_edges = result.added_edges.len() - edges_before_query;
+                telemetry.record(
+                    LspQueryOperation::TypeHierarchy,
+                    declaration,
+                    1,
+                    observation.non_empty_responses,
+                    emitted_edges,
+                    query_started.elapsed(),
+                    observation.errors,
+                    observation.timeouts,
+                );
+            }
 
             Self::update_type_hierarchy_strikes(
                 ok,
@@ -1977,7 +2142,7 @@ mod tests {
                     metadata: BTreeMap::new(),
                     source: ExtractionSource::Lsp,
                 },
-                requested_operations: vec!["requesting_references"],
+                requested_operations: vec![LspQueryOperation::References],
                 attempt_count: 1,
             };
             diagnostics.set_phase(&item, "requesting_references").await;
@@ -2041,7 +2206,7 @@ mod tests {
             .map(|id| LspPass1WorkItem {
                 id,
                 node: make_node(id),
-                requested_operations: vec!["textDocument/references"],
+                requested_operations: vec![LspQueryOperation::References],
                 attempt_count: 1,
             })
             .collect::<Vec<_>>();
@@ -2156,7 +2321,7 @@ mod tests {
         let work_items = vec![LspPass1WorkItem {
             id: 0,
             node,
-            requested_operations: vec!["textDocument/references"],
+            requested_operations: vec![LspQueryOperation::References],
             attempt_count: 3,
         }];
 

--- a/src/extract/lsp/policy.rs
+++ b/src/extract/lsp/policy.rs
@@ -277,7 +277,13 @@ struct LspQueryMetricKey {
 pub(crate) struct LspQueryTelemetry {
     language: String,
     server: String,
-    metrics: Mutex<BTreeMap<LspQueryMetricKey, LspQueryMetric>>,
+    state: Mutex<LspQueryTelemetryState>,
+}
+
+#[derive(Debug, Default)]
+struct LspQueryTelemetryState {
+    metrics: BTreeMap<LspQueryMetricKey, LspQueryMetric>,
+    pending_work: BTreeMap<LspQueryMetricKey, usize>,
 }
 
 impl LspQueryTelemetry {
@@ -285,8 +291,24 @@ impl LspQueryTelemetry {
         Self {
             language: profile.language().to_string(),
             server: profile.server().to_string(),
-            metrics: Mutex::new(BTreeMap::new()),
+            state: Mutex::new(LspQueryTelemetryState::default()),
         }
+    }
+
+    pub(crate) fn register_work_item(
+        &self,
+        operation: LspQueryOperation,
+        declaration: LspDeclarationClass,
+    ) {
+        let key = LspQueryMetricKey {
+            operation,
+            declaration,
+        };
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        *state.pending_work.entry(key).or_default() += 1;
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -305,11 +327,14 @@ impl LspQueryTelemetry {
             operation,
             declaration,
         };
-        let mut metrics = self
-            .metrics
+        let mut state = self
+            .state
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
-        let metric = metrics.entry(key).or_insert_with(|| LspQueryMetric {
+        if let Some(pending) = state.pending_work.get_mut(&key) {
+            *pending = pending.saturating_sub(1);
+        }
+        let metric = state.metrics.entry(key).or_insert_with(|| LspQueryMetric {
             language: self.language.clone(),
             server: self.server.clone(),
             operation: operation.as_str().to_string(),
@@ -331,10 +356,47 @@ impl LspQueryTelemetry {
         metric.timeouts += timeouts;
     }
 
+    /// Attribute work items cancelled by the outer job deadline. Completed
+    /// items have already decremented their pending count in `record`, so this
+    /// drains only queued or in-flight operations and cannot double count them.
+    pub(crate) fn record_job_timeout(&self, latency: Duration) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let pending = std::mem::take(&mut state.pending_work);
+        for (key, count) in pending {
+            if count == 0 {
+                continue;
+            }
+            let metric = state.metrics.entry(key.clone()).or_insert_with(|| LspQueryMetric {
+                language: self.language.clone(),
+                server: self.server.clone(),
+                operation: key.operation.as_str().to_string(),
+                declaration_class: key.declaration.as_str().to_string(),
+                scheduled_requests: 0,
+                non_empty_responses: 0,
+                emitted_edges: 0,
+                latency_ms: 0,
+                timeouts: 0,
+                errors: 0,
+            });
+            metric.latency_ms = metric.latency_ms.saturating_add(
+                latency
+                    .as_millis()
+                    .saturating_mul(count as u128)
+                    .min(u64::MAX as u128) as u64,
+            );
+            metric.timeouts = metric.timeouts.saturating_add(count);
+            metric.errors = metric.errors.saturating_add(count);
+        }
+    }
+
     pub(crate) fn snapshot(&self) -> Vec<LspQueryMetric> {
-        self.metrics
+        self.state
             .lock()
             .unwrap_or_else(|poison| poison.into_inner())
+            .metrics
             .values()
             .cloned()
             .collect()
@@ -514,5 +576,38 @@ mod tests {
                 errors: 1,
             }]
         );
+    }
+
+    #[test]
+    fn job_timeout_attributes_only_unfinished_work_items() {
+        let profile = LspQueryProfile::new("rust", "rust-analyzer");
+        let telemetry = LspQueryTelemetry::new(&profile);
+        telemetry.register_work_item(
+            LspQueryOperation::CallHierarchy,
+            LspDeclarationClass::Function,
+        );
+        telemetry.register_work_item(
+            LspQueryOperation::CallHierarchy,
+            LspDeclarationClass::Function,
+        );
+        telemetry.record(
+            LspQueryOperation::CallHierarchy,
+            LspDeclarationClass::Function,
+            3,
+            1,
+            2,
+            Duration::from_millis(10),
+            0,
+            0,
+        );
+
+        telemetry.record_job_timeout(Duration::from_millis(50));
+
+        let metrics = telemetry.snapshot();
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].scheduled_requests, 3);
+        assert_eq!(metrics[0].timeouts, 1);
+        assert_eq!(metrics[0].errors, 1);
+        assert_eq!(metrics[0].latency_ms, 60);
     }
 }

--- a/src/extract/lsp/policy.rs
+++ b/src/extract/lsp/policy.rs
@@ -284,6 +284,7 @@ pub(crate) struct LspQueryTelemetry {
 struct LspQueryTelemetryState {
     metrics: BTreeMap<LspQueryMetricKey, LspQueryMetric>,
     pending_work: BTreeMap<usize, LspQueryMetricKey>,
+    deadline_closed: bool,
 }
 
 impl LspQueryTelemetry {
@@ -300,7 +301,7 @@ impl LspQueryTelemetry {
         work_item_id: usize,
         operation: LspQueryOperation,
         declaration: LspDeclarationClass,
-    ) {
+    ) -> bool {
         let key = LspQueryMetricKey {
             operation,
             declaration,
@@ -309,7 +310,11 @@ impl LspQueryTelemetry {
             .state
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
+        if state.deadline_closed {
+            return false;
+        }
         state.pending_work.insert(work_item_id, key);
+        true
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -420,6 +425,7 @@ impl LspQueryTelemetry {
             .state
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
+        state.deadline_closed = true;
         let pending = std::mem::take(&mut state.pending_work);
         for (_, key) in pending {
             self.record_locked(&mut state, key, 0, 0, 0, latency, 1, 1);
@@ -616,16 +622,16 @@ mod tests {
     fn job_timeout_attributes_only_unfinished_work_items() {
         let profile = LspQueryProfile::new("rust", "rust-analyzer");
         let telemetry = LspQueryTelemetry::new(&profile);
-        telemetry.register_work_item(
+        assert!(telemetry.register_work_item(
             1,
             LspQueryOperation::CallHierarchy,
             LspDeclarationClass::Function,
-        );
-        telemetry.register_work_item(
+        ));
+        assert!(telemetry.register_work_item(
             2,
             LspQueryOperation::CallHierarchy,
             LspDeclarationClass::Function,
-        );
+        ));
         assert!(telemetry.record_work_item(
             1,
             3,
@@ -637,6 +643,11 @@ mod tests {
         ));
 
         telemetry.record_job_timeout(Duration::from_millis(50));
+        assert!(!telemetry.register_work_item(
+            3,
+            LspQueryOperation::References,
+            LspDeclarationClass::Struct,
+        ));
         assert!(!telemetry.record_work_item(
             2,
             2,

--- a/src/extract/lsp/policy.rs
+++ b/src/extract/lsp/policy.rs
@@ -1,0 +1,518 @@
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use crate::graph::{Node, NodeKind};
+
+/// Semantic LSP operation used for both admission and yield accounting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LspQueryOperation {
+    CallHierarchy,
+    References,
+    Implementations,
+    TypeHierarchy,
+    DocumentLinks,
+}
+
+impl LspQueryOperation {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CallHierarchy => "call_hierarchy",
+            Self::References => "references",
+            Self::Implementations => "implementations",
+            Self::TypeHierarchy => "type_hierarchy",
+            Self::DocumentLinks => "document_links",
+        }
+    }
+
+    pub(crate) const fn phase(self) -> &'static str {
+        match self {
+            Self::CallHierarchy => "requesting_call_hierarchy",
+            Self::References => "requesting_references",
+            Self::Implementations => "requesting_implementations",
+            Self::TypeHierarchy => "requesting_type_hierarchy",
+            Self::DocumentLinks => "requesting_document_links",
+        }
+    }
+}
+
+impl std::fmt::Display for LspQueryOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Stable declaration bucket used in admission rules and telemetry dimensions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LspDeclarationClass {
+    Function,
+    Trait,
+    Struct,
+    Enum,
+    TypeAlias,
+    Const,
+    Other,
+}
+
+impl LspDeclarationClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Function => "function",
+            Self::Trait => "trait",
+            Self::Struct => "struct",
+            Self::Enum => "enum",
+            Self::TypeAlias => "type_alias",
+            Self::Const => "const",
+            Self::Other => "other",
+        }
+    }
+
+    pub(crate) fn from_kind(kind: &NodeKind) -> Option<Self> {
+        match kind {
+            NodeKind::Function => Some(Self::Function),
+            NodeKind::Trait => Some(Self::Trait),
+            NodeKind::Struct => Some(Self::Struct),
+            NodeKind::Enum => Some(Self::Enum),
+            NodeKind::TypeAlias => Some(Self::TypeAlias),
+            NodeKind::Const => Some(Self::Const),
+            NodeKind::Other(_) => Some(Self::Other),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for LspDeclarationClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Negotiated capabilities that participate in admission.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct LspServerCapabilities {
+    pub references: bool,
+    pub call_hierarchy: bool,
+    pub implementations: bool,
+    pub type_hierarchy: bool,
+    pub document_links: bool,
+}
+
+impl LspServerCapabilities {
+    fn supports(self, operation: LspQueryOperation) -> bool {
+        match operation {
+            LspQueryOperation::CallHierarchy => self.call_hierarchy,
+            LspQueryOperation::References => self.references,
+            LspQueryOperation::Implementations => self.implementations,
+            LspQueryOperation::TypeHierarchy => self.type_hierarchy,
+            LspQueryOperation::DocumentLinks => self.document_links,
+        }
+    }
+}
+
+/// Per-run request budget. The profile establishes the seam; #769 can supply
+/// scope-specific finite limits without changing scheduling again.
+#[derive(Debug, Clone)]
+pub(crate) struct LspQueryBudget {
+    remaining: BTreeMap<LspQueryOperation, usize>,
+}
+
+impl LspQueryBudget {
+    fn from_limits(limits: &BTreeMap<LspQueryOperation, usize>) -> Self {
+        Self {
+            remaining: limits.clone(),
+        }
+    }
+
+    fn reserve(&mut self, operation: LspQueryOperation) -> bool {
+        let remaining = self.remaining.entry(operation).or_insert(usize::MAX);
+        if *remaining == 0 {
+            return false;
+        }
+        *remaining = remaining.saturating_sub(1);
+        true
+    }
+}
+
+/// Shared language/server query profile used by construction and every symbol
+/// scheduling pass.
+#[derive(Debug, Clone)]
+pub(crate) struct LspQueryProfile {
+    language: String,
+    server: String,
+    allowed_kinds: Option<Vec<NodeKind>>,
+    allow_declared_const_references: bool,
+    operation_limits: BTreeMap<LspQueryOperation, usize>,
+}
+
+impl LspQueryProfile {
+    pub(crate) fn new(language: &str, server: &str) -> Self {
+        Self {
+            language: language.to_string(),
+            server: server.to_string(),
+            allowed_kinds: None,
+            allow_declared_const_references: false,
+            operation_limits: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn with_allowed_kinds(mut self, kinds: &'static [NodeKind]) -> Self {
+        self.allowed_kinds = Some(kinds.to_vec());
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_operation_limit(
+        mut self,
+        operation: LspQueryOperation,
+        limit: usize,
+    ) -> Self {
+        self.operation_limits.insert(operation, limit);
+        self
+    }
+
+    pub(crate) fn budget(&self) -> LspQueryBudget {
+        LspQueryBudget::from_limits(&self.operation_limits)
+    }
+
+    pub(crate) fn language(&self) -> &str {
+        &self.language
+    }
+
+    pub(crate) fn server(&self) -> &str {
+        &self.server
+    }
+
+    #[cfg(test)]
+    pub(crate) fn allows_declared_const_references(&self) -> bool {
+        self.allow_declared_const_references
+    }
+
+    #[cfg(test)]
+    pub(crate) fn allowed_kinds(&self) -> Option<&[NodeKind]> {
+        self.allowed_kinds.as_deref()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_declared_const_references(mut self, allow: bool) -> Self {
+        self.allow_declared_const_references = allow;
+        self
+    }
+
+    pub(crate) fn admits(
+        &self,
+        node: &Node,
+        operation: LspQueryOperation,
+        capabilities: LspServerCapabilities,
+        budget: &mut LspQueryBudget,
+    ) -> bool {
+        if !self.accepts_declaration(node) || !capabilities.supports(operation) {
+            return false;
+        }
+
+        if self
+            .allowed_kinds
+            .as_deref()
+            .is_some_and(|kinds| !kinds.contains(&node.id.kind))
+        {
+            return false;
+        }
+
+        let Some(declaration) = LspDeclarationClass::from_kind(&node.id.kind) else {
+            return false;
+        };
+        let operation_matches = match operation {
+            LspQueryOperation::CallHierarchy => declaration == LspDeclarationClass::Function,
+            LspQueryOperation::References => {
+                matches!(
+                    declaration,
+                    LspDeclarationClass::Function
+                        | LspDeclarationClass::Struct
+                        | LspDeclarationClass::Enum
+                        | LspDeclarationClass::TypeAlias
+                        | LspDeclarationClass::Const
+                ) && (declaration != LspDeclarationClass::Const
+                    || self.allow_declared_const_references)
+            }
+            LspQueryOperation::Implementations => declaration == LspDeclarationClass::Trait,
+            LspQueryOperation::TypeHierarchy => matches!(
+                declaration,
+                LspDeclarationClass::Trait
+                    | LspDeclarationClass::Struct
+                    | LspDeclarationClass::Enum
+            ),
+            LspQueryOperation::DocumentLinks => declaration == LspDeclarationClass::Other,
+        };
+
+        operation_matches && budget.reserve(operation)
+    }
+
+    pub(crate) fn accepts_declaration(&self, node: &Node) -> bool {
+        node.language == self.language
+            && node.metadata.get("synthetic").map(String::as_str) != Some("true")
+            && !matches!(&node.id.kind, NodeKind::Other(kind) if kind == "crate" || kind == "diagnostic")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LspQueryMetric {
+    pub language: String,
+    pub server: String,
+    pub operation: String,
+    pub declaration_class: String,
+    pub scheduled_requests: usize,
+    pub non_empty_responses: usize,
+    pub emitted_edges: usize,
+    pub latency_ms: u64,
+    pub timeouts: usize,
+    pub errors: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct LspQueryMetricKey {
+    operation: LspQueryOperation,
+    declaration: LspDeclarationClass,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct LspQueryTelemetry {
+    language: String,
+    server: String,
+    metrics: Mutex<BTreeMap<LspQueryMetricKey, LspQueryMetric>>,
+}
+
+impl LspQueryTelemetry {
+    pub(crate) fn new(profile: &LspQueryProfile) -> Self {
+        Self {
+            language: profile.language().to_string(),
+            server: profile.server().to_string(),
+            metrics: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn record(
+        &self,
+        operation: LspQueryOperation,
+        declaration: LspDeclarationClass,
+        scheduled_requests: usize,
+        non_empty_responses: usize,
+        emitted_edges: usize,
+        latency: Duration,
+        errors: usize,
+        timeouts: usize,
+    ) {
+        let key = LspQueryMetricKey {
+            operation,
+            declaration,
+        };
+        let mut metrics = self
+            .metrics
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let metric = metrics.entry(key).or_insert_with(|| LspQueryMetric {
+            language: self.language.clone(),
+            server: self.server.clone(),
+            operation: operation.as_str().to_string(),
+            declaration_class: declaration.as_str().to_string(),
+            scheduled_requests: 0,
+            non_empty_responses: 0,
+            emitted_edges: 0,
+            latency_ms: 0,
+            timeouts: 0,
+            errors: 0,
+        });
+        metric.scheduled_requests += scheduled_requests;
+        metric.non_empty_responses += non_empty_responses;
+        metric.emitted_edges += emitted_edges;
+        metric.latency_ms = metric
+            .latency_ms
+            .saturating_add(latency.as_millis().min(u64::MAX as u128) as u64);
+        metric.errors += errors;
+        metric.timeouts += timeouts;
+    }
+
+    pub(crate) fn snapshot(&self) -> Vec<LspQueryMetric> {
+        self.metrics
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .values()
+            .cloned()
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use crate::graph::{ExtractionSource, NodeId};
+
+    use super::*;
+
+    fn node(kind: NodeKind) -> Node {
+        Node {
+            id: NodeId {
+                root: "root".to_string(),
+                file: PathBuf::from("src/lib.rs"),
+                name: "target".to_string(),
+                kind,
+            },
+            language: "rust".to_string(),
+            line_start: 1,
+            line_end: 1,
+            signature: String::new(),
+            body: String::new(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::TreeSitter,
+        }
+    }
+
+    #[test]
+    fn operation_admission_is_capability_kind_and_budget_aware() {
+        let profile = LspQueryProfile::new("rust", "rust-analyzer")
+            .with_operation_limit(LspQueryOperation::CallHierarchy, 1);
+        let capabilities = LspServerCapabilities {
+            call_hierarchy: true,
+            ..Default::default()
+        };
+        let mut budget = profile.budget();
+
+        assert!(profile.admits(
+            &node(NodeKind::Function),
+            LspQueryOperation::CallHierarchy,
+            capabilities,
+            &mut budget
+        ));
+        assert!(!profile.admits(
+            &node(NodeKind::Function),
+            LspQueryOperation::CallHierarchy,
+            capabilities,
+            &mut budget
+        ));
+        assert!(!profile.admits(
+            &node(NodeKind::Struct),
+            LspQueryOperation::CallHierarchy,
+            capabilities,
+            &mut profile.budget()
+        ));
+    }
+
+    #[test]
+    fn server_profile_applies_to_references_implementations_and_type_hierarchy() {
+        static FUNCTION_AND_TRAIT: &[NodeKind] = &[NodeKind::Function, NodeKind::Trait];
+        let profile = LspQueryProfile::new("python", "pyright-langserver")
+            .with_allowed_kinds(FUNCTION_AND_TRAIT);
+        let capabilities = LspServerCapabilities {
+            references: true,
+            implementations: true,
+            type_hierarchy: true,
+            ..Default::default()
+        };
+        let mut function = node(NodeKind::Function);
+        function.language = "python".to_string();
+        let mut trait_node = node(NodeKind::Trait);
+        trait_node.language = "python".to_string();
+        let mut struct_node = node(NodeKind::Struct);
+        struct_node.language = "python".to_string();
+
+        assert!(profile.admits(
+            &function,
+            LspQueryOperation::References,
+            capabilities,
+            &mut profile.budget()
+        ));
+        assert!(profile.admits(
+            &trait_node,
+            LspQueryOperation::Implementations,
+            capabilities,
+            &mut profile.budget()
+        ));
+        assert!(!profile.admits(
+            &struct_node,
+            LspQueryOperation::References,
+            capabilities,
+            &mut profile.budget()
+        ));
+        assert!(!profile.admits(
+            &struct_node,
+            LspQueryOperation::TypeHierarchy,
+            capabilities,
+            &mut profile.budget()
+        ));
+    }
+
+    #[test]
+    fn synthetic_and_declared_const_references_are_default_denied() {
+        let profile = LspQueryProfile::new("rust", "rust-analyzer");
+        let capabilities = LspServerCapabilities {
+            references: true,
+            ..Default::default()
+        };
+        let mut synthetic = node(NodeKind::Function);
+        synthetic
+            .metadata
+            .insert("synthetic".to_string(), "true".to_string());
+
+        assert!(!profile.admits(
+            &synthetic,
+            LspQueryOperation::References,
+            capabilities,
+            &mut profile.budget()
+        ));
+        assert!(!profile.admits(
+            &node(NodeKind::Const),
+            LspQueryOperation::References,
+            capabilities,
+            &mut profile.budget()
+        ));
+        assert!(profile.clone().with_declared_const_references(true).admits(
+            &node(NodeKind::Const),
+            LspQueryOperation::References,
+            capabilities,
+            &mut profile.budget()
+        ));
+    }
+
+    #[test]
+    fn telemetry_aggregates_by_operation_and_declaration() {
+        let profile = LspQueryProfile::new("rust", "rust-analyzer");
+        let telemetry = LspQueryTelemetry::new(&profile);
+        telemetry.record(
+            LspQueryOperation::References,
+            LspDeclarationClass::Struct,
+            1,
+            1,
+            2,
+            Duration::from_millis(7),
+            0,
+            0,
+        );
+        telemetry.record(
+            LspQueryOperation::References,
+            LspDeclarationClass::Struct,
+            1,
+            0,
+            0,
+            Duration::from_millis(3),
+            1,
+            1,
+        );
+
+        assert_eq!(
+            telemetry.snapshot(),
+            vec![LspQueryMetric {
+                language: "rust".to_string(),
+                server: "rust-analyzer".to_string(),
+                operation: "references".to_string(),
+                declaration_class: "struct".to_string(),
+                scheduled_requests: 2,
+                non_empty_responses: 1,
+                emitted_edges: 2,
+                latency_ms: 10,
+                timeouts: 1,
+                errors: 1,
+            }]
+        );
+    }
+}

--- a/src/extract/lsp/policy.rs
+++ b/src/extract/lsp/policy.rs
@@ -283,7 +283,7 @@ pub(crate) struct LspQueryTelemetry {
 #[derive(Debug, Default)]
 struct LspQueryTelemetryState {
     metrics: BTreeMap<LspQueryMetricKey, LspQueryMetric>,
-    pending_work: BTreeMap<LspQueryMetricKey, usize>,
+    pending_work: BTreeMap<usize, LspQueryMetricKey>,
 }
 
 impl LspQueryTelemetry {
@@ -297,6 +297,7 @@ impl LspQueryTelemetry {
 
     pub(crate) fn register_work_item(
         &self,
+        work_item_id: usize,
         operation: LspQueryOperation,
         declaration: LspDeclarationClass,
     ) {
@@ -308,7 +309,7 @@ impl LspQueryTelemetry {
             .state
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
-        *state.pending_work.entry(key).or_default() += 1;
+        state.pending_work.insert(work_item_id, key);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -323,17 +324,72 @@ impl LspQueryTelemetry {
         errors: usize,
         timeouts: usize,
     ) {
-        let key = LspQueryMetricKey {
-            operation,
-            declaration,
-        };
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
-        if let Some(pending) = state.pending_work.get_mut(&key) {
-            *pending = pending.saturating_sub(1);
-        }
+        self.record_locked(
+            &mut state,
+            LspQueryMetricKey {
+                operation,
+                declaration,
+            },
+            scheduled_requests,
+            non_empty_responses,
+            emitted_edges,
+            latency,
+            errors,
+            timeouts,
+        );
+    }
+
+    /// Complete a registered Pass 1 item exactly once. If the outer deadline
+    /// already claimed the item, a late worker completion is ignored.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn record_work_item(
+        &self,
+        work_item_id: usize,
+        scheduled_requests: usize,
+        non_empty_responses: usize,
+        emitted_edges: usize,
+        latency: Duration,
+        errors: usize,
+        timeouts: usize,
+    ) -> bool {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let Some(key) = state.pending_work.remove(&work_item_id) else {
+            return false;
+        };
+        self.record_locked(
+            &mut state,
+            key,
+            scheduled_requests,
+            non_empty_responses,
+            emitted_edges,
+            latency,
+            errors,
+            timeouts,
+        );
+        true
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn record_locked(
+        &self,
+        state: &mut LspQueryTelemetryState,
+        key: LspQueryMetricKey,
+        scheduled_requests: usize,
+        non_empty_responses: usize,
+        emitted_edges: usize,
+        latency: Duration,
+        errors: usize,
+        timeouts: usize,
+    ) {
+        let operation = key.operation;
+        let declaration = key.declaration;
         let metric = state.metrics.entry(key).or_insert_with(|| LspQueryMetric {
             language: self.language.clone(),
             server: self.server.clone(),
@@ -357,38 +413,16 @@ impl LspQueryTelemetry {
     }
 
     /// Attribute work items cancelled by the outer job deadline. Completed
-    /// items have already decremented their pending count in `record`, so this
-    /// drains only queued or in-flight operations and cannot double count them.
+    /// items have already atomically removed their IDs, so this drains only
+    /// in-flight operations and owns their terminal outcome.
     pub(crate) fn record_job_timeout(&self, latency: Duration) {
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
         let pending = std::mem::take(&mut state.pending_work);
-        for (key, count) in pending {
-            if count == 0 {
-                continue;
-            }
-            let metric = state.metrics.entry(key.clone()).or_insert_with(|| LspQueryMetric {
-                language: self.language.clone(),
-                server: self.server.clone(),
-                operation: key.operation.as_str().to_string(),
-                declaration_class: key.declaration.as_str().to_string(),
-                scheduled_requests: 0,
-                non_empty_responses: 0,
-                emitted_edges: 0,
-                latency_ms: 0,
-                timeouts: 0,
-                errors: 0,
-            });
-            metric.latency_ms = metric.latency_ms.saturating_add(
-                latency
-                    .as_millis()
-                    .saturating_mul(count as u128)
-                    .min(u64::MAX as u128) as u64,
-            );
-            metric.timeouts = metric.timeouts.saturating_add(count);
-            metric.errors = metric.errors.saturating_add(count);
+        for (_, key) in pending {
+            self.record_locked(&mut state, key, 0, 0, 0, latency, 1, 1);
         }
     }
 
@@ -583,25 +617,35 @@ mod tests {
         let profile = LspQueryProfile::new("rust", "rust-analyzer");
         let telemetry = LspQueryTelemetry::new(&profile);
         telemetry.register_work_item(
+            1,
             LspQueryOperation::CallHierarchy,
             LspDeclarationClass::Function,
         );
         telemetry.register_work_item(
+            2,
             LspQueryOperation::CallHierarchy,
             LspDeclarationClass::Function,
         );
-        telemetry.record(
-            LspQueryOperation::CallHierarchy,
-            LspDeclarationClass::Function,
+        assert!(telemetry.record_work_item(
+            1,
             3,
             1,
             2,
             Duration::from_millis(10),
             0,
             0,
-        );
+        ));
 
         telemetry.record_job_timeout(Duration::from_millis(50));
+        assert!(!telemetry.record_work_item(
+            2,
+            2,
+            1,
+            1,
+            Duration::from_millis(60),
+            0,
+            0,
+        ));
 
         let metrics = telemetry.snapshot();
         assert_eq!(metrics.len(), 1);

--- a/src/extract/lsp/policy.rs
+++ b/src/extract/lsp/policy.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -139,7 +139,7 @@ impl LspQueryBudget {
 pub(crate) struct LspQueryProfile {
     language: String,
     server: String,
-    allowed_kinds: Option<Vec<NodeKind>>,
+    allowed_kinds: Option<HashSet<NodeKind>>,
     allow_declared_const_references: bool,
     operation_limits: BTreeMap<LspQueryOperation, usize>,
 }
@@ -156,7 +156,7 @@ impl LspQueryProfile {
     }
 
     pub(crate) fn with_allowed_kinds(mut self, kinds: &'static [NodeKind]) -> Self {
-        self.allowed_kinds = Some(kinds.to_vec());
+        self.allowed_kinds = Some(kinds.iter().cloned().collect());
         self
     }
 
@@ -188,8 +188,8 @@ impl LspQueryProfile {
     }
 
     #[cfg(test)]
-    pub(crate) fn allowed_kinds(&self) -> Option<&[NodeKind]> {
-        self.allowed_kinds.as_deref()
+    pub(crate) fn allowed_kinds(&self) -> Option<&HashSet<NodeKind>> {
+        self.allowed_kinds.as_ref()
     }
 
     #[cfg(test)]
@@ -211,7 +211,7 @@ impl LspQueryProfile {
 
         if self
             .allowed_kinds
-            .as_deref()
+            .as_ref()
             .is_some_and(|kinds| !kinds.contains(&node.id.kind))
         {
             return false;
@@ -283,8 +283,15 @@ pub(crate) struct LspQueryTelemetry {
 #[derive(Debug, Default)]
 struct LspQueryTelemetryState {
     metrics: BTreeMap<LspQueryMetricKey, LspQueryMetric>,
-    pending_work: BTreeMap<usize, LspQueryMetricKey>,
+    pending_work: BTreeMap<usize, PendingLspQuery>,
     deadline_closed: bool,
+}
+
+#[derive(Debug)]
+struct PendingLspQuery {
+    key: LspQueryMetricKey,
+    scheduled_requests: usize,
+    started_at: std::time::Instant,
 }
 
 impl LspQueryTelemetry {
@@ -313,8 +320,25 @@ impl LspQueryTelemetry {
         if state.deadline_closed {
             return false;
         }
-        state.pending_work.insert(work_item_id, key);
+        state.pending_work.insert(
+            work_item_id,
+            PendingLspQuery {
+                key,
+                scheduled_requests: 0,
+                started_at: std::time::Instant::now(),
+            },
+        );
         true
+    }
+
+    pub(crate) fn note_requests_started(&self, work_item_id: usize, count: usize) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        if let Some(pending) = state.pending_work.get_mut(&work_item_id) {
+            pending.scheduled_requests = pending.scheduled_requests.saturating_add(count);
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -354,7 +378,6 @@ impl LspQueryTelemetry {
     pub(crate) fn record_work_item(
         &self,
         work_item_id: usize,
-        scheduled_requests: usize,
         non_empty_responses: usize,
         emitted_edges: usize,
         latency: Duration,
@@ -365,13 +388,13 @@ impl LspQueryTelemetry {
             .state
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
-        let Some(key) = state.pending_work.remove(&work_item_id) else {
+        let Some(pending) = state.pending_work.remove(&work_item_id) else {
             return false;
         };
         self.record_locked(
             &mut state,
-            key,
-            scheduled_requests,
+            pending.key,
+            pending.scheduled_requests,
             non_empty_responses,
             emitted_edges,
             latency,
@@ -420,15 +443,24 @@ impl LspQueryTelemetry {
     /// Attribute work items cancelled by the outer job deadline. Completed
     /// items have already atomically removed their IDs, so this drains only
     /// in-flight operations and owns their terminal outcome.
-    pub(crate) fn record_job_timeout(&self, latency: Duration) {
+    pub(crate) fn record_job_timeout(&self) {
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
         state.deadline_closed = true;
         let pending = std::mem::take(&mut state.pending_work);
-        for (_, key) in pending {
-            self.record_locked(&mut state, key, 0, 0, 0, latency, 1, 1);
+        for (_, pending) in pending {
+            self.record_locked(
+                &mut state,
+                pending.key,
+                pending.scheduled_requests,
+                0,
+                0,
+                pending.started_at.elapsed(),
+                1,
+                1,
+            );
         }
     }
 
@@ -632,9 +664,10 @@ mod tests {
             LspQueryOperation::CallHierarchy,
             LspDeclarationClass::Function,
         ));
+        telemetry.note_requests_started(1, 3);
+        telemetry.note_requests_started(2, 2);
         assert!(telemetry.record_work_item(
             1,
-            3,
             1,
             2,
             Duration::from_millis(10),
@@ -642,14 +675,13 @@ mod tests {
             0,
         ));
 
-        telemetry.record_job_timeout(Duration::from_millis(50));
+        telemetry.record_job_timeout();
         assert!(!telemetry.register_work_item(
             3,
             LspQueryOperation::References,
             LspDeclarationClass::Struct,
         ));
         assert!(!telemetry.record_work_item(
-            2,
             2,
             1,
             1,
@@ -660,9 +692,9 @@ mod tests {
 
         let metrics = telemetry.snapshot();
         assert_eq!(metrics.len(), 1);
-        assert_eq!(metrics[0].scheduled_requests, 3);
+        assert_eq!(metrics[0].scheduled_requests, 5);
         assert_eq!(metrics[0].timeouts, 1);
         assert_eq!(metrics[0].errors, 1);
-        assert_eq!(metrics[0].latency_ms, 60);
+        assert!(metrics[0].latency_ms >= 10);
     }
 }

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -213,6 +213,8 @@ pub struct EnrichmentResult {
     /// Per-language LSP enrichment stats for the scan summary.
     /// Populated by `enrich_all()` from individual enricher results.
     pub lsp_entries: Vec<scan_stats::LspEnrichmentEntry>,
+    /// Operation/declaration query-yield measurements from LSP enrichers.
+    pub lsp_query_metrics: Vec<lsp::LspQueryMetric>,
 }
 
 /// Phase 2: Asynchronous enrichment after initial extraction.
@@ -720,6 +722,7 @@ impl EnricherRegistry {
                     let edge_count = enrichment.added_edges.len();
                     let node_count = enrichment.new_nodes.len();
                     let error_count = enrichment.error_count;
+                    let query_metrics = enrichment.lsp_query_metrics;
                     let status = if enrichment.aborted {
                         scan_stats::LspStatus::Aborted
                     } else {
@@ -728,6 +731,7 @@ impl EnricherRegistry {
                     result.added_edges.extend(enrichment.added_edges);
                     result.updated_nodes.extend(enrichment.updated_nodes);
                     result.new_nodes.extend(enrichment.new_nodes);
+                    result.lsp_query_metrics.extend(query_metrics.clone());
                     result.lsp_entries.push(scan_stats::LspEnrichmentEntry {
                         language: lang,
                         server_name: server,
@@ -738,6 +742,7 @@ impl EnricherRegistry {
                         duration: dur,
                         status,
                         remediation: enricher.toolchain_remediation().map(str::to_string),
+                        query_metrics,
                     });
                 }
                 Err(e) => {
@@ -764,6 +769,7 @@ impl EnricherRegistry {
                         duration: dur,
                         status,
                         remediation: enricher.toolchain_remediation().map(str::to_string),
+                        query_metrics: Vec::new(),
                     });
                 }
             }

--- a/src/extract/scan_stats.rs
+++ b/src/extract/scan_stats.rs
@@ -84,6 +84,7 @@ pub struct LspEnrichmentEntry {
     pub duration: Duration,
     pub status: LspStatus,
     pub remediation: Option<String>,
+    pub query_metrics: Vec<crate::extract::lsp::LspQueryMetric>,
 }
 
 impl LspEnrichmentEntry {
@@ -128,6 +129,21 @@ impl LspEnrichmentEntry {
             line.push_str(" -- ");
             line.push_str(remediation);
         }
+        if !self.query_metrics.is_empty() {
+            let scheduled = self
+                .query_metrics
+                .iter()
+                .map(|metric| metric.scheduled_requests)
+                .sum::<usize>();
+            let non_empty = self
+                .query_metrics
+                .iter()
+                .map(|metric| metric.non_empty_responses)
+                .sum::<usize>();
+            line.push_str(&format!(
+                " -- query yield {non_empty}/{scheduled} non-empty"
+            ));
+        }
         line
     }
 }
@@ -158,6 +174,8 @@ pub struct LspLanguageStats {
     pub server_missing: bool,
     /// Optional actionable setup guidance for this language server.
     pub remediation: Option<String>,
+    /// Query-yield measurements grouped by operation and declaration class.
+    pub query_metrics: Vec<crate::extract::lsp::LspQueryMetric>,
 }
 
 /// Per-root stats populated after `RootExtracted`.
@@ -312,6 +330,7 @@ impl ExtractionConsumer for ScanStatsConsumer {
             ExtractionEventKind::RootExtracted,
             ExtractionEventKind::LanguageDetected,
             ExtractionEventKind::EnrichmentComplete,
+            ExtractionEventKind::LspQueryMetrics,
             ExtractionEventKind::PassesComplete,
         ]
     }
@@ -423,6 +442,7 @@ impl ExtractionConsumer for ScanStatsConsumer {
                             aborted: *aborted,
                             server_missing: *server_missing,
                             remediation: remediation.clone(),
+                            query_metrics: Vec::new(),
                         },
                     );
                 }
@@ -432,6 +452,20 @@ impl ExtractionConsumer for ScanStatsConsumer {
                     slug,
                     added_edges.len(),
                 );
+            }
+
+            ExtractionEvent::LspQueryMetrics {
+                slug,
+                language,
+                metrics,
+            } => {
+                if let Some(language_stats) = stats
+                    .lsp_stats
+                    .get_mut(slug)
+                    .and_then(|by_language| by_language.get_mut(language))
+                {
+                    language_stats.query_metrics = metrics.to_vec();
+                }
             }
 
             ExtractionEvent::PassesComplete {
@@ -908,6 +942,53 @@ mod tests {
         let _ = lsp.duration;
     }
 
+    #[tokio::test]
+    async fn test_lsp_query_metrics_are_delivered_to_language_stats() {
+        let c = make_consumer();
+        c.on_event(&ExtractionEvent::EnrichmentComplete {
+            slug: slug("api"),
+            language: "rust".into(),
+            added_edges: empty_arc_edges(),
+            new_nodes: empty_arc_nodes(),
+            updated_nodes: std::sync::Arc::from([]),
+            server_name: Some("rust-analyzer".to_string()),
+            error_count: 0,
+            server_missing: false,
+            remediation: None,
+            aborted: false,
+            diagnostic: None,
+        })
+        .await
+        .unwrap();
+        c.on_event(&ExtractionEvent::LspQueryMetrics {
+            slug: slug("api"),
+            language: "rust".into(),
+            metrics: std::sync::Arc::from(
+                vec![crate::extract::lsp::LspQueryMetric {
+                    language: "rust".to_string(),
+                    server: "rust-analyzer".to_string(),
+                    operation: "call_hierarchy".to_string(),
+                    declaration_class: "function".to_string(),
+                    scheduled_requests: 3,
+                    non_empty_responses: 2,
+                    emitted_edges: 4,
+                    latency_ms: 17,
+                    timeouts: 0,
+                    errors: 0,
+                }]
+                .into_boxed_slice(),
+            ),
+        })
+        .await
+        .unwrap();
+
+        let stats = c.stats.read().unwrap();
+        let metrics = &stats.lsp_stats["api"]["rust"].query_metrics;
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].scheduled_requests, 3);
+        assert_eq!(metrics[0].emitted_edges, 4);
+    }
+
     /// EnrichmentComplete without server_name does NOT populate lsp_stats.
     #[tokio::test]
     async fn test_enrichment_complete_without_server_name_no_lsp_stats() {
@@ -947,6 +1028,7 @@ mod tests {
             duration: Duration::from_secs_f64(3.5),
             status: LspStatus::Ok,
             remediation: None,
+            query_metrics: Vec::new(),
         };
         let l = e.summary_line();
         assert!(l.contains("rust (rust-analyzer)"));
@@ -966,6 +1048,7 @@ mod tests {
             duration: Duration::from_millis(5),
             status: LspStatus::NotFound,
             remediation: Some("install json ls".to_string()),
+            query_metrics: Vec::new(),
         };
         let line = e.summary_line();
         assert!(line.contains("not found"));

--- a/src/server/changed_file_plan.rs
+++ b/src/server/changed_file_plan.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use git2::{Delta, Diff, DiffFindOptions, DiffOptions, Repository};
 
-use crate::extract::lsp::requested_operations_for_node;
-use crate::graph::{Node, NodeKind};
+use crate::extract::lsp::planned_operations_for_node;
+use crate::graph::Node;
 
 pub(crate) const MAX_CHANGED_LSP_NODES: usize = 4_096;
 pub(crate) const MAX_CHANGED_LSP_OPERATIONS: usize = 12_288;
@@ -222,14 +222,7 @@ pub(crate) fn plan_changed_files(input: ChangedFilePlanInput<'_>) -> Result<Chan
         if let Some(nodes) = nodes_by_file.get_mut(&file) {
             nodes.sort_by_key(|node| node.stable_id());
             for node in nodes.iter() {
-                if matches!(&node.id.kind, NodeKind::Other(kind) if kind == "diagnostic") {
-                    continue;
-                }
-                let requested_operations = requested_operations_for_node(&node.id.kind, true, true)
-                    .into_iter()
-                    .filter(|operation| *operation != "skipped_no_supported_operation")
-                    .map(str::to_string)
-                    .collect::<Vec<_>>();
+                let requested_operations = planned_operations_for_node(node);
                 if requested_operations.is_empty() {
                     continue;
                 }
@@ -416,7 +409,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
-    use crate::graph::{ExtractionSource, NodeId};
+    use crate::graph::{ExtractionSource, NodeId, NodeKind};
 
     fn node(file: &str, name: &str, kind: NodeKind) -> Node {
         Node {
@@ -470,7 +463,47 @@ mod tests {
         assert_eq!(ids.len(), 2);
         assert!(ids.iter().all(|id| id.contains("src/changed.rs")));
         assert!(!ids.iter().any(|id| id.contains("unrelated")));
-        assert_eq!(plan.operation_count, 4);
+        assert_eq!(plan.operation_count, 2);
+    }
+
+    #[test]
+    fn planner_uses_shared_profile_for_synthetic_const_and_language_restrictions() {
+        let mut synthetic = node("src/changed.rs", "literal", NodeKind::Const);
+        synthetic
+            .metadata
+            .insert("synthetic".to_string(), "true".to_string());
+        let declared_const = node("src/changed.rs", "DECLARED", NodeKind::Const);
+        let mut python_struct = node("src/changed.rs", "Model", NodeKind::Struct);
+        python_struct.language = "python".to_string();
+        let mut python_function = node("src/changed.rs", "handler", NodeKind::Function);
+        python_function.language = "python".to_string();
+        let nodes = vec![
+            synthetic,
+            declared_const,
+            python_struct,
+            python_function,
+        ];
+
+        let plan = plan_changed_files(ChangedFilePlanInput {
+            provenance: provenance(),
+            root_slug: "fixture",
+            changes: vec![ChangedFile {
+                kind: ChangedFileKind::Modified,
+                old_path: None,
+                new_path: Some(PathBuf::from("src/changed.rs")),
+            }],
+            cached_nodes: &nodes,
+            max_nodes: 16,
+            max_operations: 16,
+        })
+        .unwrap();
+
+        assert_eq!(plan.planned_nodes.len(), 1);
+        assert!(plan.planned_nodes[0].stable_id.contains("handler"));
+        assert_eq!(
+            plan.planned_nodes[0].requested_operations,
+            vec!["call_hierarchy"]
+        );
     }
 
     #[test]

--- a/src/server/changed_file_plan.rs
+++ b/src/server/changed_file_plan.rs
@@ -463,7 +463,7 @@ mod tests {
         assert_eq!(ids.len(), 2);
         assert!(ids.iter().all(|id| id.contains("src/changed.rs")));
         assert!(!ids.iter().any(|id| id.contains("unrelated")));
-        assert_eq!(plan.operation_count, 2);
+        assert_eq!(plan.operation_count, 3);
     }
 
     #[test]

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -480,11 +480,7 @@ impl RnaHandler {
                             super::sentinel::clear_lsp_sentinel(&repo_root);
                             if let Some(job_id) = degraded_job_id.as_deref() {
                                 enrichment_jobs.mark_degraded(
-                                    &repo_root,
-                                    job_id,
-                                    node_count,
-                                    edge_count,
-                                    detail,
+                                    &repo_root, job_id, node_count, edge_count, detail,
                                 );
                             }
                         } else if !persist_succeeded
@@ -1054,10 +1050,7 @@ impl RnaHandler {
                 match result {
                     Ok(r) => r,
                     Err(e) => {
-                        tracing::error!(
-                            "[cache-hit bus] emit_enrichment_pipeline failed: {:#}",
-                            e
-                        );
+                        tracing::error!("[cache-hit bus] emit_enrichment_pipeline failed: {:#}", e);
                         if e.is_timeout() {
                             bg_lsp_status.set_timed_out(&format!("{}", e));
                             bg_jobs.mark_timed_out(&bg_repo_root, &job_id, format!("{}", e));
@@ -2016,21 +2009,25 @@ impl RnaHandler {
                     );
                 }
                 let lsp_abort_detail = if run_lsp_in_bus {
-                    (!diagnostics.is_empty()).then(|| diagnostics.join("; ")).or_else(|| {
-                        let lsp_failures = self
-                            .scan_stats
-                            .read()
-                            .map(|stats| {
-                                lsp_abort_failures_for_slugs(&stats, &participating_lsp_slugs)
+                    (!diagnostics.is_empty())
+                        .then(|| diagnostics.join("; "))
+                        .or_else(|| {
+                            let lsp_failures = self
+                                .scan_stats
+                                .read()
+                                .map(|stats| {
+                                    lsp_abort_failures_for_slugs(&stats, &participating_lsp_slugs)
+                                })
+                                .unwrap_or_else(|_| {
+                                    vec!["scan stats unavailable: lock poisoned".to_string()]
+                                });
+                            (!lsp_failures.is_empty()).then(|| {
+                                format!(
+                                    "LSP call-reference enrichment aborted: {}",
+                                    lsp_failures.join("; ")
+                                )
                             })
-                            .unwrap_or_else(|_| {
-                                vec!["scan stats unavailable: lock poisoned".to_string()]
-                            });
-                        (!lsp_failures.is_empty()).then(|| format!(
-                            "LSP call-reference enrichment aborted: {}",
-                            lsp_failures.join("; ")
-                        ))
-                    })
+                        })
                 } else {
                     None
                 };
@@ -2416,13 +2413,15 @@ impl RnaHandler {
                             .count()
                     });
 
-                let lsp_abort_detail = (!diagnostics.is_empty()).then(|| diagnostics.join("; ")).or_else(|| {
-                    let stats = self.scan_stats.read().unwrap_or_else(|e| e.into_inner());
-                    lsp_abort_failures_for_slugs(&stats, &participating_lsp_slugs)
-                        .into_iter()
-                        .next()
-                        .map(|failure| format!("LSP enrichment aborted for {failure}"))
-                });
+                let lsp_abort_detail = (!diagnostics.is_empty())
+                    .then(|| diagnostics.join("; "))
+                    .or_else(|| {
+                        let stats = self.scan_stats.read().unwrap_or_else(|e| e.into_inner());
+                        lsp_abort_failures_for_slugs(&stats, &participating_lsp_slugs)
+                            .into_iter()
+                            .next()
+                            .map(|failure| format!("LSP enrichment aborted for {failure}"))
+                    });
                 if let Some(detail) = lsp_abort_detail.as_deref() {
                     on_progress(&format!("Enrichment: {detail}"));
                 }
@@ -3164,6 +3163,7 @@ mod tests {
                     aborted: true,
                     server_missing: false,
                     remediation: None,
+                    query_metrics: Vec::new(),
                 },
             )]
             .into_iter()
@@ -3182,6 +3182,7 @@ mod tests {
                     aborted: true,
                     server_missing: false,
                     remediation: None,
+                    query_metrics: Vec::new(),
                 },
             )]
             .into_iter()

--- a/src/service/roots.rs
+++ b/src/service/roots.rs
@@ -271,6 +271,24 @@ pub fn list_roots_from_slugs(
                         lang,
                         detail_parts.join(", ")
                     ));
+                    let mut query_metrics = ls.query_metrics.iter().collect::<Vec<_>>();
+                    query_metrics.sort_by(|left, right| {
+                        (&left.operation, &left.declaration_class)
+                            .cmp(&(&right.operation, &right.declaration_class))
+                    });
+                    for metric in query_metrics {
+                        line.push_str(&format!(
+                            "\n    query: {}/{} scheduled={} non_empty={} edges={} latency_ms={} timeouts={} errors={}",
+                            metric.operation,
+                            metric.declaration_class,
+                            metric.scheduled_requests,
+                            metric.non_empty_responses,
+                            metric.emitted_edges,
+                            metric.latency_ms,
+                            metric.timeouts,
+                            metric.errors,
+                        ));
+                    }
                 }
                 true
             } else {
@@ -1315,6 +1333,18 @@ mod tests {
                 aborted: false,
                 server_missing: false,
                 remediation: None,
+                query_metrics: vec![crate::extract::lsp::LspQueryMetric {
+                    language: "rust".to_string(),
+                    server: "rust-analyzer".to_string(),
+                    operation: "call_hierarchy".to_string(),
+                    declaration_class: "function".to_string(),
+                    scheduled_requests: 12,
+                    non_empty_responses: 8,
+                    emitted_edges: 703,
+                    latency_ms: 45_000,
+                    timeouts: 1,
+                    errors: 2,
+                }],
             },
         );
         stats.lsp_stats.insert(primary_slug.clone(), root_lsp);
@@ -1323,6 +1353,11 @@ mod tests {
         assert!(
             result.contains("LSP: rust-analyzer -> rust"),
             "should show per-language LSP line, got: {}",
+            result
+        );
+        assert!(
+            result.contains("query: call_hierarchy/function scheduled=12 non_empty=8 edges=703 latency_ms=45000 timeouts=1 errors=2"),
+            "should expose operation/declaration query yield through list_roots, got: {}",
             result
         );
         assert!(
@@ -1341,8 +1376,8 @@ mod tests {
             result
         );
         assert!(
-            !result.contains("errors"),
-            "should not show errors when 0, got: {}",
+            !result.contains("LSP: rust-analyzer -> rust (703 edges, 150 nodes, 45s, errors"),
+            "should not show language-level errors when 0, got: {}",
             result
         );
         assert!(
@@ -1388,6 +1423,7 @@ mod tests {
                 aborted: true,
                 server_missing: false,
                 remediation: Some("install pyright".to_string()),
+                query_metrics: Vec::new(),
             },
         );
         stats.lsp_stats.insert(primary_slug.clone(), root_lsp);
@@ -1462,6 +1498,7 @@ mod tests {
                 aborted: false,
                 server_missing: false,
                 remediation: None,
+                query_metrics: Vec::new(),
             },
         );
         stats.lsp_stats.insert(primary_slug.clone(), root_lsp);


### PR DESCRIPTION
Closes #767

## Aim
Agents receive high-signal compiler relationships without paying broad, semantically invalid LSP query costs.

## Problem
RNA currently admits LSP work primarily from declaration kind and server capability. That policy is too coarse: it is not shared across every scheduling path, cannot distinguish operations, and does not expose enough yield telemetry to prove that a query class improves delivered context.

## Chosen solution
Introduce one shared LSP query profile owned by the built-in language/server descriptor and consumed by every work-item construction and scheduling path. Admission will evaluate operation, declaration class, language/server policy, negotiated capability, and runtime budget. Synthetic nodes remain globally ineligible and declared Const references remain default-deny. High-signal Function call hierarchy and Trait implementation work remain eligible when advertised.

Record scheduled requests, non-empty responses, emitted edges, latency, timeouts, and errors by language, operation, and declaration class, and expose an aggregate report suitable for deciding whether a capability earns its cost.

Add regression coverage for allowed, denied, server-profiled, capability-gated, and budget-gated work across the relevant passes.

## Scope boundaries
- Do not perform #768 corpus measurement or opt declared constants in.
- Do not implement #769 on-demand/reference scoping.
- Do not add language conditionals to generic scheduling.

## Planning evidence

### Aim
- Current: broad AST-kind admission schedules semantically invalid or low-yield work.
- Desired: agents get useful calls/implementations while the system can prove query yield.
- Signal: per-profile request/yield/error/latency counters and regression fixtures.

### Problem space
- Hard constraints: shared construction policy; synthetic default-deny; declared Const default-deny; negotiated capability and runtime budget must participate; no generic language branches.
- Blast radius: all built-in LSP construction and pass scheduling.
- Precedent: the unified descriptor from #765 and degraded completion from #766.

### Problem statement
Agents need compiler-resolved relationships that improve navigation, but current kind-only admission cannot distinguish semantic operations or demonstrate their value, causing invalid work and opaque cost.

### Solution-space recommendation
Selected a shared operation-aware profile at the descriptor/scheduling seam plus structured yield telemetry. Rejected pass-local allow-lists because they drift, blanket removal of references because it loses high-signal relationships, and broad opt-in because #768 must earn that expansion with evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operation-aware LSP enrichment that considers server capabilities, language support, declaration types, and runtime budgets.
  * Added detailed query-yield metrics, including scheduled requests, responses, emitted edges, latency, timeouts, and errors.
  * `list_roots` now displays per-language LSP query metrics.

* **Bug Fixes**
  * Improved handling of LSP timeouts, partial results, unsupported operations, and stale scan conditions.

* **Documentation**
  * Documented LSP admission rules and query-yield reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->