### PR TITLE
Measure declared-constant LSP reference yield before enabling it

### DIFF
--- a/.oh/friction-logs/768-oh-task.md
+++ b/.oh/friction-logs/768-oh-task.md
@@ -1,0 +1,14 @@
+---
+id: 768-oh-task-friction
+outcome: context-assembly
+title: 'Issue 768 workflow friction'
+---
+
+# Issue 768 workflow friction
+
+| Time | Tool path | Severity | Friction | Impact | Follow-up |
+|---|---|---|---|---|---|
+| 2026-07-16 | `but status -fv` | skipped | GitButler reported that setup requires a `gitbutler/*` branch, while this task was required to start from `origin/main` without a worktree. | The repository-explicit `git` commands from `/oh-task` were used for branch, commit, and push operations. | Decide whether ordinary RNA issue branches should be initialized for GitButler or exempted explicitly. |
+| 2026-07-16 | `gh pr create --draft` | friction | GitHub rejected a draft PR with no commits between `main` and `issue/768`. | A process-only empty commit was required before the draft PR could exist; no implementation file changed first. | Encode this empty-commit fallback in `/oh-task`. |
+| 2026-07-16 | RNA scan gate | friction | The required full scan finalized degraded because `typescript-language-server` did not reach quiescence. | Exact symbol, artifact, and source-span search remained usable, but repo-wide LSP coverage was partial. | Diagnose TypeScript initialization separately; it did not block the bounded Rust/Python probe. |
+| 2026-07-16 | RNA exact source spans | friction | Two initial source-span requests exceeded the 200-line hard cap. | The requests were narrowed and then succeeded; no raw code-read fallback was used. | Surface the maximum in CLI help/error-adjacent examples. |

--- a/.oh/metis/declared-constant-lsp-yield.md
+++ b/.oh/metis/declared-constant-lsp-yield.md
@@ -18,8 +18,8 @@ scheduling.
 
 A profile clears the opt-in bar only when the maintained probe shows all of:
 
-- at least 80% non-empty responses across five declared constants, including
-  one deliberately unused control;
+- at least 80% non-empty responses across the maintained declared-constant
+  surface, including one deliberately unused control;
 - at least one emitted `ReferencedBy` edge per scheduled constant request;
 - 100% correctness in the emitted-edge sample, with no self, literal, unused,
   or unexpected referrer edges;
@@ -34,9 +34,13 @@ isolation.
 ## Corpus and method
 
 `tests/fixtures/lsp_const_yield/` contains maintained two-file Rust and Python
-projects. Each defines five declared constants: four used from local and
-cross-file functions, plus one unused control. The fixtures also contain
-functions, a shared `Config` type, and a Rust trait/implementation.
+projects. The Rust fixture covers every declaration form currently collapsed
+into `NodeKind::Const`: four top-level `const` declarations, one `static`, one
+`static mut`, one associated constant, and one unused top-level control. The
+seven used declarations have local and cross-file references. The Python
+fixture defines five module-level ALL_CAPS constants: four used and one unused
+control. Both fixtures also contain functions and a shared `Config` type; Rust
+adds a trait/implementation.
 
 Run the real-server probe sequentially:
 
@@ -46,30 +50,31 @@ cargo test measure_declared_const_reference_yield -- --ignored --nocapture --tes
 
 The ignored test copies the maintained sources to temporary project roots,
 extracts real RNA nodes, opts constants into a test-only enricher, then records
-RNA's actual query telemetry and emitted graph edges. Three complete observed
-trials produced the same decision.
+RNA's actual query telemetry and emitted graph edges. Two complete trials of
+the expanded declaration-form corpus produced the same decision. Earlier
+top-level-only probes were discarded as insufficient and are not the basis for
+the opt-in.
 
 ## Results
 
 | Server / class | Requests | Non-empty | Edges | Aggregate latency | Timeouts | Errors |
 |---|---:|---:|---:|---:|---:|---:|
-| rust-analyzer / Const, trial 1 | 5 | 4 (80%) | 10 | 5 ms | 0 | 0 |
-| rust-analyzer / Const, trial 2 | 5 | 4 (80%) | 10 | 0 ms | 0 | 0 |
-| rust-analyzer / Const, trial 3 | 5 | 4 (80%) | 10 | 5 ms | 0 | 0 |
-| rust-analyzer / Struct | 1 | 1 | 5 | 0-1 ms | 0 | 0 |
+| rust-analyzer / Const, trial 1 | 8 | 7 (87.5%) | 16 | 8 ms | 0 | 0 |
+| rust-analyzer / Const, trial 2 | 8 | 7 (87.5%) | 16 | 0 ms | 0 | 0 |
+| rust-analyzer / Struct | 1 | 1 | 8 | 0-1 ms | 0 | 0 |
 | rust-analyzer / Trait implementations | 1 | 1 | 1 | 0-1 ms | 0 | 0 |
-| rust-analyzer / Function call hierarchy | 36 | 12 | 0 | 4-12 ms | 0 | 0 |
+| rust-analyzer / Function call hierarchy | 54 | 18 | 0 | 16-21 ms | 0 | 0 |
 | Pyright / Const, trial 1 | 5 | 0 | 0 | 150,005 ms | 5 | 5 |
 | Pyright / Const, trial 2 | 5 | 0 | 0 | 150,010 ms | 5 | 5 |
-| Pyright / Const, trial 3 | 5 | 0 | 0 | 150,010 ms | 5 | 5 |
 | Pyright / Struct | 1 | 0 | 0 | 30,001-30,002 ms | 1 | 1 |
-| Pyright / Function call hierarchy | 33 | 13 | 2 | 165-173 ms | 0 | 0 |
+| Pyright / Function call hierarchy | 33 | 13 | 2 | 163-172 ms | 0 | 0 |
 
-Rust's ten constant edges were all compiler-confirmed mappings from the
-expected enclosing functions to `RETRY_LIMIT`, `TIMEOUT_MS`, `DEFAULT_PORT`,
-or `FEATURE_FLAG`. The deliberately unused `UNUSED_SENTINEL` produced no edge.
-The extra two `RETRY_LIMIT` edges came from the expected `make_config` and
-`worker_config` functions.
+Rust's sixteen constant edges exactly matched the expected
+`(referrer file/name, declaration file/name)` set and multiplicity across
+top-level const, static, static mut, and associated-constant references. The
+deliberately unused `UNUSED_SENTINEL` produced no edge. Exact pair equality
+means a cross-wired mapping such as `local_timeout -> RETRY_LIMIT` fails the
+probe.
 
 Pyright produced no constant edge to sample. Every constant reference request
 hit the 30-second timeout, matching the prior large-corpus warning that broad
@@ -79,6 +84,11 @@ Function call-hierarchy edge counts are fixture-dependent: the Rust fixture's
 functions intentionally do not call one another, while the Python constructors
 produce two in-fixture calls. These rows are comparison context, not part of
 the constant opt-in threshold.
+
+Measured executables:
+
+- `rust-analyzer 0.0.0 (566fe415d1 2026-03-01)`
+- `pyright 1.1.408`
 
 ## Consequence
 

--- a/.oh/metis/declared-constant-lsp-yield.md
+++ b/.oh/metis/declared-constant-lsp-yield.md
@@ -45,6 +45,7 @@ adds a trait/implementation.
 Run the real-server probe sequentially:
 
 ```bash
+cargo check --lib
 cargo test measure_declared_const_reference_yield -- --ignored --nocapture --test-threads=1
 ```
 

--- a/.oh/metis/declared-constant-lsp-yield.md
+++ b/.oh/metis/declared-constant-lsp-yield.md
@@ -1,0 +1,101 @@
+---
+id: declared-constant-lsp-yield
+outcome: context-assembly
+title: 'Declared Constant References Must Earn a Per-Server Opt-In'
+---
+
+## Decision
+
+Enable declared-constant `textDocument/references` only for the built-in
+Rust/rust-analyzer profile. Keep Python/Pyright and every other unmeasured
+profile disabled.
+
+This is a per-language/server decision, not evidence for a global `Const`
+allow-list. Synthetic constants remain categorically excluded before
+scheduling.
+
+## Threshold
+
+A profile clears the opt-in bar only when the maintained probe shows all of:
+
+- at least 80% non-empty responses across five declared constants, including
+  one deliberately unused control;
+- at least one emitted `ReferencedBy` edge per scheduled constant request;
+- 100% correctness in the emitted-edge sample, with no self, literal, unused,
+  or unexpected referrer edges;
+- zero timeouts and zero request errors; and
+- average constant-reference latency no more than 2x the comparable Struct
+  reference latency.
+
+The probe compares Function call hierarchy, Trait implementations where
+supported, and Struct references so constant yield is not interpreted in
+isolation.
+
+## Corpus and method
+
+`tests/fixtures/lsp_const_yield/` contains maintained two-file Rust and Python
+projects. Each defines five declared constants: four used from local and
+cross-file functions, plus one unused control. The fixtures also contain
+functions, a shared `Config` type, and a Rust trait/implementation.
+
+Run the real-server probe sequentially:
+
+```bash
+cargo test measure_declared_const_reference_yield -- --ignored --nocapture --test-threads=1
+```
+
+The ignored test copies the maintained sources to temporary project roots,
+extracts real RNA nodes, opts constants into a test-only enricher, then records
+RNA's actual query telemetry and emitted graph edges. Three complete observed
+trials produced the same decision.
+
+## Results
+
+| Server / class | Requests | Non-empty | Edges | Aggregate latency | Timeouts | Errors |
+|---|---:|---:|---:|---:|---:|---:|
+| rust-analyzer / Const, trial 1 | 5 | 4 (80%) | 10 | 5 ms | 0 | 0 |
+| rust-analyzer / Const, trial 2 | 5 | 4 (80%) | 10 | 0 ms | 0 | 0 |
+| rust-analyzer / Const, trial 3 | 5 | 4 (80%) | 10 | 5 ms | 0 | 0 |
+| rust-analyzer / Struct | 1 | 1 | 5 | 0-1 ms | 0 | 0 |
+| rust-analyzer / Trait implementations | 1 | 1 | 1 | 0-1 ms | 0 | 0 |
+| rust-analyzer / Function call hierarchy | 36 | 12 | 0 | 4-12 ms | 0 | 0 |
+| Pyright / Const, trial 1 | 5 | 0 | 0 | 150,005 ms | 5 | 5 |
+| Pyright / Const, trial 2 | 5 | 0 | 0 | 150,010 ms | 5 | 5 |
+| Pyright / Const, trial 3 | 5 | 0 | 0 | 150,010 ms | 5 | 5 |
+| Pyright / Struct | 1 | 0 | 0 | 30,001-30,002 ms | 1 | 1 |
+| Pyright / Function call hierarchy | 33 | 13 | 2 | 165-173 ms | 0 | 0 |
+
+Rust's ten constant edges were all compiler-confirmed mappings from the
+expected enclosing functions to `RETRY_LIMIT`, `TIMEOUT_MS`, `DEFAULT_PORT`,
+or `FEATURE_FLAG`. The deliberately unused `UNUSED_SENTINEL` produced no edge.
+The extra two `RETRY_LIMIT` edges came from the expected `make_config` and
+`worker_config` functions.
+
+Pyright produced no constant edge to sample. Every constant reference request
+hit the 30-second timeout, matching the prior large-corpus warning that broad
+Pyright references can consume warm-up time without delivering graph value.
+
+Function call-hierarchy edge counts are fixture-dependent: the Rust fixture's
+functions intentionally do not call one another, while the Python constructors
+produce two in-fixture calls. These rows are comparison context, not part of
+the constant opt-in threshold.
+
+## Consequence
+
+The built-in descriptor is the policy seam. Rust sets
+`allow_declared_const_references = true`; the macro default remains false, so
+every unmeasured server and Pyright stay denied without generic language
+conditionals.
+
+Re-run the maintained probe when a language-server upgrade, transport change,
+or fixture expansion could change the decision. Do not infer that one server's
+success generalizes to another.
+
+## References
+
+- Issue #768
+- PR #774
+- `.oh/metis/operation-aware-lsp-query-admission.md`
+- `src/extract/lsp/policy.rs`
+- `src/extract/lsp/mod.rs`
+- `tests/fixtures/lsp_const_yield/`

--- a/.oh/sessions/774-ship.md
+++ b/.oh/sessions/774-ship.md
@@ -1,0 +1,61 @@
+---
+session: 774-ship
+artifact_type: ship
+updated: 2026-07-16
+---
+
+# Ship Pipeline — PR #774
+
+## Pre-flight
+
+- PR: #774, branch `issue/768`, closes #768.
+- Required RNA scan completed with exact/artifact search ready and degraded
+  repo-wide TypeScript LSP coverage.
+- Relevant metis: operation-aware LSP query admission and declared-constant
+  LSP yield.
+- Relevant guardrails: repo-native, no-language-conditionals-in-generic,
+  computed-but-not-delivered, test-with-real-mcp-client, and
+  no-parallel-cargo-agents.
+- No pre-existing CodeRabbit comments existed while the PR was draft.
+
+## Step 1: RNA-Grounded Review
+
+**Verdict:** CONTINUE
+
+RNA reported 53 dependents across six subsystems within three hops of the
+shared descriptor. Registry/EventBus parity and changed-file planning have
+focused regression coverage. All six issue acceptance criteria are met by the
+maintained two-server probe, thresholded decision, metis, and Rust-only
+descriptor opt-in.
+
+Findings:
+
+1. Measurement configuration parity was fixed by applying Pyright's built-in
+   initialization settings and config hint before the final probe.
+2. Changed-file planner/runtime parity was fixed and covered by a focused
+   regression.
+3. The real-server probe is intentionally ignored in ordinary CI; normal unit
+   tests pin the profile decision, while the documented ship command supplies
+   real-server evidence.
+4. The local full library suite had one environment-sensitive failure because
+   current-repo operation history contains the word `aborted`; 2,013 other
+   library tests passed. Clean CI is the full-suite authority.
+
+The complete review is posted on PR #774.
+
+## Step 2: Independent Review
+
+**Verdict:** REQUEST CHANGES
+
+The reviewer found two blocking evidence gaps:
+
+1. Rust's profile admits every real `NodeKind::Const`, while the first fixture
+   measured only top-level `const`.
+2. Independent source/target allow-lists could accept a cross-wired edge.
+
+Both were fixed. The Rust fixture now measures top-level const, static,
+static mut, associated const, and an unused control. The correctness oracle
+requires the exact sixteen expected file/name edge pairs and exact
+multiplicity. The probe also records successful `rust-analyzer --version` and
+`pyright --version` output. Two complete expanded-corpus trials pass with Rust
+eligible and Pyright ineligible.

--- a/.oh/sessions/774-ship.md
+++ b/.oh/sessions/774-ship.md
@@ -59,3 +59,39 @@ requires the exact sixteen expected file/name edge pairs and exact
 multiplicity. The probe also records successful `rust-analyzer --version` and
 `pyright --version` output. Two complete expanded-corpus trials pass with Rust
 eligible and Pyright ineligible.
+
+The independent reviewer re-reviewed the fixes and approved the PR.
+
+## Step 3: Fix Review Findings
+
+The fixture and correctness-oracle fixes were committed and pushed. Focused
+unit tests, `cargo check --lib`, clippy, formatting, and two sequential
+real-server probe trials passed.
+
+## Step 3b: Mark Ready
+
+PR #774 was marked ready for review and CodeRabbit review was explicitly
+requested.
+
+## Step 4: Regression Oracle
+
+**Verdict:** PASS
+
+The regression oracle confirmed default-deny behavior, Rust-only opt-in,
+synthetic-constant exclusion, exact edge correctness, maintained two-server
+fixtures, and production-path planner coverage.
+
+## Step 5: Merit Assessment
+
+**Verdict:** MERGE
+
+The change converts a speculative global constant allow-list into measured,
+per-server policy. Rust gains useful constant references while Pyright and
+unmeasured profiles avoid known timeout/error cost.
+
+## CodeRabbit Review
+
+CodeRabbit requested one documentation correction: the reproducible probe
+instructions must run `cargo check --lib` before the ignored real-server test.
+The metis and operational LSP documentation now show that required sequential
+preflight.

--- a/docs/lsp-enrichment.md
+++ b/docs/lsp-enrichment.md
@@ -46,6 +46,7 @@ RNA records scheduled requests, non-empty responses, emitted edges, latency, tim
 The reproducible probe is:
 
 ```bash
+cargo check --lib
 cargo test measure_declared_const_reference_yield -- --ignored --nocapture --test-threads=1
 ```
 

--- a/docs/lsp-enrichment.md
+++ b/docs/lsp-enrichment.md
@@ -39,9 +39,17 @@ Before requesting call hierarchy or references for a symbol, RNA sends `textDocu
 
 ### Operation-aware query admission
 
-Every LSP request is admitted through one shared query profile. The profile combines the requested operation, declaration class, language/server configuration, negotiated server capabilities, and the operation's runtime budget. Synthetic values are always rejected, and declared constants are default-denied for reference queries. High-signal function call hierarchy and trait implementation requests remain enabled when the server advertises those capabilities.
+Every LSP request is admitted through one shared query profile. The profile combines the requested operation, declaration class, language/server configuration, negotiated server capabilities, and the operation's runtime budget. Synthetic values are always rejected, and declared constants are default-denied for reference queries unless a language/server profile has cleared a measured yield, correctness, latency, and reliability threshold. Rust-analyzer is currently the only built-in declared-constant opt-in; Pyright remains disabled because the maintained probe produced only timeouts and no edges. High-signal function call hierarchy and trait implementation requests remain enabled when the server advertises those capabilities.
 
 RNA records scheduled requests, non-empty responses, emitted edges, latency, timeouts, and errors for each language/server, operation, and declaration class. `list_roots` exposes these query-yield rows beneath each language's LSP summary so operators can compare request cost with agent-visible graph value.
+
+The reproducible probe is:
+
+```bash
+cargo test measure_declared_const_reference_yield -- --ignored --nocapture --test-threads=1
+```
+
+It runs maintained Rust and Python fixtures sequentially through RNA's actual LSP enricher and asserts the current per-server decision.
 
 ## Auto-detected Language Servers
 

--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -3040,7 +3040,7 @@ mod tests {
         );
         assert!(
             !event_bus_path.allows_declared_const_references(),
-            "built-in declared-Const references remain disabled pending #768"
+            "Pyright declared-Const references remain disabled after the #768 probe"
         );
         assert_eq!(
             crate::extract::Enricher::name(&event_bus_path),

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -60,6 +60,7 @@ pub(crate) struct BuiltinLspDescriptor {
     init_settings: Option<InitSettingsFactory>,
     config_file: Option<&'static str>,
     toolchain_remediation: Option<&'static str>,
+    allow_declared_const_references: bool,
 }
 
 impl BuiltinLspDescriptor {
@@ -78,6 +79,9 @@ impl BuiltinLspDescriptor {
         }
         if let Some(remediation) = self.toolchain_remediation {
             enricher = enricher.with_toolchain_remediation(remediation);
+        }
+        if self.allow_declared_const_references {
+            enricher = enricher.with_declared_const_references(true);
         }
         if let Some(kinds) = crate::extract::configs::config_for_language(self.language)
             .and_then(|config| config.lsp_enrichable_kinds)
@@ -104,6 +108,7 @@ macro_rules! builtin_lsp {
             init_settings: None,
             config_file: None,
             toolchain_remediation: None,
+            allow_declared_const_references: false,
         }
     };
 }
@@ -112,6 +117,7 @@ static BUILTIN_LSP_DESCRIPTORS: &[BuiltinLspDescriptor] = &[
     BuiltinLspDescriptor {
         init_settings: None,
         config_file: Some("Cargo.toml"),
+        allow_declared_const_references: true,
         ..builtin_lsp!("rust", "rust-analyzer", &[], &["rs"])
     },
     BuiltinLspDescriptor {
@@ -477,6 +483,11 @@ impl LspEnricher {
     /// When set, only nodes matching these kinds are sent for enrichment.
     pub fn with_enrichable_kinds(mut self, kinds: &'static [NodeKind]) -> Self {
         self.query_profile = self.query_profile.with_allowed_kinds(kinds);
+        self
+    }
+
+    fn with_declared_const_references(mut self, allow: bool) -> Self {
+        self.query_profile = self.query_profile.with_declared_const_references(allow);
         self
     }
 
@@ -2907,7 +2918,12 @@ mod tests {
         assert!(python_kinds.contains(&NodeKind::Trait));
         assert!(
             !python.allows_declared_const_references(),
-            "built-in profiles must keep declared-Const references default-off"
+            "Pyright must keep declared-Const references disabled after the #768 probe"
+        );
+        let rust = builtin_lsp_enricher("rust").expect("rust is a built-in LSP profile");
+        assert!(
+            rust.allows_declared_const_references(),
+            "rust-analyzer cleared the #768 declared-Const yield threshold"
         );
         assert_eq!(
             python.init_settings,
@@ -3793,6 +3809,225 @@ mod tests {
         let _result = enricher
             .enrich(&nodes, &index, std::path::Path::new("."))
             .await;
+    }
+
+    /// Reproducible, opt-in probe for issue #768. This intentionally exercises
+    /// RNA's real LSP scheduling, telemetry, and edge rendering against maintained
+    /// fixtures. Production opt-ins remain separately encoded in built-in profiles.
+    #[tokio::test]
+    #[ignore = "requires installed rust-analyzer and pyright-langserver"]
+    async fn measure_declared_const_reference_yield() {
+        use crate::extract::{Extractor, python::PythonExtractor, rust::RustExtractor};
+
+        struct FixtureCase {
+            language: &'static str,
+            server: &'static str,
+            args: &'static [&'static str],
+            extension: &'static str,
+            config_name: &'static str,
+            config: &'static str,
+            sources: &'static [(&'static str, &'static str)],
+            expect_enable: bool,
+        }
+
+        let cases = [
+            FixtureCase {
+                language: "rust",
+                server: "rust-analyzer",
+                args: &[],
+                extension: "rs",
+                config_name: "Cargo.toml",
+                config: include_str!("../../../tests/fixtures/lsp_const_yield/rust/Cargo.toml"),
+                sources: &[
+                    (
+                        "src/lib.rs",
+                        include_str!("../../../tests/fixtures/lsp_const_yield/rust/src/lib.rs"),
+                    ),
+                    (
+                        "src/worker.rs",
+                        include_str!("../../../tests/fixtures/lsp_const_yield/rust/src/worker.rs"),
+                    ),
+                ],
+                expect_enable: true,
+            },
+            FixtureCase {
+                language: "python",
+                server: "pyright-langserver",
+                args: &["--stdio"],
+                extension: "py",
+                config_name: "pyproject.toml",
+                config: include_str!(
+                    "../../../tests/fixtures/lsp_const_yield/python/pyproject.toml"
+                ),
+                sources: &[
+                    (
+                        "constants.py",
+                        include_str!("../../../tests/fixtures/lsp_const_yield/python/constants.py"),
+                    ),
+                    (
+                        "consumer.py",
+                        include_str!("../../../tests/fixtures/lsp_const_yield/python/consumer.py"),
+                    ),
+                ],
+                expect_enable: false,
+            },
+        ];
+
+        for case in cases {
+            if tokio::process::Command::new(case.server)
+                .arg("--version")
+                .output()
+                .await
+                .is_err()
+            {
+                panic!("{} is required for the #768 measurement probe", case.server);
+            }
+
+            let fixture = tempfile::tempdir().expect("create measurement fixture");
+            std::fs::write(fixture.path().join(case.config_name), case.config)
+                .expect("write fixture config");
+
+            let mut nodes = Vec::new();
+            for (relative_path, content) in case.sources {
+                let absolute_path = fixture.path().join(relative_path);
+                std::fs::create_dir_all(
+                    absolute_path
+                        .parent()
+                        .expect("fixture source has a parent directory"),
+                )
+                .expect("create fixture source directory");
+                std::fs::write(&absolute_path, content).expect("write fixture source");
+
+                let extracted = match case.language {
+                    "rust" => RustExtractor::new()
+                        .extract(std::path::Path::new(relative_path), content)
+                        .expect("extract Rust fixture"),
+                    "python" => PythonExtractor::new()
+                        .extract(std::path::Path::new(relative_path), content)
+                        .expect("extract Python fixture"),
+                    other => panic!("unsupported measurement fixture language: {other}"),
+                };
+                nodes.extend(extracted.nodes);
+            }
+
+            let mut enricher =
+                LspEnricher::new(case.language, case.server, case.args, &[case.extension])
+                    .with_declared_const_references(true);
+            enricher = match case.language {
+                "rust" => enricher.with_config_file("Cargo.toml"),
+                "python" => enricher
+                    .with_settings(python_init_settings())
+                    .with_config_file("pyproject.toml"),
+                _ => enricher,
+            };
+            let result = enricher
+                .enrich(&nodes, &GraphIndex::new(), fixture.path())
+                .await
+                .unwrap_or_else(|error| panic!("{} enrichment failed: {error}", case.server));
+
+            assert!(
+                !result.aborted,
+                "{} aborted: {:?}",
+                case.server, result.diagnostic
+            );
+            let const_metric = result
+                .lsp_query_metrics
+                .iter()
+                .find(|metric| {
+                    metric.operation == "references" && metric.declaration_class == "const"
+                })
+                .unwrap_or_else(|| panic!("{} emitted no Const telemetry", case.server));
+            let type_metric = result
+                .lsp_query_metrics
+                .iter()
+                .find(|metric| {
+                    metric.operation == "references" && metric.declaration_class == "struct"
+                })
+                .unwrap_or_else(|| panic!("{} emitted no Struct telemetry", case.server));
+
+            let const_edges = result
+                .added_edges
+                .iter()
+                .filter(|edge| {
+                    edge.kind == EdgeKind::ReferencedBy && edge.to.kind == NodeKind::Const
+                })
+                .collect::<Vec<_>>();
+            let expected_constants = ["RETRY_LIMIT", "TIMEOUT_MS", "DEFAULT_PORT", "FEATURE_FLAG"];
+            let expected_referrers = [
+                "local_retry_limit",
+                "local_timeout",
+                "local_port",
+                "local_feature",
+                "worker_retry_limit",
+                "worker_timeout",
+                "worker_port",
+                "worker_feature",
+                "make_config",
+                "worker_config",
+            ];
+
+            assert_eq!(
+                const_metric.scheduled_requests, 5,
+                "{} should measure exactly five declared constants",
+                case.server
+            );
+            let const_average_ms =
+                const_metric.latency_ms.max(1) / const_metric.scheduled_requests.max(1) as u64;
+            let type_average_ms =
+                type_metric.latency_ms.max(1) / type_metric.scheduled_requests.max(1) as u64;
+            let clears_threshold = const_metric.non_empty_responses * 100
+                >= const_metric.scheduled_requests * 80
+                && const_metric.emitted_edges >= const_metric.scheduled_requests
+                && const_metric.timeouts == 0
+                && const_metric.errors == 0
+                && const_average_ms <= type_average_ms.saturating_mul(2).max(2);
+            assert_eq!(
+                clears_threshold, case.expect_enable,
+                "{} eligibility decision changed: Const={const_metric:?}, Struct={type_metric:?}",
+                case.server
+            );
+
+            assert!(
+                const_edges
+                    .iter()
+                    .all(|edge| expected_constants.contains(&edge.to.name.as_str())),
+                "{} emitted a Const edge to an unexpected declaration: {const_edges:#?}",
+                case.server
+            );
+            assert!(
+                const_edges
+                    .iter()
+                    .all(|edge| expected_referrers.contains(&edge.from.name.as_str())),
+                "{} emitted a Const edge from an unexpected referrer: {const_edges:#?}",
+                case.server
+            );
+            assert!(
+                const_edges
+                    .iter()
+                    .all(|edge| edge.to.name != "UNUSED_SENTINEL"),
+                "{} emitted a spurious edge to the unused control constant",
+                case.server
+            );
+            if case.expect_enable {
+                for constant in expected_constants {
+                    assert!(
+                        const_edges.iter().any(|edge| edge.to.name == constant),
+                        "{} failed to emit a correct sampled edge for {constant}",
+                        case.server
+                    );
+                }
+            }
+
+            eprintln!(
+                "CONST_YIELD_RESULT language={} server={} eligible={} result_errors={} metrics={:#?} const_edges={:#?}",
+                case.language,
+                case.server,
+                clears_threshold,
+                result.error_count,
+                result.lsp_query_metrics,
+                const_edges
+            );
+        }
     }
 
     /// Verify that the quiescent readiness condition matches the rust-analyzer

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -3823,18 +3823,99 @@ mod tests {
             language: &'static str,
             server: &'static str,
             args: &'static [&'static str],
+            version_command: &'static str,
+            version_args: &'static [&'static str],
             extension: &'static str,
             config_name: &'static str,
             config: &'static str,
             sources: &'static [(&'static str, &'static str)],
+            expected_const_requests: usize,
+            expected_const_edges:
+                &'static [(&'static str, &'static str, &'static str, &'static str)],
             expect_enable: bool,
         }
+
+        const RUST_CONST_EDGES: &[(&str, &str, &str, &str)] = &[
+            (
+                "src/lib.rs",
+                "local_retry_limit",
+                "src/lib.rs",
+                "RETRY_LIMIT",
+            ),
+            ("src/lib.rs", "make_config", "src/lib.rs", "RETRY_LIMIT"),
+            (
+                "src/worker.rs",
+                "worker_retry_limit",
+                "src/lib.rs",
+                "RETRY_LIMIT",
+            ),
+            (
+                "src/worker.rs",
+                "worker_config",
+                "src/lib.rs",
+                "RETRY_LIMIT",
+            ),
+            ("src/lib.rs", "local_timeout", "src/lib.rs", "TIMEOUT_MS"),
+            (
+                "src/worker.rs",
+                "worker_timeout",
+                "src/lib.rs",
+                "TIMEOUT_MS",
+            ),
+            ("src/lib.rs", "local_port", "src/lib.rs", "DEFAULT_PORT"),
+            ("src/worker.rs", "worker_port", "src/lib.rs", "DEFAULT_PORT"),
+            ("src/lib.rs", "local_feature", "src/lib.rs", "FEATURE_FLAG"),
+            (
+                "src/worker.rs",
+                "worker_feature",
+                "src/lib.rs",
+                "FEATURE_FLAG",
+            ),
+            (
+                "src/lib.rs",
+                "local_static_timeout",
+                "src/lib.rs",
+                "STATIC_TIMEOUT_MS",
+            ),
+            (
+                "src/worker.rs",
+                "worker_static_timeout",
+                "src/lib.rs",
+                "STATIC_TIMEOUT_MS",
+            ),
+            (
+                "src/lib.rs",
+                "local_mutable_limit",
+                "src/lib.rs",
+                "MUTABLE_LIMIT",
+            ),
+            (
+                "src/worker.rs",
+                "worker_mutable_limit",
+                "src/lib.rs",
+                "MUTABLE_LIMIT",
+            ),
+            (
+                "src/lib.rs",
+                "local_associated_limit",
+                "src/lib.rs",
+                "ASSOCIATED_LIMIT",
+            ),
+            (
+                "src/worker.rs",
+                "worker_associated_limit",
+                "src/lib.rs",
+                "ASSOCIATED_LIMIT",
+            ),
+        ];
 
         let cases = [
             FixtureCase {
                 language: "rust",
                 server: "rust-analyzer",
                 args: &[],
+                version_command: "rust-analyzer",
+                version_args: &["--version"],
                 extension: "rs",
                 config_name: "Cargo.toml",
                 config: include_str!("../../../tests/fixtures/lsp_const_yield/rust/Cargo.toml"),
@@ -3848,12 +3929,16 @@ mod tests {
                         include_str!("../../../tests/fixtures/lsp_const_yield/rust/src/worker.rs"),
                     ),
                 ],
+                expected_const_requests: 8,
+                expected_const_edges: RUST_CONST_EDGES,
                 expect_enable: true,
             },
             FixtureCase {
                 language: "python",
                 server: "pyright-langserver",
                 args: &["--stdio"],
+                version_command: "pyright",
+                version_args: &["--version"],
                 extension: "py",
                 config_name: "pyproject.toml",
                 config: include_str!(
@@ -3869,19 +3954,30 @@ mod tests {
                         include_str!("../../../tests/fixtures/lsp_const_yield/python/consumer.py"),
                     ),
                 ],
+                expected_const_requests: 5,
+                expected_const_edges: &[],
                 expect_enable: false,
             },
         ];
 
         for case in cases {
-            if tokio::process::Command::new(case.server)
-                .arg("--version")
+            let version = tokio::process::Command::new(case.version_command)
+                .args(case.version_args)
                 .output()
                 .await
-                .is_err()
-            {
-                panic!("{} is required for the #768 measurement probe", case.server);
-            }
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "{} is required for the #768 measurement probe: {error}",
+                        case.version_command
+                    )
+                });
+            assert!(
+                version.status.success(),
+                "{} version command failed: {}",
+                case.version_command,
+                String::from_utf8_lossy(&version.stderr)
+            );
+            let version = String::from_utf8_lossy(&version.stdout).trim().to_string();
 
             let fixture = tempfile::tempdir().expect("create measurement fixture");
             std::fs::write(fixture.path().join(case.config_name), case.config)
@@ -3952,23 +4048,10 @@ mod tests {
                     edge.kind == EdgeKind::ReferencedBy && edge.to.kind == NodeKind::Const
                 })
                 .collect::<Vec<_>>();
-            let expected_constants = ["RETRY_LIMIT", "TIMEOUT_MS", "DEFAULT_PORT", "FEATURE_FLAG"];
-            let expected_referrers = [
-                "local_retry_limit",
-                "local_timeout",
-                "local_port",
-                "local_feature",
-                "worker_retry_limit",
-                "worker_timeout",
-                "worker_port",
-                "worker_feature",
-                "make_config",
-                "worker_config",
-            ];
 
             assert_eq!(
-                const_metric.scheduled_requests, 5,
-                "{} should measure exactly five declared constants",
+                const_metric.scheduled_requests, case.expected_const_requests,
+                "{} measured an unexpected declared-constant surface",
                 case.server
             );
             let const_average_ms =
@@ -3990,38 +4073,52 @@ mod tests {
             assert!(
                 const_edges
                     .iter()
-                    .all(|edge| expected_constants.contains(&edge.to.name.as_str())),
-                "{} emitted a Const edge to an unexpected declaration: {const_edges:#?}",
-                case.server
-            );
-            assert!(
-                const_edges
-                    .iter()
-                    .all(|edge| expected_referrers.contains(&edge.from.name.as_str())),
-                "{} emitted a Const edge from an unexpected referrer: {const_edges:#?}",
-                case.server
-            );
-            assert!(
-                const_edges
-                    .iter()
                     .all(|edge| edge.to.name != "UNUSED_SENTINEL"),
                 "{} emitted a spurious edge to the unused control constant",
                 case.server
             );
             if case.expect_enable {
-                for constant in expected_constants {
-                    assert!(
-                        const_edges.iter().any(|edge| edge.to.name == constant),
-                        "{} failed to emit a correct sampled edge for {constant}",
-                        case.server
-                    );
-                }
+                let actual_pairs = const_edges
+                    .iter()
+                    .map(|edge| {
+                        (
+                            edge.from.file.to_string_lossy().to_string(),
+                            edge.from.name.clone(),
+                            edge.to.file.to_string_lossy().to_string(),
+                            edge.to.name.clone(),
+                        )
+                    })
+                    .collect::<std::collections::BTreeSet<_>>();
+                let expected_pairs = case
+                    .expected_const_edges
+                    .iter()
+                    .map(|(from_file, from_name, to_file, to_name)| {
+                        (
+                            (*from_file).to_string(),
+                            (*from_name).to_string(),
+                            (*to_file).to_string(),
+                            (*to_name).to_string(),
+                        )
+                    })
+                    .collect::<std::collections::BTreeSet<_>>();
+                assert_eq!(
+                    const_edges.len(),
+                    expected_pairs.len(),
+                    "{} emitted duplicate or extra Const edges: {const_edges:#?}",
+                    case.server
+                );
+                assert_eq!(
+                    actual_pairs, expected_pairs,
+                    "{} Const edge mapping was not exactly correct",
+                    case.server
+                );
             }
 
             eprintln!(
-                "CONST_YIELD_RESULT language={} server={} eligible={} result_errors={} metrics={:#?} const_edges={:#?}",
+                "CONST_YIELD_RESULT language={} server={} version={:?} eligible={} result_errors={} metrics={:#?} const_edges={:#?}",
                 case.language,
                 case.server,
+                version,
                 clears_threshold,
                 result.error_count,
                 result.lsp_query_metrics,

--- a/src/extract/lsp/policy.rs
+++ b/src/extract/lsp/policy.rs
@@ -192,7 +192,6 @@ impl LspQueryProfile {
         self.allowed_kinds.as_ref()
     }
 
-    #[cfg(test)]
     pub(crate) fn with_declared_const_references(mut self, allow: bool) -> Self {
         self.allow_declared_const_references = allow;
         self
@@ -666,14 +665,7 @@ mod tests {
         ));
         telemetry.note_requests_started(1, 3);
         telemetry.note_requests_started(2, 2);
-        assert!(telemetry.record_work_item(
-            1,
-            1,
-            2,
-            Duration::from_millis(10),
-            0,
-            0,
-        ));
+        assert!(telemetry.record_work_item(1, 1, 2, Duration::from_millis(10), 0, 0,));
 
         telemetry.record_job_timeout();
         assert!(!telemetry.register_work_item(
@@ -681,14 +673,7 @@ mod tests {
             LspQueryOperation::References,
             LspDeclarationClass::Struct,
         ));
-        assert!(!telemetry.record_work_item(
-            2,
-            1,
-            1,
-            Duration::from_millis(60),
-            0,
-            0,
-        ));
+        assert!(!telemetry.record_work_item(2, 1, 1, Duration::from_millis(60), 0, 0,));
 
         let metrics = telemetry.snapshot();
         assert_eq!(metrics.len(), 1);

--- a/src/server/changed_file_plan.rs
+++ b/src/server/changed_file_plan.rs
@@ -477,12 +477,7 @@ mod tests {
         python_struct.language = "python".to_string();
         let mut python_function = node("src/changed.rs", "handler", NodeKind::Function);
         python_function.language = "python".to_string();
-        let nodes = vec![
-            synthetic,
-            declared_const,
-            python_struct,
-            python_function,
-        ];
+        let nodes = vec![synthetic, declared_const, python_struct, python_function];
 
         let plan = plan_changed_files(ChangedFilePlanInput {
             provenance: provenance(),
@@ -498,11 +493,23 @@ mod tests {
         })
         .unwrap();
 
-        assert_eq!(plan.planned_nodes.len(), 1);
-        assert!(plan.planned_nodes[0].stable_id.contains("handler"));
-        assert_eq!(
-            plan.planned_nodes[0].requested_operations,
-            vec!["call_hierarchy"]
+        assert_eq!(plan.planned_nodes.len(), 2);
+        let declared = plan
+            .planned_nodes
+            .iter()
+            .find(|node| node.stable_id.contains("DECLARED"))
+            .expect("measured rust-analyzer profile should admit declared constants");
+        assert_eq!(declared.requested_operations, vec!["references"]);
+        let handler = plan
+            .planned_nodes
+            .iter()
+            .find(|node| node.stable_id.contains("handler"))
+            .expect("Python function remains admitted");
+        assert_eq!(handler.requested_operations, vec!["call_hierarchy"]);
+        assert!(
+            plan.planned_nodes.iter().all(
+                |node| !node.stable_id.contains("literal") && !node.stable_id.contains("Model")
+            )
         );
     }
 

--- a/tests/fixtures/lsp_const_yield/python/constants.py
+++ b/tests/fixtures/lsp_const_yield/python/constants.py
@@ -1,0 +1,30 @@
+RETRY_LIMIT = 3
+TIMEOUT_MS = 250
+DEFAULT_PORT = 8080
+FEATURE_FLAG = True
+UNUSED_SENTINEL = 99
+
+
+class Config:
+    def __init__(self, retries: int) -> None:
+        self.retries = retries
+
+
+def local_retry_limit() -> int:
+    return RETRY_LIMIT
+
+
+def local_timeout() -> int:
+    return TIMEOUT_MS
+
+
+def local_port() -> int:
+    return DEFAULT_PORT
+
+
+def local_feature() -> bool:
+    return FEATURE_FLAG
+
+
+def make_config() -> Config:
+    return Config(RETRY_LIMIT)

--- a/tests/fixtures/lsp_const_yield/python/consumer.py
+++ b/tests/fixtures/lsp_const_yield/python/consumer.py
@@ -1,0 +1,21 @@
+from constants import Config, DEFAULT_PORT, FEATURE_FLAG, RETRY_LIMIT, TIMEOUT_MS
+
+
+def worker_retry_limit() -> int:
+    return RETRY_LIMIT
+
+
+def worker_timeout() -> int:
+    return TIMEOUT_MS
+
+
+def worker_port() -> int:
+    return DEFAULT_PORT
+
+
+def worker_feature() -> bool:
+    return FEATURE_FLAG
+
+
+def worker_config() -> Config:
+    return Config(RETRY_LIMIT)

--- a/tests/fixtures/lsp_const_yield/python/pyproject.toml
+++ b/tests/fixtures/lsp_const_yield/python/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "rna-lsp-const-yield-python"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[tool.pyright]
+include = ["."]

--- a/tests/fixtures/lsp_const_yield/rust/Cargo.toml
+++ b/tests/fixtures/lsp_const_yield/rust/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rna-lsp-const-yield-rust"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/tests/fixtures/lsp_const_yield/rust/src/lib.rs
+++ b/tests/fixtures/lsp_const_yield/rust/src/lib.rs
@@ -1,0 +1,43 @@
+pub mod worker;
+
+pub const RETRY_LIMIT: usize = 3;
+pub const TIMEOUT_MS: u64 = 250;
+pub const DEFAULT_PORT: u16 = 8080;
+pub const FEATURE_FLAG: bool = true;
+pub const UNUSED_SENTINEL: usize = 99;
+
+pub struct Config {
+    pub retries: usize,
+}
+
+pub trait Retryable {
+    fn retries(&self) -> usize;
+}
+
+impl Retryable for Config {
+    fn retries(&self) -> usize {
+        self.retries
+    }
+}
+
+pub fn local_retry_limit() -> usize {
+    RETRY_LIMIT
+}
+
+pub fn local_timeout() -> u64 {
+    TIMEOUT_MS
+}
+
+pub fn local_port() -> u16 {
+    DEFAULT_PORT
+}
+
+pub fn local_feature() -> bool {
+    FEATURE_FLAG
+}
+
+pub fn make_config() -> Config {
+    Config {
+        retries: RETRY_LIMIT,
+    }
+}

--- a/tests/fixtures/lsp_const_yield/rust/src/lib.rs
+++ b/tests/fixtures/lsp_const_yield/rust/src/lib.rs
@@ -5,9 +5,15 @@ pub const TIMEOUT_MS: u64 = 250;
 pub const DEFAULT_PORT: u16 = 8080;
 pub const FEATURE_FLAG: bool = true;
 pub const UNUSED_SENTINEL: usize = 99;
+pub static STATIC_TIMEOUT_MS: u64 = 500;
+pub static mut MUTABLE_LIMIT: usize = 7;
 
 pub struct Config {
     pub retries: usize,
+}
+
+impl Config {
+    pub const ASSOCIATED_LIMIT: usize = 11;
 }
 
 pub trait Retryable {
@@ -34,6 +40,18 @@ pub fn local_port() -> u16 {
 
 pub fn local_feature() -> bool {
     FEATURE_FLAG
+}
+
+pub fn local_static_timeout() -> u64 {
+    STATIC_TIMEOUT_MS
+}
+
+pub fn local_mutable_limit() -> usize {
+    unsafe { MUTABLE_LIMIT }
+}
+
+pub fn local_associated_limit() -> usize {
+    Config::ASSOCIATED_LIMIT
 }
 
 pub fn make_config() -> Config {

--- a/tests/fixtures/lsp_const_yield/rust/src/worker.rs
+++ b/tests/fixtures/lsp_const_yield/rust/src/worker.rs
@@ -1,0 +1,23 @@
+use crate::{Config, DEFAULT_PORT, FEATURE_FLAG, RETRY_LIMIT, TIMEOUT_MS};
+
+pub fn worker_retry_limit() -> usize {
+    RETRY_LIMIT
+}
+
+pub fn worker_timeout() -> u64 {
+    TIMEOUT_MS
+}
+
+pub fn worker_port() -> u16 {
+    DEFAULT_PORT
+}
+
+pub fn worker_feature() -> bool {
+    FEATURE_FLAG
+}
+
+pub fn worker_config() -> Config {
+    Config {
+        retries: RETRY_LIMIT,
+    }
+}

--- a/tests/fixtures/lsp_const_yield/rust/src/worker.rs
+++ b/tests/fixtures/lsp_const_yield/rust/src/worker.rs
@@ -1,4 +1,6 @@
-use crate::{Config, DEFAULT_PORT, FEATURE_FLAG, RETRY_LIMIT, TIMEOUT_MS};
+use crate::{
+    Config, DEFAULT_PORT, FEATURE_FLAG, MUTABLE_LIMIT, RETRY_LIMIT, STATIC_TIMEOUT_MS, TIMEOUT_MS,
+};
 
 pub fn worker_retry_limit() -> usize {
     RETRY_LIMIT
@@ -14,6 +16,18 @@ pub fn worker_port() -> u16 {
 
 pub fn worker_feature() -> bool {
     FEATURE_FLAG
+}
+
+pub fn worker_static_timeout() -> u64 {
+    STATIC_TIMEOUT_MS
+}
+
+pub fn worker_mutable_limit() -> usize {
+    unsafe { MUTABLE_LIMIT }
+}
+
+pub fn worker_associated_limit() -> usize {
+    Config::ASSOCIATED_LIMIT
 }
 
 pub fn worker_config() -> Config {


### PR DESCRIPTION
Closes #768

## Problem

RNA currently has no direct evidence that querying declared constants for LSP references produces sufficiently useful, correct graph edges to justify its warm-up cost and reliability risk. Synthetic constants are excluded, but enabling real declarations without measurements would replace one unsupported assumption with another.

## Chosen solution

Run a bounded, reproducible measurement over representative maintained fixtures for at least two supported language servers. Compare declared-constant request count, non-empty response rate, emitted edges, latency, timeout/error rate, and sampled edge correctness against Function, Trait where supported, and type-reference yield. State decision thresholds before interpreting results. Enable `Const` only in a per-server profile that clears every threshold; otherwise preserve the current disabled defaults and record the evidence and decision in repo-native metis.

## Workflow framing

- **Aim:** Agents receive useful constant-reference context only where measured evidence shows it is correct, reliable, and worth the query cost.
- **Problem-space:** LSP servers differ in reference support and latency; a global default is unsafe, synthetic constants remain categorically excluded, and real-server evidence is required.
- **Problem statement:** Maintainers need a bounded decision procedure for declared-constant enrichment because current telemetry can measure yield but no representative multi-server evidence establishes whether enabling it improves agent context.
- **Solution-space recommendation:** Prefer a measured per-profile decision over global enablement, intuition-only enablement, or permanent categorical exclusion.

## Acceptance plan

- [x] Select representative maintained fixtures covering at least two supported servers.
- [x] Measure request count, response yield, emitted edges, latency, errors/timeouts, and sampled correctness.
- [x] Compare with Function, Trait, and type-reference yield where useful.
- [x] Record explicit thresholds, measurements, and decision in repo-native metis.
- [x] Enable per-profile `Const` only if all thresholds clear; otherwise leave it disabled.
- [x] Complete review, real-server verification, CI, and delivery/comment audit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declared-constant references are now enriched only when a language/server profile meets yield, correctness, latency, and reliability thresholds (Rust analyzer opt-in).
  * Planning and query admission now admit eligible Rust constant references while excluding synthetic or unsupported items.
* **Bug Fixes**
  * Improved handling and messaging around reference enrichment and timeout-driven eligibility outcomes.
* **Documentation**
  * Updated guidance on declared-constant reference eligibility and added a reproducible probe procedure.
* **Tests**
  * Expanded Rust/Python fixture coverage and assertions for declared-constant reference behavior and thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
