### PR TITLE
Add benchmark-safe business_context=disabled without excluding repository docs

### DIFF
--- a/.oh/sessions/783-dev.md
+++ b/.oh/sessions/783-dev.md
@@ -8,8 +8,8 @@ updated: 2026-07-17
 
 # Dev Pipeline — benchmark-safe business context isolation
 
-**Issue:** #783  
-**Branch:** `issue/783`  
+**Issue:** #783
+**Branch:** `issue/783`
 **Base:** `bc3a73f5664a649267ba007bdef10ffaa9f921ac`
 
 ## Aim
@@ -18,22 +18,22 @@ updated: 2026-07-17
 
 **Current state:** RNA has independent extraction, persistence, embedding, reopen, and delivery seams for `.oh` artifacts and history-derived records, with no typed context policy spanning them. A Markdown-level switch would incorrectly remove normal project documentation.
 
-**Desired state:** `business_context=disabled` is observable, deterministic, and fail-closed across fresh and mixed persisted indexes; README, nested Markdown, RST, source, tests, and config remain available.
+**Desired state:** `business_context=disabled` is observable and deterministic across fresh scans and same-mode reopens; README, nested Markdown, RST, source, tests, and config remain available. A missing, legacy, invalid, or mismatched cache-mode marker causes the exact disposable repository cache/index to be deleted and rebuilt before any query is served.
 
 ### Mechanism
 
-Introduce one typed shared-service context mode and one centralized classification/filtering policy, thread it through scan and every benchmark query path, suppress excluded records before persistence and embedding, and reapply the policy at every delivery boundary.
+Introduce one typed context mode at the CLI/harness, enforce it at event admission by suppressing `.oh` business-artifact and Git history producers, and persist it with the disposable index identity/metadata. Existing consumers and query paths remain unchanged because they only open a mode-compatible index.
 
 ### Feedback
 
-An adversarial fixture with an identical sentinel in every content class returns ordinary docs/code/tests/config in exact, hybrid, semantic/reranked, batch, traversal, repo-map, and reopened-index queries while returning zero `.oh`, commit, PR-merge, or history-edge records. JSON diagnostics and benchmark manifests report `disabled` plus deterministic excluded counts.
+An adversarial fixture with an identical sentinel in every content class proves ordinary docs/code/tests/config still enter the event stream and survive fresh disabled scan plus same-mode reopen, while `.oh`, commit, PR-merge, and history-edge producer events are absent. A mismatched/legacy cache is deleted and rebuilt before query service. JSON diagnostics and benchmark manifests report `disabled` plus producer exclusion counts.
 
 ### Guardrails
 
 - Markdown/RST inclusion and LSP support are invariant; `include_markdown` remains independent.
 - Git may optimize filesystem change detection but contributes no history content in disabled mode.
 - Invalid CLI mode or explicit persisted provenance fails closed.
-- Apply computed-but-not-delivered across extraction, LanceDB, embeddings, CLI, and MCP-visible rendering.
+- Treat indexes as disposable derived data: incompatible mode metadata is never read or sanitized in place.
 - No language-specific conditionals in generic extraction.
 
 ## Problem Space
@@ -48,7 +48,7 @@ Create a trustworthy experimental isolation boundary, not merely a CLI presentat
 |---|---|---|---|
 | Ordinary Markdown/RST/docs remain indexed | hard | Removing them changes the benchmark repository | No |
 | `.oh`, commit/PR nodes, and history edges are absent | hard | They are the isolated treatment variable | No |
-| Mixed indexes must remain safe | hard | Reopen/query can observe data written by an enabled run | No |
+| Mismatched/legacy indexes must be discarded before query | hard | A query path must only observe a mode-compatible index | No |
 | Invalid mode/provenance fails closed | hard | Silent enablement invalidates evidence | No |
 | Git remains scanner optimization | hard | Non-git directories must still scan | No |
 | Shared service prevents CLI/MCP drift | hard | Multiple delivery paths already exist | No |
@@ -60,16 +60,16 @@ Create a trustworthy experimental isolation boundary, not merely a CLI presentat
 - Scan/build and incremental graph paths in `src/server/graph.rs` and `src/scanner.rs`.
 - Node and edge `ExtractionSource` provenance in `src/graph/mod.rs`.
 - Full/incremental LanceDB write and reopen in `src/server/store/`.
-- Shared search, batch, traversal, and repo-map rendering in `src/service/`.
-- Embedding/hybrid/rerank paths in `src/embed/`.
+- EventBus/`BusOptions` admission and the consumers that receive extraction events.
+- Disposable cache/index identity and lifecycle checks before reopen.
 - `.oh` loading and automatic preamble injection in `src/oh/` and `src/server/mod.rs`.
 - Git/PR-merge extraction and persistence in `src/git/` and graph stores.
 
 ### Assumptions Made Explicit
 
-1. `.oh` path components and `ExtractionSource::Git` are the authoritative excluded classes; edge endpoint filtering is also required so dangling relationships cannot leak.
-2. Missing legacy provenance may retain the documented TreeSitter compatibility default, but an explicit unknown persisted value is corruption and must error rather than become TreeSitter.
-3. A delivery filter remains mandatory even when extraction/persistence are correct because users can reopen a copied or pre-existing mixed cache.
+1. Producer type is the authoritative isolation boundary: disabled mode does not emit `.oh` business-artifact events or Git commit/PR/history events.
+2. Ordinary Markdown/RST/source/test/config producers remain unchanged, even when their bodies contain the same adversarial term as excluded content.
+3. The graph, LanceDB, embedding, and query layers consume only a mode-compatible index. Missing, legacy, invalid, or mismatched mode metadata is a cache miss that deletes and rebuilds the exact disposable repository cache.
 
 ### X-Y Check
 
@@ -77,7 +77,7 @@ The request names a CLI flag, but the underlying need is experimental context is
 
 ## Problem Statement
 
-Benchmark operators need RNA queries whose candidate universe excludes repo-native business/history records without excluding normal repository content, but today no shared typed policy controls all producers, stores, embeddings, and renderers. The solution must therefore establish a lifecycle-wide isolation boundary with fail-closed delivery, rather than reinterpret Markdown inclusion.
+Benchmark operators need RNA queries whose candidate universe excludes repo-native business/history records without excluding normal repository content. The narrow boundary is producer admission plus disposable-index compatibility: prevent excluded events from entering a disabled build and rebuild any incompatible cache before serving queries.
 
 ## Solution Space
 
@@ -85,34 +85,75 @@ Benchmark operators need RNA queries whose candidate universe excludes repo-nati
 |---|---|---|---|
 | A | Band-aid | Add `--business-context` in `main.rs` and filter printed CLI rows | Mixed indexes, embeddings, repo-map, and alternate renderers still leak |
 | B | Local optimum | Exclude `.oh` and Git extraction during scan only | Pre-existing persisted rows and query-time paths still leak |
-| C | Reframe | Shared typed policy applied at extraction, persistence/reopen, embeddings, and delivery | Wider signature threading and focused compatibility work |
-| D | Redesign | Separate enabled/disabled cache namespaces | Storage duplication; still needs classification and fail-closed validation |
+| C | Reframe | Shared typed policy applied at extraction, persistence/reopen, embeddings, and delivery | Rejected: duplicates policy across many consumers and query paths |
+| D | Redesign | Producer admission plus mode-compatible disposable cache lifecycle | Narrow seam; incompatible caches rebuild instead of being sanitized |
 
 ### Recommendation
 
-**Selected:** Option C — shared typed lifecycle policy.
+**Selected:** Option D — producer admission plus mode-compatible disposable cache lifecycle.
 
-Define `BusinessContextMode::{Enabled, Disabled}` in the shared service layer with strict parsing and a centralized policy that classifies nodes and edges, filters complete `GraphState` snapshots, and returns structured exclusion counts. Pass it explicitly through scan and all benchmark query commands. In disabled mode:
+Define strict `BusinessContextMode::{Enabled, Disabled}` parsing at the CLI/harness. In disabled mode:
 
-1. Add `.oh` as an exact path-component scanner exclusion without changing Markdown/RST extraction.
-2. Skip Git/PR-merge content extraction while preserving Git-backed change detection.
-3. Filter nodes and edges immediately before all full/incremental persistence and embedding writes.
-4. Filter mixed graph snapshots on LanceDB reopen and again at search/batch/traversal/repo-map delivery boundaries.
+1. Do not emit `.oh` business-artifact events.
+2. Do not launch or emit Git commit, PR-merge, or history-edge producers; preserve Git-backed filesystem change detection.
+3. Let existing graph, LanceDB, embedding, and query consumers process the remaining event stream unchanged.
+4. Persist the selected mode in cache/index identity or metadata. Same-mode reopen is allowed; missing, legacy, invalid, or mismatched mode deletes the exact disposable repository cache/index and rebuilds before any query is served.
 5. Suppress the automatic business-context preamble.
-6. Render the selected mode and excluded node/edge/artifact/history counts in operation/capability JSON and benchmark manifests.
-7. Reject invalid mode values and explicit unknown persisted node or edge provenance.
+6. Render the selected mode and producer exclusion counts in operation/capability JSON and benchmark manifests.
 
-The duplicated delivery checks are intentional defense in depth: producer hygiene keeps disabled indexes clean, while consumer filtering makes copied/mixed indexes safe.
+There are deliberately no filters in search, source-span, batch, graph traversal, repo-map, outcome-progress, persistence, embedding, or reranking paths.
 
 ### Verification Strategy
 
-- Unit tests for strict mode parsing, exact `.oh` path classification, Git node/edge classification, endpoint filtering, counts, and invalid provenance.
+- Unit tests for strict mode parsing, producer admission, preamble suppression, mode metadata validation, and exact cache deletion/rebuild behavior.
 - Adversarial fixture with one sentinel in `.oh`, commit/PR/history data, README, nested `.md`, arbitrary `.md`, `.rst`, source, tests, and config.
-- Fresh disabled scan plus exact/keyword/hybrid/semantic/reranked queries.
-- Batch lookup and neighbors/impact traversal rooted both inside and outside excluded subgraphs.
-- Enabled scan followed by disabled reopen/query to prove mixed-cache filtering.
+- Fresh disabled scan plus exact/keyword/hybrid/semantic/reranked queries against the compatible index.
+- Same-mode persisted reopen.
+- Enabled/legacy/invalid cache opened as disabled causes exact cache deletion and rebuild before query.
 - Repo-map and capability/diagnostic JSON assertions.
 - Real CLI verification and real MCP SDK smoke for any changed MCP-visible delivery path.
+
+## Salvage
+
+**Updated:** 2026-07-17
+**Outcome:** Useful discovery preserved; the no-patch execution attempt is discarded and implementation resumes from one falsifiable vertical slice.
+
+### Salvage Report
+
+**Reason:** The serial execute sub-agent completed seam discovery but stalled before producing any implementation patch.
+**Original Aim:** Make `business_context=disabled` a lifecycle-wide, fail-closed isolation boundary while retaining ordinary repository content.
+
+#### Learnings
+
+1. The isolated full scan and RNA source spans produced a reliable seam map; repeating framing or scanning would add delay, not evidence.
+2. Delegating the entire lifecycle-wide change as one implementation step was too broad to produce a checkable patch.
+3. The compiler-driven path starts with a strict shared mode, centralized graph classifier/sanitizer, and explicit handler/load fields; downstream producer and renderer wiring can then follow concrete errors.
+
+#### New Guardrails
+
+- **Guardrail:** Do not redo the completed aim/problem/solution sequence, draft PR, or isolated full scan.
+  **Reason:** Those artifacts are settled and independently useful.
+  **Trigger:** Revisit only if implementation falsifies a framing assumption.
+- **Guardrail:** Do not delegate another broad execute pass before a local vertical slice compiles.
+  **Reason:** The stalled attempt returned mapping but no code.
+  **Trigger:** Revisit only for a bounded independent review or test task.
+
+#### Missing Context
+
+No new domain context was missing. The failure was execution granularity: constructor, load, persistence, search, source-span, repo-map, preamble, and embedding seams were identified but not ordered into a minimal compiling slice.
+
+#### Local Practices
+
+For cross-cutting Rust policy changes, land the shared type and sanitizer first, wire one handler/load boundary, and use `cargo check --lib` to turn remaining propagation into a finite queue.
+
+#### Reusable Fragments
+
+- Full-scan evidence: 36,006 symbols, 102,050 edges, 577 files, with a known TypeScript LSP quiescence degradation tracked separately by #781.
+- Seam map: `src/service/`, `src/server/state.rs`, `src/server/store/`, `src/server/graph.rs`, `src/service/search.rs`, `src/service/repomap.rs`, `src/server/mod.rs`, `src/main.rs`, and embedding persistence/query boundaries.
+
+#### Fresh Start Recommendation
+
+Implement and test one falsifiable slice: strict `BusinessContextMode` parsing plus centralized node/edge filtering that rebuilds `GraphState`, then wire it through `RnaHandler` and LanceDB reopen. The slice passes when unit tests prove `.oh`/Git records are excluded, ordinary Markdown survives, explicit unknown persisted provenance errors, and `cargo check --lib` succeeds.
 
 ## RNA Tool Friction Log
 
@@ -124,3 +165,58 @@ The duplicated delivery checks are intentional defense in depth: producer hygien
 | framing | RNA CLI source span | An initial JSON span exceeded the file's 20 lines | Narrowed the RNA request to the reported bound | minor |
 
 No Grep/Read/raw-file fallback was used for code navigation during framing.
+
+## Architecture Override Salvage
+
+**Updated:** 2026-07-17
+**Outcome:** The mixed-index/delivery-filter implementation is discarded. Event-bus discovery, fixture design, typed mode/harness work, and direct preamble coverage seed a narrow restart.
+
+### Salvage Report
+
+**Reason:** The implementation grew to roughly 1,586 insertions across 28 tracked files because it treated mixed-index sanitization as a requirement. The user explicitly rejected that premise and authorized disposable-index rebuild behavior.
+**Original Aim:** Let benchmark operators remove RNA business and Git-history context while retaining ordinary repository content.
+
+#### Learnings
+
+1. I thought disabled mode had to safely read an enabled/mixed index, but the index is disposable derived data and may be deleted and rebuilt on any mode incompatibility.
+2. Event admission is the stable architecture boundary: `.oh` artifacts and Git history have distinct producers, while ordinary Markdown/RST/source/test/config records flow through independent producers.
+3. Once cache compatibility is validated before reopen, existing persistence, embedding, exact/hybrid/rerank, source-span, batch, traversal, repo-map, and outcome-progress consumers need no policy awareness.
+4. The adversarial identical-term fixture remains valuable because it proves isolation is based on producer provenance, not text matching.
+
+#### New Guardrails
+
+- **Guardrail:** Do not sanitize incompatible business-context indexes in place.
+  **Reason:** The cache is disposable; lifecycle invalidation is simpler and prevents scattered delivery policy.
+  **Trigger:** Revisit only if an index becomes authoritative or non-rebuildable.
+- **Guardrail:** Business-context policy belongs at producer admission and cache compatibility, not query rendering.
+  **Reason:** Query-layer filters duplicate logic and expand the correctness surface.
+  **Trigger:** Revisit only if a new excluded source bypasses EventBus admission.
+- **Guardrail:** Delete only the exact repository cache/index after validating its path and incompatibility.
+  **Reason:** Rebuild is safe only when deletion scope is precise and derived-data-only.
+  **Trigger:** Every missing, legacy, invalid, or mismatched mode marker.
+
+#### Missing Context
+
+The initial framing treated “mixed indexes must remain safe” as a hard acceptance criterion instead of asking whether the index was disposable. Establishing cache authority and rebuild cost upfront would have selected the narrower design.
+
+#### Local Practices
+
+For optional producer classes in an event-driven indexer, first test whether admission plus cache identity can enforce the invariant. Do not thread policy through every downstream consumer unless incompatible snapshots must remain readable.
+
+#### Reusable Fragments
+
+- EventBus/`BusOptions` seam mapping for `.oh` artifact events, Git history extraction, and existing consumers.
+- Typed `BusinessContextMode` CLI/harness parsing and explicit disabled-mode proxy launch.
+- Benchmark manifest diagnostics for mode and excluded producer counts.
+- Adversarial fixture covering `.oh`, README, docs, arbitrary Markdown/RST, source, tests, and config with one shared term.
+- Direct automatic-preamble suppression test.
+
+#### Fresh Start Recommendation
+
+Restore the sprawling uncommitted implementation, retain this session note and focused fixtures/harness insights, then implement only: typed mode, producer admission/counting, cache mode metadata with exact invalidation/rebuild, preamble suppression, diagnostics/manifests, and fresh/same-mode/mismatch lifecycle tests.
+
+### Additional RNA Tool Friction
+
+| Phase | Tool | What happened | Workaround | Severity |
+|---|---|---|---|---|
+| review | RNA CLI incremental persist | The refresh extracted current symbols but Lance incremental merge failed on an ambiguous `tested_by` insert; the resulting index also retained degraded partial LSP coverage | Recorded the degraded state and used RNA exact source spans/diff review without raw code-search fallback | minor |

--- a/.oh/sessions/783-dev.md
+++ b/.oh/sessions/783-dev.md
@@ -220,3 +220,54 @@ Restore the sprawling uncommitted implementation, retain this session note and f
 | Phase | Tool | What happened | Workaround | Severity |
 |---|---|---|---|---|
 | review | RNA CLI incremental persist | The refresh extracted current symbols but Lance incremental merge failed on an ambiguous `tested_by` insert; the resulting index also retained degraded partial LSP coverage | Recorded the degraded state and used RNA exact source spans/diff review without raw code-search fallback | minor |
+| broad test | RNA CLI source span | After the full library suite, the working-repo cache was unavailable and RNA returned “No index found” for the single failing test span | Used one bounded `git show` source fallback to inspect the unchanged assertion before applying the narrow error-contract fix | minor |
+
+## Execute Restart
+
+**Updated:** 2026-07-17
+**Status:** complete
+
+### Pre-flight
+
+- [x] **Aim is clear:** benchmark operators can disable RNA business/history producers while ordinary repository content remains unchanged.
+- [x] **Constraints are known:** producer admission plus exact disposable-cache compatibility; no query/delivery filters; serial Cargo; protected workspace paths untouched.
+- [x] **Context is loaded:** a clean git-archive RNA scan mapped `TreeSitterConsumer`, `BusOptions`, full/incremental graph extraction, the PR-history producer, independent embedding history producers, cache migration, preamble injection, operation reports, and harness entry points.
+- [x] **Scope is bounded:** typed mode, producer admission/counts, cache marker/invalidation/rebuild, preamble suppression, diagnostics/manifests, and lifecycle tests only.
+- [x] **Success criteria are explicit:** fresh disabled scan and same-mode reopen contain baseline-supported Markdown/source/test/config while ordinary RST remains admitted and uncounted; neither graph contains `.oh` or Git-history content; missing/invalid/mismatched markers delete the exact repo cache and rebuild before query; query consumers remain policy-free.
+
+### Explicit Non-goals
+
+No changes to search/source-span/batch/traversal/repo-map/outcome-progress filtering, GraphState sanitization, persisted provenance parsing, Lance row schemas, language extractors, or in-place mixed-index compatibility.
+
+### Restart RNA Friction
+
+The working-repo RNA cache retained discarded symbols after an incremental-persist ambiguity. A fresh extract-only scan of a temporary `git archive` supplied current source spans; no raw code-search fallback was used.
+
+## Review
+
+**Updated:** 2026-07-17
+**Verdict:** ALIGNED
+
+- **Necessary:** benchmark runs otherwise consume repo-native `.oh` and Git-history context that changes the comparison universe.
+- **Aligned:** isolation is enforced at producer admission and disposable-cache compatibility; no service/result filters were added.
+- **Sufficient:** one typed mode, one shared admission policy, one exact cache marker, and existing OperationReport/manifests carry diagnostics.
+- **Mechanism clear:** disabled producers cannot create excluded records, and incompatible caches are deleted and rebuilt before cache-backed queries read them.
+- **Changes complete:** fresh/reopen/mismatch/legacy lifecycles, direct CLI query dispatch, preamble suppression, diagnostics, ordinary supported-file search/traversal, and RST non-exclusion are covered. Baseline RST extraction/LSP and paid hybrid/rerank proof remain explicitly deferred to #784/#785.
+
+No unresolved in-scope drift remains. The bounded live-read sweep found existing `stats`/`outcome-progress` behavior outside the frozen producer/cache contract; the architecture override intentionally leaves service/query consumers unchanged.
+
+## Final Verification
+
+**Updated:** 2026-07-17
+**Status:** green
+
+- Issue-owned Rust formatting and `git diff --check` passed. Repository-wide `cargo fmt --all -- --check` remains blocked only by unrelated pre-existing formatting drift outside #783's paths and wrote no changes.
+- Python byte-compilation passed; `scripts/tests/test_swebench_rna_one.py` passed 15/15.
+- `cargo check` passed for the library, binary, and embeddings feature.
+- `cargo clippy -- -D warnings` passed for the library, binary, and embeddings feature.
+- Full `cargo test --tests` passed: library 2053 passed/4 ignored, binary 5 passed, business-context isolation 2 passed, CLI exit contract 1 passed, and content-source contract 1 passed.
+- `cargo test --doc` passed with 12 ignored examples and no failures.
+- Invalid CLI business-context input failed closed with the expected `enabled or disabled` diagnostic.
+- No model, embedding-runtime, benchmark, or paid API call was made.
+
+Implementation is ready for the mandatory fresh final-diff review. The draft PR must remain unmerged until that independent approval is recorded on the final commit.

--- a/.oh/sessions/783-dev.md
+++ b/.oh/sessions/783-dev.md
@@ -1,0 +1,126 @@
+---
+session: "783-dev"
+artifact_type: session
+issue: 783
+outcome: context-assembly
+updated: 2026-07-17
+---
+
+# Dev Pipeline — benchmark-safe business context isolation
+
+**Issue:** #783  
+**Branch:** `issue/783`  
+**Base:** `bc3a73f5664a649267ba007bdef10ffaa9f921ac`
+
+## Aim
+
+**Aim:** Benchmark builders can explicitly remove RNA-specific business and Git-history context while continuing to discover, rank, traverse, embed, and LSP-enrich ordinary repository documentation and code.
+
+**Current state:** RNA has independent extraction, persistence, embedding, reopen, and delivery seams for `.oh` artifacts and history-derived records, with no typed context policy spanning them. A Markdown-level switch would incorrectly remove normal project documentation.
+
+**Desired state:** `business_context=disabled` is observable, deterministic, and fail-closed across fresh and mixed persisted indexes; README, nested Markdown, RST, source, tests, and config remain available.
+
+### Mechanism
+
+Introduce one typed shared-service context mode and one centralized classification/filtering policy, thread it through scan and every benchmark query path, suppress excluded records before persistence and embedding, and reapply the policy at every delivery boundary.
+
+### Feedback
+
+An adversarial fixture with an identical sentinel in every content class returns ordinary docs/code/tests/config in exact, hybrid, semantic/reranked, batch, traversal, repo-map, and reopened-index queries while returning zero `.oh`, commit, PR-merge, or history-edge records. JSON diagnostics and benchmark manifests report `disabled` plus deterministic excluded counts.
+
+### Guardrails
+
+- Markdown/RST inclusion and LSP support are invariant; `include_markdown` remains independent.
+- Git may optimize filesystem change detection but contributes no history content in disabled mode.
+- Invalid CLI mode or explicit persisted provenance fails closed.
+- Apply computed-but-not-delivered across extraction, LanceDB, embeddings, CLI, and MCP-visible rendering.
+- No language-specific conditionals in generic extraction.
+
+## Problem Space
+
+### Objective
+
+Create a trustworthy experimental isolation boundary, not merely a CLI presentation filter.
+
+### Constraints
+
+| Constraint | Type | Reason | Question? |
+|---|---|---|---|
+| Ordinary Markdown/RST/docs remain indexed | hard | Removing them changes the benchmark repository | No |
+| `.oh`, commit/PR nodes, and history edges are absent | hard | They are the isolated treatment variable | No |
+| Mixed indexes must remain safe | hard | Reopen/query can observe data written by an enabled run | No |
+| Invalid mode/provenance fails closed | hard | Silent enablement invalidates evidence | No |
+| Git remains scanner optimization | hard | Non-git directories must still scan | No |
+| Shared service prevents CLI/MCP drift | hard | Multiple delivery paths already exist | No |
+| Single shared checkout, serial Cargo | hard | Repository workflow and cache safety | No |
+
+### Terrain
+
+- CLI command structs and dispatch in `src/main.rs`.
+- Scan/build and incremental graph paths in `src/server/graph.rs` and `src/scanner.rs`.
+- Node and edge `ExtractionSource` provenance in `src/graph/mod.rs`.
+- Full/incremental LanceDB write and reopen in `src/server/store/`.
+- Shared search, batch, traversal, and repo-map rendering in `src/service/`.
+- Embedding/hybrid/rerank paths in `src/embed/`.
+- `.oh` loading and automatic preamble injection in `src/oh/` and `src/server/mod.rs`.
+- Git/PR-merge extraction and persistence in `src/git/` and graph stores.
+
+### Assumptions Made Explicit
+
+1. `.oh` path components and `ExtractionSource::Git` are the authoritative excluded classes; edge endpoint filtering is also required so dangling relationships cannot leak.
+2. Missing legacy provenance may retain the documented TreeSitter compatibility default, but an explicit unknown persisted value is corruption and must error rather than become TreeSitter.
+3. A delivery filter remains mandatory even when extraction/persistence are correct because users can reopen a copied or pre-existing mixed cache.
+
+### X-Y Check
+
+The request names a CLI flag, but the underlying need is experimental context isolation across the complete data lifecycle. Confidence is high that the issue acceptance criteria already state the underlying need.
+
+## Problem Statement
+
+Benchmark operators need RNA queries whose candidate universe excludes repo-native business/history records without excluding normal repository content, but today no shared typed policy controls all producers, stores, embeddings, and renderers. The solution must therefore establish a lifecycle-wide isolation boundary with fail-closed delivery, rather than reinterpret Markdown inclusion.
+
+## Solution Space
+
+| Option | Level | Approach | Main trade-off |
+|---|---|---|---|
+| A | Band-aid | Add `--business-context` in `main.rs` and filter printed CLI rows | Mixed indexes, embeddings, repo-map, and alternate renderers still leak |
+| B | Local optimum | Exclude `.oh` and Git extraction during scan only | Pre-existing persisted rows and query-time paths still leak |
+| C | Reframe | Shared typed policy applied at extraction, persistence/reopen, embeddings, and delivery | Wider signature threading and focused compatibility work |
+| D | Redesign | Separate enabled/disabled cache namespaces | Storage duplication; still needs classification and fail-closed validation |
+
+### Recommendation
+
+**Selected:** Option C — shared typed lifecycle policy.
+
+Define `BusinessContextMode::{Enabled, Disabled}` in the shared service layer with strict parsing and a centralized policy that classifies nodes and edges, filters complete `GraphState` snapshots, and returns structured exclusion counts. Pass it explicitly through scan and all benchmark query commands. In disabled mode:
+
+1. Add `.oh` as an exact path-component scanner exclusion without changing Markdown/RST extraction.
+2. Skip Git/PR-merge content extraction while preserving Git-backed change detection.
+3. Filter nodes and edges immediately before all full/incremental persistence and embedding writes.
+4. Filter mixed graph snapshots on LanceDB reopen and again at search/batch/traversal/repo-map delivery boundaries.
+5. Suppress the automatic business-context preamble.
+6. Render the selected mode and excluded node/edge/artifact/history counts in operation/capability JSON and benchmark manifests.
+7. Reject invalid mode values and explicit unknown persisted node or edge provenance.
+
+The duplicated delivery checks are intentional defense in depth: producer hygiene keeps disabled indexes clean, while consumer filtering makes copied/mixed indexes safe.
+
+### Verification Strategy
+
+- Unit tests for strict mode parsing, exact `.oh` path classification, Git node/edge classification, endpoint filtering, counts, and invalid provenance.
+- Adversarial fixture with one sentinel in `.oh`, commit/PR/history data, README, nested `.md`, arbitrary `.md`, `.rst`, source, tests, and config.
+- Fresh disabled scan plus exact/keyword/hybrid/semantic/reranked queries.
+- Batch lookup and neighbors/impact traversal rooted both inside and outside excluded subgraphs.
+- Enabled scan followed by disabled reopen/query to prove mixed-cache filtering.
+- Repo-map and capability/diagnostic JSON assertions.
+- Real CLI verification and real MCP SDK smoke for any changed MCP-visible delivery path.
+
+## RNA Tool Friction Log
+
+| Phase | Tool | What happened | Workaround | Severity |
+|---|---|---|---|---|
+| framing | RNA MCP | MCP tools were not exposed in this agent session | Used installed `repo-native-alignment 0.2.10` CLI as the mandatory fallback | skipped |
+| framing | RNA CLI cache | Cache reflected the prior branch, reported schema v23/degraded TypeScript LSP, and had no embedding index | Diagnosed the stale state; used exact current-filesystem source spans and will run the required fresh full scan before code | minor |
+| framing | RNA CLI body retrieval | `--include-body` rejects file-scoped requests | Retried with discovered stable node IDs; no raw source fallback | minor |
+| framing | RNA CLI source span | An initial JSON span exceeded the file's 20 lines | Narrowed the RNA request to the reported bound | minor |
+
+No Grep/Read/raw-file fallback was used for code navigation during framing.

--- a/.oh/sessions/783-dev.md
+++ b/.oh/sessions/783-dev.md
@@ -246,28 +246,72 @@ The working-repo RNA cache retained discarded symbols after an incremental-persi
 ## Review
 
 **Updated:** 2026-07-17
-**Verdict:** ALIGNED
+**Verdict:** ALIGNED AFTER BOUNDED ADJUSTMENT
 
-- **Necessary:** benchmark runs otherwise consume repo-native `.oh` and Git-history context that changes the comparison universe.
-- **Aligned:** isolation is enforced at producer admission and disposable-cache compatibility; no service/result filters were added.
-- **Sufficient:** one typed mode, one shared admission policy, one exact cache marker, and existing OperationReport/manifests carry diagnostics.
-- **Mechanism clear:** disabled producers cannot create excluded records, and incompatible caches are deleted and rebuilt before cache-backed queries read them.
-- **Changes complete:** fresh/reopen/mismatch/legacy lifecycles, direct CLI query dispatch, preamble suppression, diagnostics, ordinary supported-file search/traversal, and RST non-exclusion are covered. Baseline RST extraction/LSP and paid hybrid/rerank proof remain explicitly deferred to #784/#785.
+This review supersedes the pre-dissent `ALIGNED`/complete claim. Dissent found
+three producer-boundary bypass classes that invalidated that earlier claim:
 
-No unresolved in-scope drift remains. The bounded live-read sweep found existing `stats`/`outcome-progress` behavior outside the frozen producer/cache contract; the architecture override intentionally leaves service/query consumers unchanged.
+1. live `outcome_progress`, `repo_map`, and `search --include-markdown` reads
+   could produce business context outside the cache-backed graph;
+2. foreground enrichment and the incremental graph fallback invoked the
+   enabled-default embedding wrapper instead of the handler's admission; and
+3. the harness certified business-context diagnostics from aggregate logs, so
+   one phase could satisfy another phase's evidence requirement.
+
+The bounded remediation now applies the existing mode/admission only where
+those producers are invoked. `outcome_progress` stops before its direct outcome
+and Git-history load, `repo_map` skips only its direct outcome load, and live
+Markdown chunks pass through the shared repository-file admission predicate.
+Both full embedding call sites pass the existing admission. Harness validation
+requires independent scan and, when launched, embedding diagnostics before
+aggregating counts. No `GraphState`, result, traversal, rendering, persistence,
+reranking, or schema filter was added.
+
+The post-remediation bounded `/review` returned `ADJUST` only for two
+formatting-only smoke-test hunks and this stale session evidence. The smoke-test
+formatting was restored while retaining its required admission field, and this
+record now reflects the post-dissent state. No architecture or scope drift was
+found. Baseline RST extraction/LSP and paid hybrid/rerank proof remain deferred
+to #784/#785.
 
 ## Final Verification
 
 **Updated:** 2026-07-17
 **Status:** green
 
-- Issue-owned Rust formatting and `git diff --check` passed. Repository-wide `cargo fmt --all -- --check` remains blocked only by unrelated pre-existing formatting drift outside #783's paths and wrote no changes.
-- Python byte-compilation passed; `scripts/tests/test_swebench_rna_one.py` passed 15/15.
-- `cargo check` passed for the library, binary, and embeddings feature.
-- `cargo clippy -- -D warnings` passed for the library, binary, and embeddings feature.
-- Full `cargo test --tests` passed: library 2053 passed/4 ignored, binary 5 passed, business-context isolation 2 passed, CLI exit contract 1 passed, and content-source contract 1 passed.
-- `cargo test --doc` passed with 12 ignored examples and no failures.
-- Invalid CLI business-context input failed closed with the expected `enabled or disabled` diagnostic.
-- No model, embedding-runtime, benchmark, or paid API call was made.
+This section supersedes the earlier green/final-verification claim because the
+dissent remediation changed the diff after that evidence was recorded.
 
-Implementation is ready for the mandatory fresh final-diff review. The draft PR must remain unmerged until that independent approval is recorded on the final commit.
+- `cargo check --lib` and `cargo check --bin repo-native-alignment` passed.
+- Library and business-context integration test targets compiled with
+  `--no-run`.
+- Focused Rust regressions passed for single-file `.oh` admission, direct
+  outcome-progress/repo-map producer suppression, and live Markdown isolation.
+- The embeddings-feature regression passed with empty symbols, recorded both
+  disabled Git-history producer decisions, and returned before model loading.
+- Python byte-compilation passed; `scripts/tests/test_swebench_rna_one.py`
+  passed 16/16, including phase-specific scan/embedding certification.
+- No model, embedding-runtime, benchmark, credential, or paid API call was
+  made.
+
+Serialized broad verification also passed on the adjusted diff:
+
+- targeted issue-owned Rust formatting and `git diff --check` passed;
+- `cargo check` and strict `cargo clippy -- -D warnings` passed for the library,
+  binary, embeddings library, and embeddings binary;
+- `cargo test --tests` passed: library 2056 passed/4 ignored, binary 5 passed,
+  business-context isolation 3 passed, CLI exit contract 1 passed, and
+  content-source contract 1 passed;
+- `cargo test --doc` passed with 12 ignored examples and no failures; and
+- invalid `--business-context` input exited 2 with the expected
+  `enabled or disabled` diagnostic.
+
+Implementation is ready for the remediation commit and draft-PR evidence. The
+draft PR remains unmerged and must not be marked ready by this bounded task.
+
+### Post-Dissent RNA Friction
+
+| Phase | Tool | What happened | Workaround | Severity |
+|---|---|---|---|---|
+| remediation | installed RNA CLI | RNA MCP was unavailable and the installed CLI reported no index for the working repository even after broader unfiltered queries | Built an extract-only disposable index from the exact `11d5b140` archive and used RNA exact symbols/source spans for producer mapping | minor |
+| bounded review | RNA CLI plus current diff | The disposable exact-head index necessarily did not contain the uncommitted remediation | Used the RNA-mapped base context plus the bounded raw `git diff` as the authoritative current-change fallback; no raw source-search loop was used | minor |

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ CLI and MCP share the same index. Run `scan --full` from the CLI to build the co
 | `search <query>` | Search symbols by name, keyword, or meaning — filter by kind/language/file |
 | `graph --node <id> --mode <mode>` | Traverse neighbors, impact analysis, or reachability |
 | `scan --repo <dir>` | Scan + extract + embed + persist. Prints an OperationReport summary with ready capabilities, degraded query classes, and next enrichment commands. |
+| `--business-context enabled\|disabled <command>` | Global context mode. `disabled` excludes `.oh/**`, automatic business-context preambles, and Git-history producers while preserving ordinary repository files; incompatible disposable caches are deleted and rebuilt before use. Defaults to `enabled`. |
 | `scan --repo <dir> --timings` | Include measured operation phase timings in the scan summary. Unmeasured subphases are omitted rather than inferred. |
 | `scan --repo <dir> --full` | Full pipeline including LSP enrichment. Incremental on repeat runs. Persists a recent OperationReport for `list_roots`. |
 | `enrich --repo <dir> --capability embeddings\|call-references --scope repo\|root\|changed\|targets\|task` | Run selected enrichment against an existing graph cache without source extraction. Broad type/constant references are default-off and run only for an explicit `changed`, `targets`, or `task` scope with visible `--max-requests` and `--max-duration-ms` limits. Use repeated `--target-symbol` values for `targets`; use `--task-file` and/or `--target-symbol` for `task`. Scoped broad-reference work never continues repo-wide, persists `default_profile`/full/scoped/partial/unavailable evidence, and rejects empty, ambiguous, or unmapped declarations rather than widening the request. |
@@ -273,6 +274,8 @@ CLI and MCP share the same index. Run `scan --full` from the CLI to build the co
 
 
 Recent scan/enrich operation history is bounded diagnostic state under `.oh/.cache/operation_reports.json`. It is repo-native control-plane state for CLI/MCP visibility, not source truth; non-terminal records from a previous process are marked stale on read.
+
+Use `--business-context disabled` only when a run must exclude RNA-specific business and history context, such as a benchmark. The mode is producer-based: README, Markdown, RST, source, tests, and configuration paths are not excluded by the context policy. Extraction and LSP availability for each admitted file type still follow the repository's configured baseline capabilities.
 
 ### ADR validation primitive
 

--- a/scripts/swebench_rna_mcp_proxy.py
+++ b/scripts/swebench_rna_mcp_proxy.py
@@ -19,6 +19,9 @@ from swebench_rna_one import utc_now
 def arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--rna-binary", type=Path, required=True)
+    parser.add_argument(
+        "--business-context", choices=("disabled",), default="disabled"
+    )
     parser.add_argument("--repo", type=Path, required=True)
     parser.add_argument("--trace", type=Path, required=True)
     parser.add_argument("--server-stderr", type=Path, required=True)
@@ -100,7 +103,13 @@ def main() -> int:
     lock = threading.Lock()
     with args.server_stderr.open("wb") as server_stderr:
         server = subprocess.Popen(
-            [str(args.rna_binary), "--repo", str(args.repo)],
+            [
+                str(args.rna_binary),
+                "--business-context",
+                args.business_context,
+                "--repo",
+                str(args.repo),
+            ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=server_stderr,

--- a/scripts/swebench_rna_one.py
+++ b/scripts/swebench_rna_one.py
@@ -12,6 +12,7 @@ import importlib.util
 import importlib.metadata
 import json
 import os
+import re
 import signal
 import shutil
 import subprocess
@@ -42,6 +43,7 @@ TOKEN_FIELDS = (
     "reasoning_tokens",
     "cost_usd",
 )
+BUSINESS_CONTEXT_MODE = "disabled"
 
 
 class HarnessError(RuntimeError):
@@ -102,6 +104,19 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def rna_command(rna_binary: Path, *args: str) -> list[str]:
+    """Build every benchmark RNA command with isolation made explicit."""
+    command = [
+        str(rna_binary),
+        "--business-context",
+        BUSINESS_CONTEXT_MODE,
+        *args,
+    ]
+    if args and args[0] == "scan":
+        command.append("--timings")
+    return command
 
 
 def run_logged(
@@ -390,6 +405,8 @@ def proxy_config(
                     str(proxy_script),
                     "--rna-binary",
                     str(rna_binary),
+                    "--business-context",
+                    BUSINESS_CONTEXT_MODE,
                     "--repo",
                     str(checkout),
                     "--trace",
@@ -972,6 +989,62 @@ def parse_enrichment_state(
     }
 
 
+def parse_business_context_state(log_paths: Mapping[str, Path]) -> dict[str, Any]:
+    """Fail closed unless RNA reports the benchmark's selected isolation mode."""
+    mode_pattern = re.compile(r"business context:\s*(enabled|disabled)", re.IGNORECASE)
+    counts_pattern = re.compile(
+        r"excluded producer inputs:\s*(\d+)\s+\.oh file\(s\),\s*"
+        r"(\d+)\s+Git-history producer\(s\)",
+        re.IGNORECASE,
+    )
+    observations: list[dict[str, Any]] = []
+    observed_modes: list[str] = []
+    observed_counts: list[tuple[int, int]] = []
+    for name, path in log_paths.items():
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        modes = [match.lower() for match in mode_pattern.findall(text)]
+        counts = [
+            (int(files), int(producers))
+            for files, producers in counts_pattern.findall(text)
+        ]
+        observed_modes.extend(modes)
+        observed_counts.extend(counts)
+        if modes or counts:
+            observations.append(
+                {
+                    "source": name,
+                    "modes": modes,
+                    "counts": [
+                        {
+                            "business_artifact_files": files,
+                            "git_history_producers": producers,
+                        }
+                        for files, producers in counts
+                    ],
+                }
+            )
+
+    if not observed_modes or not observed_counts:
+        raise HarnessError(
+            "RNA pre-warm omitted business-context mode and exclusion diagnostics"
+        )
+    unexpected = sorted(set(observed_modes) - {BUSINESS_CONTEXT_MODE})
+    if unexpected:
+        raise HarnessError(
+            "RNA benchmark command escaped disabled business-context mode: "
+            + ", ".join(unexpected)
+        )
+    return {
+        "selected_mode": BUSINESS_CONTEXT_MODE,
+        "diagnostic_status": "validated",
+        "business_artifact_files": max(files for files, _ in observed_counts),
+        "git_history_producers": max(producers for _, producers in observed_counts),
+        "observations": observations,
+    }
+
+
 def prewarm_rna(
     *,
     rna_binary: Path,
@@ -984,7 +1057,7 @@ def prewarm_rna(
     commands: list[CommandResult] = []
     scan_stdout = logs / "scan.stdout.log"
     scan_stderr = logs / "scan.stderr.log"
-    scan_command = [str(rna_binary), "scan", "--repo", str(checkout)]
+    scan_command = rna_command(rna_binary, "scan", "--repo", str(checkout))
     if condition == "structural":
         scan_command.append("--extract-only")
     else:
@@ -1000,8 +1073,8 @@ def prewarm_rna(
     embedding: CommandResult | None = None
     if condition == "full":
         embedding = run_logged(
-            [
-                str(rna_binary),
+            rna_command(
+                rna_binary,
                 "enrich",
                 "--capability",
                 "embeddings",
@@ -1010,16 +1083,18 @@ def prewarm_rna(
                 "--repo",
                 str(checkout),
                 "--no-background-continuation",
-            ],
+            ),
             cwd=checkout,
             stdout_path=logs / "embeddings.stdout.log",
             stderr_path=logs / "embeddings.stderr.log",
             timeout=timeout,
         )
         commands.append(embedding)
+    readiness_stdout = logs / "readiness.stdout.log"
+    readiness_stderr = logs / "readiness.stderr.log"
     readiness = run_logged(
-        [
-            str(rna_binary),
+        rna_command(
+            rna_binary,
             "search",
             "--repo",
             str(checkout),
@@ -1028,16 +1103,26 @@ def prewarm_rna(
             "--limit",
             "1",
             "--verbose",
-        ],
+        ),
         cwd=checkout,
-        stdout_path=logs / "readiness.stdout.log",
-        stderr_path=logs / "readiness.stderr.log",
+        stdout_path=readiness_stdout,
+        stderr_path=readiness_stderr,
         timeout=60,
     )
     commands.append(readiness)
     state = parse_enrichment_state(
         scan, scan_stdout, scan_stderr, embedding, readiness
     )
+    business_context_logs = {
+        "scan_stdout": scan_stdout,
+        "scan_stderr": scan_stderr,
+        "readiness_stdout": readiness_stdout,
+        "readiness_stderr": readiness_stderr,
+    }
+    if embedding is not None:
+        business_context_logs["embedding_stdout"] = logs / "embeddings.stdout.log"
+        business_context_logs["embedding_stderr"] = logs / "embeddings.stderr.log"
+    state["business_context"] = parse_business_context_state(business_context_logs)
     state["selected_condition"] = condition
     if readiness.exit_code != 0:
         raise HarnessError(
@@ -1257,6 +1342,13 @@ def main(argv: Sequence[str] | None = None) -> int:
                 ),
             },
             "selected_enrichment_condition": args.enrichment_condition,
+            "business_context": {
+                "selected_mode": BUSINESS_CONTEXT_MODE,
+                "diagnostic_status": "not_run",
+                "business_artifact_files": None,
+                "git_history_producers": None,
+                "observations": [],
+            },
         }
         checkout = run_dir / "checkout"
         materialize_started = time.monotonic()
@@ -1350,6 +1442,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             timeout=args.prewarm_timeout_seconds,
         )
         manifest["rna"]["enrichment_state"] = enrichment_state
+        manifest["rna"]["business_context"] = enrichment_state["business_context"]
         manifest["rna"]["prewarm_commands"] = [
             dataclasses.asdict(command) for command in prewarm_commands
         ]

--- a/scripts/swebench_rna_one.py
+++ b/scripts/swebench_rna_one.py
@@ -989,8 +989,10 @@ def parse_enrichment_state(
     }
 
 
-def parse_business_context_state(log_paths: Mapping[str, Path]) -> dict[str, Any]:
-    """Fail closed unless RNA reports the benchmark's selected isolation mode."""
+def parse_business_context_state(
+    phase_log_paths: Mapping[str, Mapping[str, Path]],
+) -> dict[str, Any]:
+    """Fail closed unless every reporting phase certifies the selected mode."""
     mode_pattern = re.compile(r"business context:\s*(enabled|disabled)", re.IGNORECASE)
     counts_pattern = re.compile(
         r"excluded producer inputs:\s*(\d+)\s+\.oh file\(s\),\s*"
@@ -998,47 +1000,61 @@ def parse_business_context_state(log_paths: Mapping[str, Path]) -> dict[str, Any
         re.IGNORECASE,
     )
     observations: list[dict[str, Any]] = []
-    observed_modes: list[str] = []
     observed_counts: list[tuple[int, int]] = []
-    for name, path in log_paths.items():
-        if not path.exists():
-            continue
-        text = path.read_text(encoding="utf-8", errors="replace")
-        modes = [match.lower() for match in mode_pattern.findall(text)]
-        counts = [
-            (int(files), int(producers))
-            for files, producers in counts_pattern.findall(text)
-        ]
-        observed_modes.extend(modes)
-        observed_counts.extend(counts)
-        if modes or counts:
-            observations.append(
-                {
-                    "source": name,
-                    "modes": modes,
-                    "counts": [
-                        {
-                            "business_artifact_files": files,
-                            "git_history_producers": producers,
-                        }
-                        for files, producers in counts
-                    ],
-                }
-            )
+    if not phase_log_paths:
+        raise HarnessError("RNA pre-warm declared no business-context reporting phases")
+    for phase, log_paths in phase_log_paths.items():
+        phase_modes: list[str] = []
+        phase_counts: list[tuple[int, int]] = []
+        phase_observations: list[dict[str, Any]] = []
+        for name, path in log_paths.items():
+            if not path.exists():
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            modes = [match.lower() for match in mode_pattern.findall(text)]
+            counts = [
+                (int(files), int(producers))
+                for files, producers in counts_pattern.findall(text)
+            ]
+            phase_modes.extend(modes)
+            phase_counts.extend(counts)
+            if modes or counts:
+                phase_observations.append(
+                    {
+                        "source": name,
+                        "modes": modes,
+                        "counts": [
+                            {
+                                "business_artifact_files": files,
+                                "git_history_producers": producers,
+                            }
+                            for files, producers in counts
+                        ],
+                    }
+                )
 
-    if not observed_modes or not observed_counts:
-        raise HarnessError(
-            "RNA pre-warm omitted business-context mode and exclusion diagnostics"
+        if not phase_modes or not phase_counts:
+            raise HarnessError(
+                f"RNA {phase} phase omitted business-context mode and exclusion diagnostics"
+            )
+        unexpected = sorted(set(phase_modes) - {BUSINESS_CONTEXT_MODE})
+        if unexpected:
+            raise HarnessError(
+                f"RNA {phase} phase escaped disabled business-context mode: "
+                + ", ".join(unexpected)
+            )
+        observed_counts.extend(phase_counts)
+        observations.append(
+            {
+                "phase": phase,
+                "sources": phase_observations,
+            }
         )
-    unexpected = sorted(set(observed_modes) - {BUSINESS_CONTEXT_MODE})
-    if unexpected:
-        raise HarnessError(
-            "RNA benchmark command escaped disabled business-context mode: "
-            + ", ".join(unexpected)
-        )
+
     return {
         "selected_mode": BUSINESS_CONTEXT_MODE,
         "diagnostic_status": "validated",
+        "validated_phases": list(phase_log_paths),
         "business_artifact_files": max(files for files, _ in observed_counts),
         "git_history_producers": max(producers for _, producers in observed_counts),
         "observations": observations,
@@ -1113,16 +1129,18 @@ def prewarm_rna(
     state = parse_enrichment_state(
         scan, scan_stdout, scan_stderr, embedding, readiness
     )
-    business_context_logs = {
-        "scan_stdout": scan_stdout,
-        "scan_stderr": scan_stderr,
-        "readiness_stdout": readiness_stdout,
-        "readiness_stderr": readiness_stderr,
+    business_context_phases = {
+        "scan": {
+            "stdout": scan_stdout,
+            "stderr": scan_stderr,
+        },
     }
     if embedding is not None:
-        business_context_logs["embedding_stdout"] = logs / "embeddings.stdout.log"
-        business_context_logs["embedding_stderr"] = logs / "embeddings.stderr.log"
-    state["business_context"] = parse_business_context_state(business_context_logs)
+        business_context_phases["embedding"] = {
+            "stdout": logs / "embeddings.stdout.log",
+            "stderr": logs / "embeddings.stderr.log",
+        }
+    state["business_context"] = parse_business_context_state(business_context_phases)
     state["selected_condition"] = condition
     if readiness.exit_code != 0:
         raise HarnessError(

--- a/scripts/tests/test_swebench_rna_one.py
+++ b/scripts/tests/test_swebench_rna_one.py
@@ -33,6 +33,23 @@ PROXY_SPEC.loader.exec_module(PROXY)
 
 
 class SwebenchRnaOneTests(unittest.TestCase):
+    def test_benchmark_rna_commands_pin_disabled_business_context(self) -> None:
+        command = HARNESS.rna_command(Path("/rna"), "scan", "--repo", "/checkout")
+        self.assertEqual(
+            command[:3], ["/rna", "--business-context", "disabled"]
+        )
+        self.assertIn("--timings", command)
+        config = HARNESS.proxy_config(
+            proxy_script=Path("/proxy.py"),
+            rna_binary=Path("/rna"),
+            checkout=Path("/checkout"),
+            trace_path=Path("/trace.jsonl"),
+            stderr_path=Path("/stderr.log"),
+        )
+        proxy_args = config["mcpServers"]["rna-server"]["args"]
+        flag = proxy_args.index("--business-context")
+        self.assertEqual(proxy_args[flag + 1], "disabled")
+
     def test_isolated_checkout_has_one_local_commit_and_no_remote(self) -> None:
         instance = json.loads(
             (FIXTURES / "swebench_instance.json").read_text(encoding="utf-8")
@@ -425,6 +442,31 @@ class SwebenchRnaOneTests(unittest.TestCase):
             )
             self.assertIn("embedding_stderr", state["raw_logs"])
 
+    def test_business_context_diagnostics_are_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            log = Path(temporary) / "scan.stderr.log"
+            log.write_text(
+                "business context: disabled\n"
+                "excluded producer inputs: 3 .oh file(s), 2 Git-history producer(s)\n",
+                encoding="utf-8",
+            )
+            state = HARNESS.parse_business_context_state({"scan_stderr": log})
+            self.assertEqual(state["selected_mode"], "disabled")
+            self.assertEqual(state["business_artifact_files"], 3)
+            self.assertEqual(state["git_history_producers"], 2)
+
+            log.write_text("scan complete without diagnostics\n", encoding="utf-8")
+            with self.assertRaises(HARNESS.HarnessError):
+                HARNESS.parse_business_context_state({"scan_stderr": log})
+
+            log.write_text(
+                "business context: enabled\n"
+                "excluded producer inputs: 0 .oh file(s), 0 Git-history producer(s)\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(HARNESS.HarnessError):
+                HARNESS.parse_business_context_state({"scan_stderr": log})
+
     def test_dry_run_builds_auditable_bundle_without_executor_or_evaluator(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             output = Path(temporary) / "bundle"
@@ -456,6 +498,15 @@ class SwebenchRnaOneTests(unittest.TestCase):
             )
             self.assertEqual(manifest["status"], "dry_run_complete")
             self.assertEqual(manifest["dry_run"]["tokens_spent"], 0)
+            self.assertEqual(
+                manifest["rna"]["business_context"]["selected_mode"], "disabled"
+            )
+            self.assertEqual(
+                manifest["rna"]["business_context"]["diagnostic_status"], "not_run"
+            )
+            self.assertIsNone(
+                manifest["rna"]["business_context"]["business_artifact_files"]
+            )
             self.assertEqual(
                 manifest["checkout_isolation"]["history_commit_count"], 1
             )

--- a/scripts/tests/test_swebench_rna_one.py
+++ b/scripts/tests/test_swebench_rna_one.py
@@ -450,14 +450,17 @@ class SwebenchRnaOneTests(unittest.TestCase):
                 "excluded producer inputs: 3 .oh file(s), 2 Git-history producer(s)\n",
                 encoding="utf-8",
             )
-            state = HARNESS.parse_business_context_state({"scan_stderr": log})
+            state = HARNESS.parse_business_context_state(
+                {"scan": {"stderr": log}}
+            )
             self.assertEqual(state["selected_mode"], "disabled")
             self.assertEqual(state["business_artifact_files"], 3)
             self.assertEqual(state["git_history_producers"], 2)
+            self.assertEqual(state["validated_phases"], ["scan"])
 
             log.write_text("scan complete without diagnostics\n", encoding="utf-8")
             with self.assertRaises(HARNESS.HarnessError):
-                HARNESS.parse_business_context_state({"scan_stderr": log})
+                HARNESS.parse_business_context_state({"scan": {"stderr": log}})
 
             log.write_text(
                 "business context: enabled\n"
@@ -465,7 +468,42 @@ class SwebenchRnaOneTests(unittest.TestCase):
                 encoding="utf-8",
             )
             with self.assertRaises(HARNESS.HarnessError):
-                HARNESS.parse_business_context_state({"scan_stderr": log})
+                HARNESS.parse_business_context_state({"scan": {"stderr": log}})
+
+    def test_business_context_diagnostics_are_phase_specific(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            logs = Path(temporary)
+            scan = logs / "scan.stderr.log"
+            embedding = logs / "embedding.stderr.log"
+            scan.write_text(
+                "business context: disabled\n"
+                "excluded producer inputs: 3 .oh file(s), 2 Git-history producer(s)\n",
+                encoding="utf-8",
+            )
+            embedding.write_text("embedding complete without diagnostics\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(HARNESS.HarnessError, "embedding phase omitted"):
+                HARNESS.parse_business_context_state(
+                    {
+                        "scan": {"stderr": scan},
+                        "embedding": {"stderr": embedding},
+                    }
+                )
+
+            embedding.write_text(
+                "business context: disabled\n"
+                "excluded producer inputs: 0 .oh file(s), 1 Git-history producer(s)\n",
+                encoding="utf-8",
+            )
+            state = HARNESS.parse_business_context_state(
+                {
+                    "scan": {"stderr": scan},
+                    "embedding": {"stderr": embedding},
+                }
+            )
+            self.assertEqual(state["validated_phases"], ["scan", "embedding"])
+            self.assertEqual(state["business_artifact_files"], 3)
+            self.assertEqual(state["git_history_producers"], 2)
 
     def test_dry_run_builds_auditable_bundle_without_executor_or_evaluator(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/src/business_context.rs
+++ b/src/business_context.rs
@@ -101,24 +101,25 @@ impl BusinessContextAdmission {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    /// Remove `.oh` paths before a producer constructs an extraction event.
-    pub fn retain_repository_files(&self, files: &mut Vec<PathBuf>) -> usize {
-        if !self.mode.is_disabled() {
-            return 0;
+    /// Return whether a repository file may be produced, recording disabled `.oh` paths.
+    pub fn admit_repository_file(&self, path: &Path) -> bool {
+        if !self.mode.is_disabled() || !path_has_component(path, ".oh") {
+            return true;
         }
 
+        let mut counts = self
+            .counts
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        counts.business_artifact_files = counts.business_artifact_files.saturating_add(1);
+        false
+    }
+
+    /// Remove `.oh` paths before a producer constructs an extraction event.
+    pub fn retain_repository_files(&self, files: &mut Vec<PathBuf>) -> usize {
         let before = files.len();
-        files.retain(|path| !path_has_component(path, ".oh"));
-        let excluded = before.saturating_sub(files.len());
-        if excluded > 0 {
-            let mut counts = self
-                .counts
-                .write()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            counts.business_artifact_files =
-                counts.business_artifact_files.saturating_add(excluded);
-        }
-        excluded
+        files.retain(|path| self.admit_repository_file(path));
+        before.saturating_sub(files.len())
     }
 
     /// Return whether a Git-history producer may run, recording disabled decisions.
@@ -284,6 +285,17 @@ mod tests {
                 git_history_producers: 1,
             }
         );
+    }
+
+    #[test]
+    fn single_file_admission_shares_dot_oh_policy_and_counts() {
+        let admission = BusinessContextAdmission::new(BusinessContextMode::Disabled);
+
+        assert!(admission.admit_repository_file(Path::new("README.md")));
+        assert!(admission.admit_repository_file(Path::new("docs/oh/guide.md")));
+        assert!(!admission.admit_repository_file(Path::new(".oh/outcomes/leak.md")));
+        assert!(!admission.admit_repository_file(Path::new("docs/.oh/leak.md")));
+        assert_eq!(admission.counts().business_artifact_files, 2);
     }
 
     #[test]

--- a/src/business_context.rs
+++ b/src/business_context.rs
@@ -1,0 +1,317 @@
+//! Business-context producer admission and disposable-cache compatibility.
+
+use std::ffi::OsStr;
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+use std::str::FromStr;
+use std::sync::{Arc, RwLock};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+const CACHE_MODE_MARKER: &str = "business-context-mode";
+
+/// Controls whether RNA-specific business and Git-history producers may run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BusinessContextMode {
+    #[default]
+    Enabled,
+    Disabled,
+}
+
+impl BusinessContextMode {
+    pub fn is_disabled(self) -> bool {
+        matches!(self, Self::Disabled)
+    }
+}
+
+impl fmt::Display for BusinessContextMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Enabled => f.write_str("enabled"),
+            Self::Disabled => f.write_str("disabled"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseBusinessContextModeError(String);
+
+impl fmt::Display for ParseBusinessContextModeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid business context mode {:?}; expected enabled or disabled",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for ParseBusinessContextModeError {}
+
+impl FromStr for BusinessContextMode {
+    type Err = ParseBusinessContextModeError;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value {
+            "enabled" => Ok(Self::Enabled),
+            "disabled" => Ok(Self::Disabled),
+            other => Err(ParseBusinessContextModeError(other.to_owned())),
+        }
+    }
+}
+
+/// Counts decisions made at producer-admission time.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BusinessContextExclusionCounts {
+    pub business_artifact_files: usize,
+    pub git_history_producers: usize,
+}
+
+/// Shared producer-admission policy and diagnostics accumulator.
+#[derive(Debug, Clone)]
+pub struct BusinessContextAdmission {
+    mode: BusinessContextMode,
+    counts: Arc<RwLock<BusinessContextExclusionCounts>>,
+}
+
+impl Default for BusinessContextAdmission {
+    fn default() -> Self {
+        Self::new(BusinessContextMode::Enabled)
+    }
+}
+
+impl BusinessContextAdmission {
+    pub fn new(mode: BusinessContextMode) -> Self {
+        Self {
+            mode,
+            counts: Arc::new(RwLock::new(BusinessContextExclusionCounts::default())),
+        }
+    }
+
+    pub fn mode(&self) -> BusinessContextMode {
+        self.mode
+    }
+
+    pub fn counts(&self) -> BusinessContextExclusionCounts {
+        *self
+            .counts
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Remove `.oh` paths before a producer constructs an extraction event.
+    pub fn retain_repository_files(&self, files: &mut Vec<PathBuf>) -> usize {
+        if !self.mode.is_disabled() {
+            return 0;
+        }
+
+        let before = files.len();
+        files.retain(|path| !path_has_component(path, ".oh"));
+        let excluded = before.saturating_sub(files.len());
+        if excluded > 0 {
+            let mut counts = self
+                .counts
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            counts.business_artifact_files =
+                counts.business_artifact_files.saturating_add(excluded);
+        }
+        excluded
+    }
+
+    /// Return whether a Git-history producer may run, recording disabled decisions.
+    pub fn admit_git_history_producer(&self) -> bool {
+        if !self.mode.is_disabled() {
+            return true;
+        }
+
+        let mut counts = self
+            .counts
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        counts.git_history_producers = counts.git_history_producers.saturating_add(1);
+        false
+    }
+
+    /// Validate the exact disposable repo cache before any cache-backed read.
+    pub fn prepare_cache(&self, repo_root: &Path) -> Result<CacheModeDisposition> {
+        prepare_cache_for_mode(repo_root, self.mode)
+    }
+}
+
+/// Result of validating the disposable cache's selected context mode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CacheModeDisposition {
+    Compatible,
+    Initialized,
+    Rebuilt { previous: Option<String> },
+}
+
+impl CacheModeDisposition {
+    pub fn rebuilt(&self) -> bool {
+        matches!(self, Self::Rebuilt { .. })
+    }
+}
+
+fn path_has_component(path: &Path, expected: &str) -> bool {
+    path.components().any(
+        |component| matches!(component, Component::Normal(value) if value == OsStr::new(expected)),
+    )
+}
+
+fn validated_cache_path(repo_root: &Path) -> Result<PathBuf> {
+    if !repo_root.is_dir() {
+        bail!(
+            "repository root is not a directory: {}",
+            repo_root.display()
+        );
+    }
+
+    let oh_dir = repo_root.join(".oh");
+    if let Ok(metadata) = std::fs::symlink_metadata(&oh_dir)
+        && metadata.file_type().is_symlink()
+    {
+        bail!(
+            "refusing to manage disposable cache through symlinked .oh directory: {}",
+            oh_dir.display()
+        );
+    }
+
+    let cache_dir = oh_dir.join(".cache");
+    if cache_dir.file_name() != Some(OsStr::new(".cache"))
+        || cache_dir.parent().and_then(Path::file_name) != Some(OsStr::new(".oh"))
+    {
+        bail!(
+            "refusing unsafe disposable cache path: {}",
+            cache_dir.display()
+        );
+    }
+    if let Ok(metadata) = std::fs::symlink_metadata(&cache_dir)
+        && metadata.file_type().is_symlink()
+    {
+        bail!(
+            "refusing to delete symlinked disposable cache: {}",
+            cache_dir.display()
+        );
+    }
+    Ok(cache_dir)
+}
+
+fn write_mode_marker(cache_dir: &Path, mode: BusinessContextMode) -> Result<()> {
+    std::fs::create_dir_all(cache_dir)
+        .with_context(|| format!("failed to create cache directory {}", cache_dir.display()))?;
+    let marker = cache_dir.join(CACHE_MODE_MARKER);
+    let temporary = cache_dir.join(format!("{CACHE_MODE_MARKER}.tmp"));
+    std::fs::write(&temporary, format!("{mode}\n"))
+        .with_context(|| format!("failed to write cache mode marker {}", temporary.display()))?;
+    std::fs::rename(&temporary, &marker)
+        .with_context(|| format!("failed to install cache mode marker {}", marker.display()))?;
+    Ok(())
+}
+
+fn prepare_cache_for_mode(
+    repo_root: &Path,
+    mode: BusinessContextMode,
+) -> Result<CacheModeDisposition> {
+    let cache_dir = validated_cache_path(repo_root)?;
+    if !cache_dir.exists() {
+        write_mode_marker(&cache_dir, mode)?;
+        return Ok(CacheModeDisposition::Initialized);
+    }
+
+    let marker = cache_dir.join(CACHE_MODE_MARKER);
+    let persisted = std::fs::read_to_string(&marker).ok();
+    if persisted
+        .as_deref()
+        .map(str::trim)
+        .and_then(|value| value.parse::<BusinessContextMode>().ok())
+        == Some(mode)
+    {
+        return Ok(CacheModeDisposition::Compatible);
+    }
+
+    std::fs::remove_dir_all(&cache_dir).with_context(|| {
+        format!(
+            "failed to delete incompatible disposable cache {}",
+            cache_dir.display()
+        )
+    })?;
+    write_mode_marker(&cache_dir, mode)?;
+    Ok(CacheModeDisposition::Rebuilt {
+        previous: persisted.map(|value| value.trim().to_owned()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mode_parsing_is_strict() {
+        assert_eq!(
+            "disabled".parse::<BusinessContextMode>().unwrap(),
+            BusinessContextMode::Disabled
+        );
+        assert!("DISABLED".parse::<BusinessContextMode>().is_err());
+        assert!("unknown".parse::<BusinessContextMode>().is_err());
+    }
+
+    #[test]
+    fn disabled_admission_removes_only_dot_oh_components() {
+        let admission = BusinessContextAdmission::new(BusinessContextMode::Disabled);
+        let mut files = vec![
+            PathBuf::from(".oh/outcomes/leak.md"),
+            PathBuf::from("docs/.oh/guardrail.md"),
+            PathBuf::from("docs/oh/guide.md"),
+            PathBuf::from("README.md"),
+        ];
+
+        assert_eq!(admission.retain_repository_files(&mut files), 2);
+        assert_eq!(
+            files,
+            vec![
+                PathBuf::from("docs/oh/guide.md"),
+                PathBuf::from("README.md")
+            ]
+        );
+        assert!(!admission.admit_git_history_producer());
+        assert_eq!(
+            admission.counts(),
+            BusinessContextExclusionCounts {
+                business_artifact_files: 2,
+                git_history_producers: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn incompatible_or_legacy_cache_is_rebuilt_exactly() {
+        let repo = tempfile::tempdir().unwrap();
+        let admission = BusinessContextAdmission::new(BusinessContextMode::Disabled);
+        let cache = repo.path().join(".oh/.cache");
+        std::fs::create_dir_all(cache.join("lance")).unwrap();
+        std::fs::write(cache.join("lance/sentinel"), "legacy").unwrap();
+
+        assert!(admission.prepare_cache(repo.path()).unwrap().rebuilt());
+        assert!(!cache.join("lance/sentinel").exists());
+        assert_eq!(
+            std::fs::read_to_string(cache.join(CACHE_MODE_MARKER)).unwrap(),
+            "disabled\n"
+        );
+        assert_eq!(
+            admission.prepare_cache(repo.path()).unwrap(),
+            CacheModeDisposition::Compatible
+        );
+
+        let enabled = BusinessContextAdmission::new(BusinessContextMode::Enabled);
+        std::fs::write(cache.join("disabled-only-row"), "derived").unwrap();
+        assert!(enabled.prepare_cache(repo.path()).unwrap().rebuilt());
+        assert!(!cache.join("disabled-only-row").exists());
+        assert_eq!(
+            std::fs::read_to_string(cache.join(CACHE_MODE_MARKER)).unwrap(),
+            "enabled\n"
+        );
+    }
+}

--- a/src/business_context.rs
+++ b/src/business_context.rs
@@ -154,6 +154,10 @@ impl CacheModeDisposition {
     pub fn rebuilt(&self) -> bool {
         matches!(self, Self::Rebuilt { .. })
     }
+
+    pub fn requires_fresh_graph(&self) -> bool {
+        matches!(self, Self::Initialized | Self::Rebuilt { .. })
+    }
 }
 
 fn path_has_component(path: &Path, expected: &str) -> bool {
@@ -296,6 +300,21 @@ mod tests {
         assert!(!admission.admit_repository_file(Path::new(".oh/outcomes/leak.md")));
         assert!(!admission.admit_repository_file(Path::new("docs/.oh/leak.md")));
         assert_eq!(admission.counts().business_artifact_files, 2);
+    }
+
+    #[test]
+    fn cache_disposition_separates_deletion_from_fresh_graph_requirements() {
+        assert!(!CacheModeDisposition::Compatible.rebuilt());
+        assert!(!CacheModeDisposition::Compatible.requires_fresh_graph());
+
+        assert!(!CacheModeDisposition::Initialized.rebuilt());
+        assert!(CacheModeDisposition::Initialized.requires_fresh_graph());
+
+        let rebuilt = CacheModeDisposition::Rebuilt {
+            previous: Some("enabled".to_string()),
+        };
+        assert!(rebuilt.rebuilt());
+        assert!(rebuilt.requires_fresh_graph());
     }
 
     #[test]

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -147,6 +147,17 @@ impl EmbeddingIndex {
         ))
     }
 
+    pub async fn index_all_with_symbols_and_business_context(
+        &self,
+        _repo_root: &Path,
+        _symbols: &[crate::graph::Node],
+        _business_context: &crate::business_context::BusinessContextAdmission,
+    ) -> Result<usize> {
+        Err(anyhow!(
+            "embeddings support is not compiled in; rebuild with --features embeddings"
+        ))
+    }
+
     pub async fn index_all(&self, _repo_root: &Path) -> Result<usize> {
         Err(anyhow!(
             "embeddings support is not compiled in; rebuild with --features embeddings"

--- a/src/embed/real.rs
+++ b/src/embed/real.rs
@@ -1857,6 +1857,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn context_aware_full_index_skips_history_before_embedding() {
+        use crate::business_context::{BusinessContextAdmission, BusinessContextMode};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let idx = EmbeddingIndex::new(tmp.path()).await.unwrap();
+        let business_context = BusinessContextAdmission::new(BusinessContextMode::Disabled);
+
+        let indexed = idx
+            .index_all_with_symbols_and_business_context(tmp.path(), &[], &business_context)
+            .await
+            .unwrap();
+
+        assert_eq!(indexed, 0);
+        assert_eq!(business_context.counts().git_history_producers, 2);
+    }
+
+    #[tokio::test]
     async fn has_table_returns_true_after_index_build() {
         use crate::graph::{ExtractionSource, Node, NodeId, NodeKind};
         use std::path::PathBuf;

--- a/src/embed/real.rs
+++ b/src/embed/real.rs
@@ -701,12 +701,33 @@ impl EmbeddingIndex {
         repo_root: &Path,
         symbols: &[crate::graph::Node],
     ) -> Result<usize> {
-        self.index_all_inner(repo_root, symbols).await
+        self.index_all_inner(
+            repo_root,
+            symbols,
+            &crate::business_context::BusinessContextAdmission::default(),
+        )
+        .await
+    }
+
+    /// Index graph nodes while admitting optional history producers once.
+    pub async fn index_all_with_symbols_and_business_context(
+        &self,
+        repo_root: &Path,
+        symbols: &[crate::graph::Node],
+        business_context: &crate::business_context::BusinessContextAdmission,
+    ) -> Result<usize> {
+        self.index_all_inner(repo_root, symbols, business_context)
+            .await
     }
 
     /// Index recent git commits only (no graph nodes). Rebuilds the table from scratch.
     pub async fn index_all(&self, repo_root: &Path) -> Result<usize> {
-        self.index_all_inner(repo_root, &[]).await
+        self.index_all_inner(
+            repo_root,
+            &[],
+            &crate::business_context::BusinessContextAdmission::default(),
+        )
+        .await
     }
 
     /// Re-embed a targeted subset of nodes and upsert them into the existing table.
@@ -983,6 +1004,7 @@ impl EmbeddingIndex {
         &self,
         repo_root: &Path,
         symbols: &[crate::graph::Node],
+        business_context: &crate::business_context::BusinessContextAdmission,
     ) -> Result<usize> {
         let index_start = std::time::Instant::now();
         tracing::info!(
@@ -1013,84 +1035,92 @@ impl EmbeddingIndex {
         let mut candidates: Vec<Candidate> = Vec::new();
 
         // Index recent git commits (capped for performance)
-        let commit_count = match git::load_commits(repo_root, RECENT_COMMIT_LIMIT) {
-            Ok(commits) => {
-                for c in &commits {
-                    let changed_files_str = c
-                        .changed_files
-                        .iter()
-                        .map(|p| p.to_string_lossy().to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    let body = format!("{}\n\nFiles: {}", c.message, changed_files_str);
-                    let title = c.message.lines().next().unwrap_or(&c.message).to_string();
-                    let text_hash = blake3::hash(body.as_bytes()).to_hex().to_string();
+        let commit_count = if business_context.admit_git_history_producer() {
+            match git::load_commits(repo_root, RECENT_COMMIT_LIMIT) {
+                Ok(commits) => {
+                    for c in &commits {
+                        let changed_files_str = c
+                            .changed_files
+                            .iter()
+                            .map(|p| p.to_string_lossy().to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        let body = format!("{}\n\nFiles: {}", c.message, changed_files_str);
+                        let title = c.message.lines().next().unwrap_or(&c.message).to_string();
+                        let text_hash = blake3::hash(body.as_bytes()).to_hex().to_string();
 
-                    candidates.push(Candidate {
-                        id: c.short_hash.clone(),
-                        kind: "commit".to_string(),
-                        title,
-                        body: body.clone(),
-                        text: body,
-                        text_hash,
-                        file_path: None,
-                        language: None,
-                        subsystem: None,
-                        cyclomatic: None,
-                    });
+                        candidates.push(Candidate {
+                            id: c.short_hash.clone(),
+                            kind: "commit".to_string(),
+                            title,
+                            body: body.clone(),
+                            text: body,
+                            text_hash,
+                            file_path: None,
+                            language: None,
+                            subsystem: None,
+                            cyclomatic: None,
+                        });
+                    }
+                    commits.len()
                 }
-                commits.len()
+                Err(err) => {
+                    tracing::debug!(
+                        "EmbeddingIndex: failed to load commits for {}: {}",
+                        repo_root.display(),
+                        err
+                    );
+                    0
+                }
             }
-            Err(err) => {
-                tracing::debug!(
-                    "EmbeddingIndex: failed to load commits for {}: {}",
-                    repo_root.display(),
-                    err
-                );
-                0
-            }
+        } else {
+            0
         };
         // Index PR merge commits for structural context (what shipped)
         let mut seen_merge_shas = std::collections::HashSet::new();
-        let merge_count = match git::pr_merges::extract_pr_merges(repo_root, Some(PR_MERGE_LIMIT)) {
-            Ok((merge_nodes, _edges)) => {
-                for node in &merge_nodes {
-                    let merge_sha = node.metadata.get("merge_sha").cloned().unwrap_or_default();
-                    let short = merge_sha.get(..7).unwrap_or(&merge_sha).to_string();
-                    if seen_merge_shas.contains(&short) {
-                        continue;
+        let merge_count = if business_context.admit_git_history_producer() {
+            match git::pr_merges::extract_pr_merges(repo_root, Some(PR_MERGE_LIMIT)) {
+                Ok((merge_nodes, _edges)) => {
+                    for node in &merge_nodes {
+                        let merge_sha = node.metadata.get("merge_sha").cloned().unwrap_or_default();
+                        let short = merge_sha.get(..7).unwrap_or(&merge_sha).to_string();
+                        if seen_merge_shas.contains(&short) {
+                            continue;
+                        }
+                        seen_merge_shas.insert(short.clone());
+
+                        let branch = node
+                            .metadata
+                            .get("branch_name")
+                            .cloned()
+                            .unwrap_or_default();
+                        let files = node
+                            .metadata
+                            .get("files_changed")
+                            .cloned()
+                            .unwrap_or_default();
+                        let body = format!("{}\n\nBranch: {}\nFiles: {}", node.body, branch, files);
+                        let text_hash = blake3::hash(body.as_bytes()).to_hex().to_string();
+
+                        candidates.push(Candidate {
+                            id: format!("merge:{}", short),
+                            kind: "merge".to_string(),
+                            title: node.signature.clone(),
+                            body: body.clone(),
+                            text: body,
+                            text_hash,
+                            file_path: None,
+                            language: None,
+                            subsystem: None,
+                            cyclomatic: None,
+                        });
                     }
-                    seen_merge_shas.insert(short.clone());
-
-                    let branch = node
-                        .metadata
-                        .get("branch_name")
-                        .cloned()
-                        .unwrap_or_default();
-                    let files = node
-                        .metadata
-                        .get("files_changed")
-                        .cloned()
-                        .unwrap_or_default();
-                    let body = format!("{}\n\nBranch: {}\nFiles: {}", node.body, branch, files);
-                    let text_hash = blake3::hash(body.as_bytes()).to_hex().to_string();
-
-                    candidates.push(Candidate {
-                        id: format!("merge:{}", short),
-                        kind: "merge".to_string(),
-                        title: node.signature.clone(),
-                        body: body.clone(),
-                        text: body,
-                        text_hash,
-                        file_path: None,
-                        language: None,
-                        subsystem: None,
-                        cyclomatic: None,
-                    });
+                    seen_merge_shas.len()
                 }
-                seen_merge_shas.len()
+                Err(_) => 0,
             }
-            Err(_) => 0,
+        } else {
+            0
         };
 
         // Filter to embeddable node kinds before counting/indexing

--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -27,6 +27,7 @@ use std::sync::{Arc, Mutex, RwLock};
 
 use async_trait::async_trait;
 
+use crate::business_context::BusinessContextAdmission;
 use crate::extract::ExtractorRegistry;
 use crate::extract::event_bus::{ExtractionConsumer, ExtractionEvent, ExtractionEventKind};
 use crate::extract::scan_stats::{ScanStats, ScanStatsConsumer};
@@ -81,6 +82,7 @@ impl ExtractionConsumer for ManifestConsumer {
 /// Emits: `RootExtracted` (carrying all nodes + edges for this root)
 pub struct TreeSitterConsumer {
     registry: ExtractorRegistry,
+    business_context: BusinessContextAdmission,
     /// Optional handle to live scan stats — used to propagate encoding stats
     /// (binary skipped / lossy-decoded counts) without changing the event schema.
     scan_stats: Option<Arc<RwLock<ScanStats>>>,
@@ -90,6 +92,7 @@ impl TreeSitterConsumer {
     pub fn new() -> Self {
         Self {
             registry: ExtractorRegistry::with_builtins(),
+            business_context: BusinessContextAdmission::default(),
             scan_stats: None,
         }
     }
@@ -98,6 +101,18 @@ impl TreeSitterConsumer {
     pub fn with_scan_stats(scan_stats: Arc<RwLock<ScanStats>>) -> Self {
         Self {
             registry: ExtractorRegistry::with_builtins(),
+            business_context: BusinessContextAdmission::default(),
+            scan_stats: Some(scan_stats),
+        }
+    }
+
+    pub fn with_scan_stats_and_business_context(
+        scan_stats: Arc<RwLock<ScanStats>>,
+        business_context: BusinessContextAdmission,
+    ) -> Self {
+        Self {
+            registry: ExtractorRegistry::with_builtins(),
+            business_context,
             scan_stats: Some(scan_stats),
         }
     }
@@ -137,10 +152,12 @@ impl ExtractionConsumer for TreeSitterConsumer {
 
         // Build a ScanResult that includes all files in the root.
         let mut scanner = crate::scanner::Scanner::new(path.clone())?;
-        let all_files = {
+        let mut all_files = {
             let _ = scanner.scan(); // populate internal state
             scanner.all_known_files()
         };
+        self.business_context
+            .retain_repository_files(&mut all_files);
 
         let full_scan = crate::scanner::ScanResult {
             changed_files: Vec::new(),
@@ -2277,6 +2294,8 @@ impl ExtractionConsumer for SubsystemConsumer {
 /// in real vs stub mode. All fields default to `None` (stub / throwaway).
 #[derive(Default)]
 pub struct BusOptions {
+    /// Shared producer-admission policy for direct `RootDiscovered` extraction.
+    pub business_context: BusinessContextAdmission,
     /// Shared `ScanStats` handle owned by `RnaHandler`. When `None`, a fresh
     /// throwaway `Arc` is created. Only pass `Some` from server call sites.
     pub scan_stats: Option<Arc<RwLock<ScanStats>>>,
@@ -2338,6 +2357,7 @@ pub fn build_builtin_bus(
     opts: BusOptions,
 ) -> (crate::extract::event_bus::EventBus, Arc<RwLock<ScanStats>>) {
     let BusOptions {
+        business_context,
         scan_stats,
         embed_idx,
         lance_repo_root,
@@ -2358,9 +2378,12 @@ pub fn build_builtin_bus(
 
     // --- RootDiscovered consumers ---
     bus.register(Box::new(ManifestConsumer));
-    bus.register(Box::new(TreeSitterConsumer::with_scan_stats(Arc::clone(
-        &stats_arc,
-    ))));
+    bus.register(Box::new(
+        TreeSitterConsumer::with_scan_stats_and_business_context(
+            Arc::clone(&stats_arc),
+            business_context,
+        ),
+    ));
 
     // --- RootExtracted consumers ---
     // LanguageAccumulatorConsumer must run first (emits LanguageDetected which

--- a/src/extract/markdown.rs
+++ b/src/extract/markdown.rs
@@ -1714,6 +1714,7 @@ The manuscript uses the proxy-risk claim in the opening argument.
             "content.metadata_without_body_evidence"
         );
 
+        let business_context = crate::business_context::BusinessContextAdmission::default();
         let ctx = SearchContext {
             graph_state: &loaded,
             embed_index: None,
@@ -1723,6 +1724,7 @@ The manuscript uses the proxy-risk claim in the opening argument.
             root_filter: None,
             non_code_slugs: HashSet::new(),
             enrichment_jobs: Vec::new(),
+            business_context: &business_context,
         };
         let answer = search(
             &SearchParams {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod adr;
 pub mod bootstrap;
 pub mod bus;
+pub mod business_context;
 pub mod code;
 pub mod consumers;
 pub mod embed;

--- a/src/main.rs
+++ b/src/main.rs
@@ -656,10 +656,15 @@ async fn load_cache_backed_query_graph(
         business_context: BusinessContextAdmission::new(business_context_mode),
         ..RnaHandler::default()
     };
-    if handler.prepare_business_context_cache()?.rebuilt() {
-        return handler
+    if handler
+        .prepare_business_context_cache()?
+        .requires_fresh_graph()
+    {
+        let graph = handler
             .build_full_graph_inner(false, ScanEnrichmentOptions::extract_only())
-            .await;
+            .await?;
+        handler.persist_graph_snapshot(&graph).await?;
+        return Ok(graph);
     }
 
     Ok(load_cached_graph(repo_root).await)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1241,6 +1241,7 @@ async fn async_main() -> anyhow::Result<()> {
                     .into_iter()
                     .map(|(slug, _)| slug)
                     .collect();
+            let business_context = BusinessContextAdmission::new(business_context_mode);
             let ctx = SearchContext {
                 graph_state: &gs,
                 embed_index: embed_ref,
@@ -1250,6 +1251,7 @@ async fn async_main() -> anyhow::Result<()> {
                 root_filter,
                 non_code_slugs,
                 enrichment_jobs: EnrichmentJobLedger::default().all_jobs(&repo_root),
+                business_context: &business_context,
             };
             println!("{}", service::search(&params, &ctx).await);
             return Ok(());
@@ -1316,9 +1318,11 @@ async fn async_main() -> anyhow::Result<()> {
                 root_filter,
                 non_code_slugs: std::collections::HashSet::new(),
             };
+            let business_context = BusinessContextAdmission::new(business_context_mode);
             let ctx = OutcomeProgressContext {
                 graph_state: &gs,
                 repo_root: &repo_root,
+                business_context: &business_context,
             };
             println!("{}", service::outcome_progress(&params, &ctx));
             return Ok(());
@@ -1362,11 +1366,13 @@ async fn async_main() -> anyhow::Result<()> {
                 root_filter,
                 non_code_slugs: std::collections::HashSet::new(),
             };
+            let business_context = BusinessContextAdmission::new(business_context_mode);
             let ctx = RepoMapContext {
                 graph_state: &gs,
                 repo_root: &repo_root,
                 lsp_status: None,
                 embed_status: None,
+                business_context: &business_context,
             };
             println!("{}", service::repo_map(&params, &ctx));
             return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use rust_mcp_sdk::ToMcpServerHandler;
 use rust_mcp_sdk::schema::{Implementation, InitializeResult, ServerCapabilities};
 
 use repo_native_alignment::adr::{self, ValidateSelection};
+use repo_native_alignment::business_context::{BusinessContextAdmission, BusinessContextMode};
 use repo_native_alignment::roots::WorkspaceConfig;
 use repo_native_alignment::server::{
     self, BroadReferenceBudget, EnrichmentCapability, EnrichmentContinuation, EnrichmentJobLedger,
@@ -34,6 +35,9 @@ struct Cli {
     port: u16,
     #[arg(long)]
     log_path: Option<PathBuf>,
+    /// Include RNA-specific `.oh` and Git-history context in produced indexes.
+    #[arg(long, default_value_t = BusinessContextMode::Enabled)]
+    business_context: BusinessContextMode,
 }
 
 #[derive(Subcommand, Debug)]
@@ -532,6 +536,7 @@ struct ScanSummaryInput<'a> {
     lsp_state: server::operation_report::CapabilityState,
     lsp_detail: Option<String>,
     related_job_ids: Vec<String>,
+    business_context: &'a repo_native_alignment::business_context::BusinessContextAdmission,
 }
 
 fn lsp_call_edge_count(graph: &server::state::GraphState) -> usize {
@@ -558,6 +563,7 @@ fn print_scan_summary(input: ScanSummaryInput<'_>) {
         lsp_state,
         lsp_detail,
         related_job_ids,
+        business_context,
     } = input;
     let mut report = server::operation_report::OperationReport::new(
         operation,
@@ -574,6 +580,7 @@ fn print_scan_summary(input: ScanSummaryInput<'_>) {
         lsp_edge_count: Some(lsp_call_edge_count(graph)),
     };
     report.related_job_ids = related_job_ids;
+    report.record_business_context(business_context);
     for phase in extra_phases {
         report.add_phase(phase);
     }
@@ -637,6 +644,27 @@ async fn load_cached_graph(repo_root: &std::path::Path) -> server::state::GraphS
     }
 }
 
+/// Validate the disposable cache identity before a direct CLI query reads it.
+/// Incompatible caches are rebuilt once through the same producer-admission path
+/// used by scans; compatible caches keep the existing fast load path.
+async fn load_cache_backed_query_graph(
+    repo_root: &std::path::Path,
+    business_context_mode: BusinessContextMode,
+) -> anyhow::Result<server::state::GraphState> {
+    let handler = RnaHandler {
+        repo_root: repo_root.to_path_buf(),
+        business_context: BusinessContextAdmission::new(business_context_mode),
+        ..RnaHandler::default()
+    };
+    if handler.prepare_business_context_cache()?.rebuilt() {
+        return handler
+            .build_full_graph_inner(false, ScanEnrichmentOptions::extract_only())
+            .await;
+    }
+
+    Ok(load_cached_graph(repo_root).await)
+}
+
 fn resolve_root_filter(root_arg: Option<&str>, repo_root: &std::path::Path) -> Option<String> {
     let root_slug =
         repo_native_alignment::roots::RootConfig::code_project(repo_root.to_path_buf()).slug();
@@ -679,6 +707,7 @@ fn main() {
 async fn async_main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let log_path = cli.log_path.clone();
+    let business_context_mode = cli.business_context;
     match cli.command {
         Some(Commands::Setup(args)) => return setup::run(&args),
         Some(Commands::Test(args)) => {
@@ -711,6 +740,7 @@ async fn async_main() -> anyhow::Result<()> {
                 eprintln!("Full pipeline scan: {}", repo_root.display());
                 let handler = RnaHandler {
                     repo_root: repo_root.clone(),
+                    business_context: BusinessContextAdmission::new(business_context_mode),
                     lsp_only_roots: Arc::new(lsp_only_roots_scan),
                     ..Default::default()
                 };
@@ -750,9 +780,11 @@ async fn async_main() -> anyhow::Result<()> {
             let t0 = std::time::Instant::now();
             let handler = RnaHandler {
                 repo_root: repo_root.clone(),
+                business_context: BusinessContextAdmission::new(business_context_mode),
                 lsp_only_roots: Arc::new(lsp_only_roots_scan),
                 ..Default::default()
             };
+            handler.prepare_business_context_cache()?;
             if let Some(embed_idx) = load_existing_embedding_index(&repo_root, |msg| {
                 if enrichment.runs_embeddings() {
                     tracing::warn!("{}; scan summary may show embeddings unavailable", msg);
@@ -826,6 +858,7 @@ async fn async_main() -> anyhow::Result<()> {
                     lsp_state,
                     lsp_detail,
                     related_job_ids,
+                    business_context: &handler.business_context,
                 });
                 return Ok(());
             }
@@ -870,6 +903,7 @@ async fn async_main() -> anyhow::Result<()> {
                         lsp_state,
                         lsp_detail,
                         related_job_ids,
+                        business_context: &handler.business_context,
                     });
                     return Ok(());
                 }
@@ -906,6 +940,7 @@ async fn async_main() -> anyhow::Result<()> {
                 lsp_state,
                 lsp_detail,
                 related_job_ids,
+                business_context: &handler.business_context,
             });
             return Ok(());
         }
@@ -972,9 +1007,11 @@ async fn async_main() -> anyhow::Result<()> {
             let lsp_only_roots = workspace_config.lsp_only_roots();
             let handler = RnaHandler {
                 repo_root: repo_root.clone(),
+                business_context: BusinessContextAdmission::new(business_context_mode),
                 lsp_only_roots: Arc::new(lsp_only_roots),
                 ..Default::default()
             };
+            handler.prepare_business_context_cache()?;
             let graph = match try_load_cached_graph(&repo_root).await? {
                 Some(graph) => graph,
                 None => anyhow::bail!(
@@ -1074,6 +1111,7 @@ async fn async_main() -> anyhow::Result<()> {
                 lsp_edge_count: Some(lsp_edge_count),
             };
             report.related_job_ids = related_job_ids;
+            report.record_business_context(&handler.business_context);
             report.add_phase(server::operation_report::PhaseReport::ran(
                 match capability {
                     EnrichmentCapability::Embeddings => {
@@ -1105,7 +1143,7 @@ async fn async_main() -> anyhow::Result<()> {
         Some(Commands::Search(args)) => {
             init_tracing("warn", log_path.as_deref());
             let repo_root = args.repo.canonicalize()?;
-            let gs = load_cached_graph(&repo_root).await;
+            let gs = load_cache_backed_query_graph(&repo_root, business_context_mode).await?;
             // Load existing embedding index -- do NOT rebuild.
             let embed_idx = match repo_native_alignment::embed::EmbeddingIndex::new(&repo_root)
                 .await
@@ -1219,7 +1257,7 @@ async fn async_main() -> anyhow::Result<()> {
         Some(Commands::Graph(args)) => {
             init_tracing("warn", log_path.as_deref());
             let repo_root = args.repo.canonicalize()?;
-            let gs = load_cached_graph(&repo_root).await;
+            let gs = load_cache_backed_query_graph(&repo_root, business_context_mode).await?;
             let gp = GraphParams {
                 node: args.node.clone(),
                 mode: args.mode.clone(),
@@ -1246,12 +1284,7 @@ async fn async_main() -> anyhow::Result<()> {
         Some(Commands::Stats(args)) => {
             init_tracing("warn", log_path.as_deref());
             let repo_root = args.repo.canonicalize()?;
-            let lance_path = repo_root.join(".oh").join(".cache").join("lance");
-            if !lance_path.exists() {
-                eprintln!("No index found. Run `repo-native-alignment scan --path .` first.");
-                std::process::exit(1);
-            }
-            let gs = server::load_graph_from_lance(&repo_root).await?;
+            let gs = load_cache_backed_query_graph(&repo_root, business_context_mode).await?;
             let st = service::stats(&repo_root, &gs).await;
             println!(
                 "  Symbols: {} | Edges: {} | Embeddings: {} | Languages: {} | Last scan: {} | .oh/: {} artifacts ({} outcomes, {} signals, {} guardrails, {} metis)",
@@ -1275,7 +1308,7 @@ async fn async_main() -> anyhow::Result<()> {
         Some(Commands::OutcomeProgress(args)) => {
             init_tracing("warn", log_path.as_deref());
             let repo_root = args.repo.canonicalize()?;
-            let gs = load_cached_graph(&repo_root).await;
+            let gs = load_cache_backed_query_graph(&repo_root, business_context_mode).await?;
             let root_filter = resolve_root_filter(args.root.as_deref(), &repo_root);
             let params = OutcomeProgressParams {
                 outcome_id: args.outcome_id.clone(),
@@ -1293,7 +1326,7 @@ async fn async_main() -> anyhow::Result<()> {
         Some(Commands::ListRoots(args)) => {
             init_tracing("warn", log_path.as_deref());
             let repo_root = args.repo.canonicalize()?;
-            let gs = load_cached_graph(&repo_root).await;
+            let gs = load_cache_backed_query_graph(&repo_root, business_context_mode).await?;
             let index_map = gs.node_index_map();
             // Start with graph-derived slugs (roots that have extracted nodes).
             let mut active_slugs: std::collections::HashSet<String> =
@@ -1322,7 +1355,7 @@ async fn async_main() -> anyhow::Result<()> {
         Some(Commands::RepoMap(args)) => {
             init_tracing("warn", log_path.as_deref());
             let repo_root = args.repo.canonicalize()?;
-            let gs = load_cached_graph(&repo_root).await;
+            let gs = load_cache_backed_query_graph(&repo_root, business_context_mode).await?;
             let root_filter = resolve_root_filter(args.root.as_deref(), &repo_root);
             let params = RepoMapParams {
                 top_n: args.top_n,
@@ -1402,6 +1435,7 @@ async fn async_main() -> anyhow::Result<()> {
         .lsp_only_roots();
     let handler = RnaHandler {
         repo_root: repo_root.clone(),
+        business_context: BusinessContextAdmission::new(business_context_mode),
         lsp_only_roots: Arc::new(lsp_only_roots),
         ..Default::default()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1429,7 +1429,7 @@ async fn async_main() -> anyhow::Result<()> {
         }
         Some(Commands::Open(args)) => {
             init_tracing("warn", log_path.as_deref());
-            repo_native_alignment::open_viewer::run(args.repo).await?;
+            repo_native_alignment::open_viewer::run(args.repo, business_context_mode).await?;
             return Ok(());
         }
         None => {}

--- a/src/open_viewer.rs
+++ b/src/open_viewer.rs
@@ -50,6 +50,7 @@ struct ViewerState {
     repo_root: PathBuf,
     /// Primary root slug for root_filter
     root_slug: String,
+    business_context: crate::business_context::BusinessContextAdmission,
 }
 
 // ─── Request / response types ─────────────────────────────────────────────────
@@ -120,6 +121,7 @@ async fn dispatch_tool(state: &ViewerState, call: &McpCall) -> Result<String, St
                 repo_root: &state.repo_root,
                 lsp_status: None,
                 embed_status: None,
+                business_context: &state.business_context,
             };
             Ok(repo_map(&params, &ctx))
         }
@@ -236,6 +238,7 @@ async fn dispatch_tool(state: &ViewerState, call: &McpCall) -> Result<String, St
                 root_filter,
                 non_code_slugs,
                 enrichment_jobs: Vec::new(),
+                business_context: &state.business_context,
             };
             Ok(search(&params, &ctx).await)
         }
@@ -315,6 +318,7 @@ pub async fn run(repo: PathBuf) -> anyhow::Result<()> {
         embed_index,
         repo_root,
         root_slug,
+        business_context: crate::business_context::BusinessContextAdmission::default(),
     });
 
     let app = Router::new()

--- a/src/open_viewer.rs
+++ b/src/open_viewer.rs
@@ -19,7 +19,7 @@
 //! Responses are raw service-layer markdown/text wrapped in `{ "result": "..." }`.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use axum::Router;
@@ -31,8 +31,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::net::TcpListener;
 
+use crate::business_context::{
+    BusinessContextAdmission, BusinessContextMode, CacheModeDisposition,
+};
 use crate::embed::EmbeddingIndex;
 use crate::server::state::GraphState;
+use crate::server::{RnaHandler, ScanEnrichmentOptions};
 use crate::service::{
     RepoMapContext, RepoMapParams, SearchContext, SearchParams, list_roots_from_slugs, repo_map,
     search,
@@ -50,7 +54,7 @@ struct ViewerState {
     repo_root: PathBuf,
     /// Primary root slug for root_filter
     root_slug: String,
-    business_context: crate::business_context::BusinessContextAdmission,
+    business_context: BusinessContextAdmission,
 }
 
 // ─── Request / response types ─────────────────────────────────────────────────
@@ -271,30 +275,55 @@ async fn bind_random_port() -> anyhow::Result<TcpListener> {
 
 // ─── Entry point ─────────────────────────────────────────────────────────────
 
+async fn load_viewer_graph(
+    repo_root: &Path,
+    business_context_mode: BusinessContextMode,
+) -> anyhow::Result<(GraphState, BusinessContextAdmission)> {
+    let handler = RnaHandler {
+        repo_root: repo_root.to_path_buf(),
+        business_context: BusinessContextAdmission::new(business_context_mode),
+        ..RnaHandler::default()
+    };
+
+    let graph = match handler.prepare_business_context_cache()? {
+        CacheModeDisposition::Compatible => {
+            let lance_path = repo_root.join(".oh").join(".cache").join("lance");
+            if !lance_path.exists() {
+                anyhow::bail!(
+                    "No index found at {}.\nRun `repo-native-alignment scan --repo .` first.",
+                    lance_path.display()
+                );
+            }
+            crate::server::load_graph_from_lance(repo_root)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to load graph: {}", e))?
+        }
+        CacheModeDisposition::Initialized | CacheModeDisposition::Rebuilt { .. } => {
+            let rebuilt = handler
+                .build_full_graph_inner(false, ScanEnrichmentOptions::extract_only())
+                .await?;
+            crate::server::persist_graph_to_lance(repo_root, &rebuilt.nodes, &rebuilt.edges)
+                .await?;
+            rebuilt
+        }
+    };
+
+    Ok((graph, handler.business_context.clone()))
+}
+
 /// Run `repo-native-alignment open --repo <path>`.
 ///
-/// 1. Loads the cached graph from LanceDB (requires a prior `scan`).
+/// 1. Validates the selected business-context cache identity, rebuilding when needed.
 /// 2. Starts Axum on a random port.
 /// 3. Opens the browser.
 /// 4. Blocks until Ctrl-C.
-pub async fn run(repo: PathBuf) -> anyhow::Result<()> {
+pub async fn run(repo: PathBuf, business_context_mode: BusinessContextMode) -> anyhow::Result<()> {
     let repo_root = repo
         .canonicalize()
         .map_err(|e| anyhow::anyhow!("Cannot resolve repo path {}: {}", repo.display(), e))?;
 
-    // Load graph from LanceDB cache.
-    let lance_path = repo_root.join(".oh").join(".cache").join("lance");
-    if !lance_path.exists() {
-        anyhow::bail!(
-            "No index found at {}.\nRun `repo-native-alignment scan --repo .` first.",
-            lance_path.display()
-        );
-    }
-
     eprintln!("Loading graph from cache...");
-    let graph = crate::server::load_graph_from_lance(&repo_root)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to load graph: {}", e))?;
+    let (graph, business_context) = load_viewer_graph(&repo_root, business_context_mode).await?;
     eprintln!(
         "  {} symbols, {} edges",
         graph.nodes.len(),
@@ -318,7 +347,7 @@ pub async fn run(repo: PathBuf) -> anyhow::Result<()> {
         embed_index,
         repo_root,
         root_slug,
-        business_context: crate::business_context::BusinessContextAdmission::default(),
+        business_context,
     });
 
     let app = Router::new()
@@ -374,6 +403,87 @@ fn open_browser(url: &str) -> anyhow::Result<()> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[tokio::test]
+    async fn viewer_loader_builds_before_cache_reads_for_missing_and_incompatible_modes() {
+        for (case, existing_cache, persisted_mode) in [
+            ("initialized", false, None),
+            ("mismatch", true, Some("enabled\n")),
+            ("legacy", true, None),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let root = temp.path();
+            std::fs::write(root.join("README.md"), "# Ordinary viewer document\n").unwrap();
+            std::fs::create_dir_all(root.join(".oh/outcomes")).unwrap();
+            std::fs::write(
+                root.join(".oh/outcomes/leak.md"),
+                "---\ntitle: Hidden\nstatus: active\n---\nhidden viewer context\n",
+            )
+            .unwrap();
+
+            let cache = root.join(".oh/.cache");
+            let poison = cache.join("lance/not-a-lancedb");
+            if existing_cache {
+                std::fs::create_dir_all(poison.parent().unwrap()).unwrap();
+                std::fs::write(&poison, "must be deleted before any cache read").unwrap();
+                if let Some(mode) = persisted_mode {
+                    std::fs::write(cache.join("business-context-mode"), mode).unwrap();
+                }
+            }
+
+            let (graph, admission) = load_viewer_graph(root, BusinessContextMode::Disabled)
+                .await
+                .unwrap_or_else(|error| panic!("{case} viewer load failed: {error:#}"));
+
+            assert_eq!(admission.mode(), BusinessContextMode::Disabled);
+            assert_eq!(
+                std::fs::read_to_string(cache.join("business-context-mode")).unwrap(),
+                "disabled\n"
+            );
+            if existing_cache {
+                assert!(
+                    !poison.exists(),
+                    "{case} cache was read instead of deleted before rebuild"
+                );
+            }
+            assert!(
+                graph
+                    .nodes
+                    .iter()
+                    .any(|node| node.id.file == PathBuf::from("README.md")),
+                "{case} viewer rebuild lost ordinary repository Markdown"
+            );
+            assert!(
+                graph
+                    .nodes
+                    .iter()
+                    .all(|node| !node.id.file.starts_with(".oh")),
+                "{case} viewer rebuild admitted disabled business artifacts"
+            );
+
+            let (reopened, reopened_admission) =
+                load_viewer_graph(root, BusinessContextMode::Disabled)
+                    .await
+                    .unwrap_or_else(|error| {
+                        panic!("{case} compatible viewer reopen failed: {error:#}")
+                    });
+            assert_eq!(reopened_admission.mode(), BusinessContextMode::Disabled);
+            assert!(
+                reopened
+                    .nodes
+                    .iter()
+                    .any(|node| node.id.file == PathBuf::from("README.md")),
+                "{case} compatible reopen lost ordinary repository Markdown"
+            );
+            assert!(
+                reopened
+                    .nodes
+                    .iter()
+                    .all(|node| !node.id.file.starts_with(".oh")),
+                "{case} compatible reopen admitted disabled business artifacts"
+            );
+        }
+    }
 
     // ── value_as_u64_tolerant ────────────────────────────────────────────
 

--- a/src/server/bg_scanner.rs
+++ b/src/server/bg_scanner.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::business_context::BusinessContextAdmission;
 use crate::extract::ExtractorRegistry;
 use crate::graph::index::GraphIndex;
 use crate::graph::{Edge, Node};
@@ -122,6 +123,7 @@ pub(super) async fn update_graph(
     scan_result: &mut ScanResult,
     repo_root: &std::path::Path,
     scan_stats: &Arc<std::sync::RwLock<crate::extract::scan_stats::ScanStats>>,
+    business_context: &BusinessContextAdmission,
 ) -> (Vec<LanceDelta>, Vec<String>) {
     let mut lance_deltas: Vec<LanceDelta> = Vec::new();
     let mut enrichment_diagnostics = Vec::new();
@@ -138,7 +140,10 @@ pub(super) async fn update_graph(
     }
 
     // Apply file-level changes per root.
-    for (root_slug, scan, root_path, _scanner) in &scan_result.per_root_scans {
+    for (root_slug, scan, root_path, _scanner) in &mut scan_result.per_root_scans {
+        business_context.retain_repository_files(&mut scan.changed_files);
+        business_context.retain_repository_files(&mut scan.new_files);
+        business_context.retain_repository_files(&mut scan.deleted_files);
         if scan.changed_files.is_empty()
             && scan.new_files.is_empty()
             && scan.deleted_files.is_empty()
@@ -254,6 +259,7 @@ pub(super) async fn update_graph(
             primary_slug.clone(),
             repo_root.to_path_buf(),
             crate::extract::consumers::BusOptions {
+                business_context: business_context.clone(),
                 scan_stats: Some(Arc::clone(scan_stats)),
                 embed_idx: None,
                 lance_repo_root: None,

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -2044,6 +2044,7 @@ impl RnaHandler {
 
         let embed_repo_root = self.repo_root.clone();
         let embed_index_ref = self.embed_index.clone();
+        let embed_business_context = self.business_context.clone();
         let (embed_job_id, run_embed_job) = if enrichment.runs_embeddings() {
             match self.enrichment_jobs.begin_job(
                 &self.repo_root,
@@ -2077,7 +2078,11 @@ impl RnaHandler {
             let count = match EmbeddingIndex::new(&embed_repo_root).await {
                 Ok(idx) => {
                     match idx
-                        .index_all_with_symbols(&embed_repo_root, &embeddable_nodes)
+                        .index_all_with_symbols_and_business_context(
+                            &embed_repo_root,
+                            &embeddable_nodes,
+                            &embed_business_context,
+                        )
                         .await
                     {
                         Ok(count) => {

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -97,6 +97,7 @@ struct PipelineReportInput {
     embeddings_attached: bool,
     phases: Vec<PhaseReport>,
     related_job_ids: Vec<String>,
+    business_context: crate::business_context::BusinessContextAdmission,
 }
 
 fn build_pipeline_operation_report(
@@ -140,6 +141,7 @@ fn build_pipeline_operation_report(
         input.lsp_state,
     );
     report.related_job_ids = input.related_job_ids;
+    report.record_business_context(&input.business_context);
     report
 }
 
@@ -412,6 +414,7 @@ async fn emit_lsp_pipeline_with_budget(
         input.primary_slug,
         input.repo_root,
         crate::extract::consumers::BusOptions {
+            business_context: Default::default(),
             scan_stats: Some(input.scan_stats),
             embed_idx: None,
             lance_repo_root: None,
@@ -442,6 +445,7 @@ impl RnaHandler {
     pub(crate) fn spawn_background_scanner(&self) {
         let graph = Arc::clone(&self.graph);
         let repo_root = self.repo_root.clone();
+        let business_context = self.business_context.clone();
         let lance_write_lock = Arc::clone(&self.lance_write_lock);
         let scan_stats = Arc::clone(&self.scan_stats);
         let lsp_status = Arc::clone(&self.lsp_status);
@@ -519,6 +523,7 @@ impl RnaHandler {
                         &mut scan_result,
                         &repo_root,
                         &scan_stats,
+                        &business_context,
                     )
                     .await;
 
@@ -994,6 +999,7 @@ impl RnaHandler {
         let bg_repo_root = self.repo_root.clone();
         let bg_embed_index = self.embed_index.clone();
         let bg_embed_status = self.embed_status.clone();
+        let bg_business_context = self.business_context.clone();
         let bg_nodes = all_nodes.to_vec();
         let job_id = match self.enrichment_jobs.begin_job(
             &self.repo_root,
@@ -1054,8 +1060,12 @@ impl RnaHandler {
                             }
                             Ok(false) => {
                                 // Table missing -- full build needed
-                                idx.index_all_with_symbols(&embed_repo_root, &embeddable_nodes)
-                                    .await
+                                idx.index_all_with_symbols_and_business_context(
+                                    &embed_repo_root,
+                                    &embeddable_nodes,
+                                    &bg_business_context,
+                                )
+                                .await
                             }
                             Err(e) => {
                                 tracing::warn!("[background] Embedding table check failed: {}", e);
@@ -1597,6 +1607,7 @@ impl RnaHandler {
                     embeddings_attached: self.embed_index.load().is_some(),
                     phases,
                     related_job_ids,
+                    business_context: self.business_context.clone(),
                 },
             );
 
@@ -1923,6 +1934,7 @@ impl RnaHandler {
                 embeddings_attached: self.embed_index.load().is_some(),
                 phases,
                 related_job_ids,
+                business_context: self.business_context.clone(),
             },
         );
 
@@ -2412,6 +2424,7 @@ impl RnaHandler {
                 embeddings_attached: self.embed_index.load().is_some(),
                 phases,
                 related_job_ids,
+                business_context: self.business_context.clone(),
             },
         );
 
@@ -3104,7 +3117,12 @@ impl RnaHandler {
                 );
             }
             let count = if matches!(scope, EnrichmentScope::Repo) {
-                idx.index_all_with_symbols(&self.repo_root, &selected_nodes).await?
+                idx.index_all_with_symbols_and_business_context(
+                    &self.repo_root,
+                    &selected_nodes,
+                    &self.business_context,
+                )
+                .await?
             } else {
                 idx.reindex_nodes(&selected_nodes).await?
             };
@@ -3363,6 +3381,7 @@ mod tests {
                 embeddings_attached: false,
                 phases: Vec::new(),
                 related_job_ids: Vec::new(),
+                business_context: crate::business_context::BusinessContextAdmission::default(),
             },
         );
 

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -1372,6 +1372,12 @@ impl RnaHandler {
     {
         let pipeline_start = std::time::Instant::now();
 
+        // The foreground pipeline has its own Lance cache-load path instead of
+        // delegating to `build_full_graph_inner`. Validate the requested mode
+        // before even checking that cache so a legacy or mismatched index is
+        // deleted and rebuilt rather than entering the incremental path.
+        self.prepare_business_context_cache()?;
+
         // Try incremental path: load cached graph, apply delta, LSP on changed nodes.
         let lance_path = super::store::graph_lance_path(&self.repo_root);
         let cached = if lance_path.exists() {

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -623,6 +623,7 @@ impl RnaHandler {
                 let scan_stats = Arc::clone(&self.scan_stats);
                 let lance_write_lock = Arc::clone(&self.lance_write_lock);
                 let embed_index = Arc::clone(&self.embed_index);
+                let business_context = self.business_context.clone();
                 let lsp_status = Arc::clone(&self.lsp_status);
                 let graph_build_lock = Arc::clone(&self.graph_build_lock);
                 let incremental_update_lock = Arc::clone(&self.incremental_update_lock);
@@ -787,6 +788,7 @@ impl RnaHandler {
                             primary_slug.clone(),
                             repo_root.clone(),
                             crate::extract::consumers::BusOptions {
+                                business_context: business_context.clone(),
                                 scan_stats: Some(Arc::clone(&scan_stats)),
                                 embed_idx: None,
                                 lance_repo_root: None,
@@ -809,10 +811,8 @@ impl RnaHandler {
                                 full_state.detected_frameworks = detected_frameworks;
 
                                 // Update LSP status
-                                let lsp_call_edge_count = scoped_lsp_call_edge_count(
-                                    &full_state.edges,
-                                    &lsp_node_filter,
-                                );
+                                let lsp_call_edge_count =
+                                    scoped_lsp_call_edge_count(&full_state.edges, &lsp_node_filter);
                                 let degraded_detail =
                                     (!diagnostics.is_empty()).then(|| diagnostics.join("; "));
                                 if let Some(detail) = degraded_detail.as_deref() {
@@ -1236,6 +1236,10 @@ impl RnaHandler {
         // Invalidate cached root slugs since workspace/worktree config may have changed.
         self.invalidate_non_code_root_slugs_cache();
 
+        // Business-context mode is part of the disposable index identity. A legacy,
+        // invalid, or mismatched cache is deleted before any Lance-backed read.
+        self.prepare_business_context_cache()?;
+
         // Initialize pattern config from .oh/config.toml (once, at first build).
         crate::extract::generic::init_pattern_config(&self.repo_root);
 
@@ -1455,7 +1459,11 @@ impl RnaHandler {
                                     }
                                     Ok(false) => {
                                         match idx
-                                            .index_all_with_symbols(&self.repo_root, &state.nodes)
+                                            .index_all_with_symbols_and_business_context(
+                                                &self.repo_root,
+                                                &state.nodes,
+                                                &self.business_context,
+                                            )
                                             .await
                                         {
                                             Ok(count) => {
@@ -1614,7 +1622,17 @@ impl RnaHandler {
             }
 
             // Dirty root (or clean root with no cache): full extract
-            let all_files = scanner.all_known_files();
+            let mut all_files = scanner.all_known_files();
+            let excluded_business_files = self
+                .business_context
+                .retain_repository_files(&mut all_files);
+            if excluded_business_files > 0 {
+                tracing::info!(
+                    "Business-context admission skipped {} .oh file(s) for root '{}'",
+                    excluded_business_files,
+                    root_slug
+                );
+            }
             let full_scan = crate::scanner::ScanResult {
                 changed_files: Vec::new(),
                 new_files: all_files,
@@ -1737,23 +1755,25 @@ impl RnaHandler {
             }
         }
 
-        // 4. Extract PR merges from git history
-        match crate::git::pr_merges::extract_pr_merges(&self.repo_root, Some(100)) {
-            Ok((pr_nodes, pr_edges)) => {
-                let modified_edges =
-                    crate::git::pr_merges::link_pr_to_symbols(&pr_nodes, &all_nodes);
-                tracing::info!(
-                    "PR merges: {} nodes, {} edges, {} Modified links",
-                    pr_nodes.len(),
-                    pr_edges.len(),
-                    modified_edges.len()
-                );
-                all_nodes.extend(pr_nodes);
-                all_edges.extend(pr_edges);
-                all_edges.extend(modified_edges);
-            }
-            Err(e) => {
-                tracing::warn!("Failed to extract PR merges: {}", e);
+        // 4. Extract PR merges from git history when admitted by the selected mode.
+        if self.business_context.admit_git_history_producer() {
+            match crate::git::pr_merges::extract_pr_merges(&self.repo_root, Some(100)) {
+                Ok((pr_nodes, pr_edges)) => {
+                    let modified_edges =
+                        crate::git::pr_merges::link_pr_to_symbols(&pr_nodes, &all_nodes);
+                    tracing::info!(
+                        "PR merges: {} nodes, {} edges, {} Modified links",
+                        pr_nodes.len(),
+                        pr_edges.len(),
+                        modified_edges.len()
+                    );
+                    all_nodes.extend(pr_nodes);
+                    all_edges.extend(pr_edges);
+                    all_edges.extend(modified_edges);
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to extract PR merges: {}", e);
+                }
             }
         }
 
@@ -1813,6 +1833,7 @@ impl RnaHandler {
                     primary_slug,
                     self.repo_root.clone(),
                     crate::extract::consumers::BusOptions {
+                        business_context: self.business_context.clone(),
                         scan_stats: Some(Arc::clone(&self.scan_stats)),
                         embed_idx: None, // embed handled by spawn_background_enrichment after graph is ready
                         lance_repo_root: None, // LanceDB persist handled directly after PageRank/subsystem passes
@@ -2280,7 +2301,7 @@ impl RnaHandler {
         // If no pre-computed scan, create a fresh scanner. We hold it so we
         // can commit state after successful processing.
         let mut fallback_scanner: Option<Scanner> = None;
-        let scan = match pending_scan {
+        let mut scan = match pending_scan {
             Some(s) => s,
             None => {
                 // Fallback: scan fresh (used by background scanner path)
@@ -2291,10 +2312,20 @@ impl RnaHandler {
             }
         };
 
+        self.business_context
+            .retain_repository_files(&mut scan.changed_files);
+        self.business_context
+            .retain_repository_files(&mut scan.new_files);
+        self.business_context
+            .retain_repository_files(&mut scan.deleted_files);
+
         if scan.changed_files.is_empty()
             && scan.new_files.is_empty()
             && scan.deleted_files.is_empty()
         {
+            if let Some(scanner) = fallback_scanner {
+                scanner.commit_state()?;
+            }
             return Ok(true);
         }
 
@@ -2479,6 +2510,7 @@ impl RnaHandler {
                 primary_slug.clone(),
                 self.repo_root.clone(),
                 crate::extract::consumers::BusOptions {
+                    business_context: self.business_context.clone(),
                     scan_stats: Some(Arc::clone(&self.scan_stats)),
                     embed_idx: None, // embed handled below via targeted reindex_nodes after PageRank
                     lance_repo_root: None, // LanceDB persist handled below via persist_graph_incremental
@@ -2511,8 +2543,7 @@ impl RnaHandler {
             graph.nodes = enriched_nodes;
             graph.edges = enriched_edges;
             graph.detected_frameworks = detected_frameworks;
-            let lsp_call_edge_count =
-                scoped_lsp_call_edge_count(&graph.edges, &lsp_node_filter);
+            let lsp_call_edge_count = scoped_lsp_call_edge_count(&graph.edges, &lsp_node_filter);
             let degraded_detail = (!diagnostics.is_empty()).then(|| diagnostics.join("; "));
             if enrichment.runs_lsp() {
                 incremental_lsp_outcome = Some((lsp_call_edge_count, degraded_detail));

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -2772,7 +2772,11 @@ impl RnaHandler {
                             e
                         );
                         if let Err(e2) = embed_idx
-                            .index_all_with_symbols(&self.repo_root, &graph.nodes)
+                            .index_all_with_symbols_and_business_context(
+                                &self.repo_root,
+                                &graph.nodes,
+                                &self.business_context,
+                            )
                             .await
                         {
                             tracing::warn!("Full embed rebuild also failed: {}", e2);

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -467,7 +467,13 @@ impl RnaHandler {
 
             // Check for changes via scanner
             let mut scanner = Scanner::new(self.repo_root.clone())?;
-            let scan = scanner.scan()?;
+            let mut scan = scanner.scan()?;
+            self.business_context
+                .retain_repository_files(&mut scan.changed_files);
+            self.business_context
+                .retain_repository_files(&mut scan.new_files);
+            self.business_context
+                .retain_repository_files(&mut scan.deleted_files);
             let missing_graph_files: Vec<(String, PathBuf)> = {
                 let root_paths: std::collections::HashMap<String, PathBuf> =
                     WorkspaceConfig::load()
@@ -1013,7 +1019,11 @@ impl RnaHandler {
                         if let Err(e) = embed_idx.reindex_nodes(&changed_file_nodes).await {
                             tracing::warn!("Background incremental: re-embed failed: {}", e);
                             if let Err(e2) = embed_idx
-                                .index_all_with_symbols(&repo_root, &full_state.nodes)
+                                .index_all_with_symbols_and_business_context(
+                                    &repo_root,
+                                    &full_state.nodes,
+                                    &business_context,
+                                )
                                 .await
                             {
                                 tracing::warn!(

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -162,6 +162,7 @@ impl RnaHandler {
                 root_filter: None,
                 non_code_slugs: std::collections::HashSet::new(),
                 enrichment_jobs: Vec::new(),
+                business_context: &self.business_context,
             };
             let markdown = crate::service::search(&params, &ctx).await;
             return Ok(text_result(markdown));
@@ -188,6 +189,7 @@ impl RnaHandler {
             root_filter,
             non_code_slugs,
             enrichment_jobs: self.enrichment_jobs.all_jobs(&self.repo_root),
+            business_context: &self.business_context,
         };
         let mut markdown = crate::service::search(&params, &ctx).await;
         if self.graph_build_status.is_building() {
@@ -217,6 +219,7 @@ impl RnaHandler {
             let ctx = OutcomeProgressContext {
                 graph_state: &external_graph,
                 repo_root: &repo_path,
+                business_context: &self.business_context,
             };
             let markdown = crate::service::outcome_progress(&params, &ctx);
             return Ok(text_result(markdown));
@@ -241,6 +244,7 @@ impl RnaHandler {
         let ctx = OutcomeProgressContext {
             graph_state: &graph_state,
             repo_root: &self.repo_root,
+            business_context: &self.business_context,
         };
         let mut markdown = crate::service::outcome_progress(&params, &ctx);
         if self.graph_build_status.is_building() {
@@ -303,6 +307,7 @@ impl RnaHandler {
                 repo_root: &repo_path,
                 lsp_status: None,
                 embed_status: None,
+                business_context: &self.business_context,
             };
             let markdown = crate::service::repo_map(&params, &ctx);
             return Ok(text_result(markdown));
@@ -328,6 +333,7 @@ impl RnaHandler {
             repo_root: &self.repo_root,
             lsp_status: Some(&self.lsp_status),
             embed_status: Some(&self.embed_status),
+            business_context: &self.business_context,
         };
         let mut markdown = crate::service::repo_map(&params, &ctx);
         if self.graph_build_status.is_building() {

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -37,10 +37,16 @@ use super::RnaHandler;
 use super::ScanEnrichmentOptions;
 use super::helpers::text_result;
 use super::state::GraphState;
-use super::store::load_graph_from_lance;
+use super::store::{load_graph_from_lance, persist_graph_to_lance};
 use super::tools::{OutcomeProgress, RepoMap, Search};
 
 impl RnaHandler {
+    /// Persist a complete graph snapshot while holding this handler's Lance write lock.
+    pub async fn persist_graph_snapshot(&self, graph: &GraphState) -> anyhow::Result<()> {
+        let _lance_guard = self.lance_write_lock.lock().await;
+        persist_graph_to_lance(&self.repo_root, &graph.nodes, &graph.edges).await
+    }
+
     /// Resolve a `repo` path string to a canonical [`PathBuf`].
     ///
     /// Only absolute paths are accepted. Relative paths are rejected with an
@@ -72,6 +78,7 @@ impl RnaHandler {
         let external_handler = RnaHandler {
             repo_root: repo_path.clone(),
             business_context: self.business_context.clone(),
+            lance_write_lock: self.lance_write_lock.clone(),
             ..RnaHandler::default()
         };
         let cache_disposition = external_handler.prepare_business_context_cache().map_err(
@@ -83,13 +90,23 @@ impl RnaHandler {
                 )
             },
         )?;
-        if cache_disposition.rebuilt() {
+        if cache_disposition.requires_fresh_graph() {
             let graph = external_handler
                 .build_full_graph_inner(false, ScanEnrichmentOptions::extract_only())
                 .await
                 .map_err(|error| {
                     format!(
                         "Failed to rebuild incompatible graph cache for repo \"{}\": {}",
+                        repo_path.display(),
+                        error
+                    )
+                })?;
+            external_handler
+                .persist_graph_snapshot(&graph)
+                .await
+                .map_err(|error| {
+                    format!(
+                        "Failed to persist fresh graph cache for repo \"{}\": {}",
                         repo_path.display(),
                         error
                     )
@@ -1025,42 +1042,65 @@ mod tests {
         assert!(result.is_err(), "relative path '.' should be rejected");
     }
 
-    // ── Integration: load_external_graph with real LanceDB ──────────────
+    // ── Integration: external graph cache lifecycle ─────────────────────
 
-    /// Verify that load_external_graph succeeds when a real LanceDB is present.
-    ///
-    /// Uses the main repo's own LanceDB at `.oh/.cache/lance`. This is always
-    /// present in developer environments. If absent (fresh CI checkout without
-    /// a prior scan), the test is skipped gracefully.
+    /// Verify that an initialized external cache is built, persisted, and reopened.
     #[tokio::test]
-    async fn test_load_external_graph_succeeds_with_real_lance() {
-        let repo_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let lance_path = repo_path.join(".oh/.cache/lance/symbols.lance");
-        if !lance_path.exists() {
-            // LanceDB not present — skip rather than fail.
-            eprintln!(
-                "Skipping: symbols.lance not present at {}",
-                lance_path.display()
-            );
-            return;
-        }
-        let handler = make_handler(&std::path::PathBuf::from("/tmp"));
-        let result = handler
+    async fn test_load_external_graph_builds_initialized_cache_and_reopens() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(
+            temp.path().join("src/lib.rs"),
+            "pub fn initialized_external_repo() {}\n",
+        )
+        .unwrap();
+
+        let handler = RnaHandler {
+            repo_root: std::path::PathBuf::from("/tmp"),
+            business_context: crate::business_context::BusinessContextAdmission::new(
+                crate::business_context::BusinessContextMode::Disabled,
+            ),
+            ..RnaHandler::default()
+        };
+        let repo_path = temp.path().to_path_buf();
+        let first = handler
             .load_external_graph(repo_path.to_str().unwrap())
             .await;
-        // Using match to avoid unwrap_err() which requires GraphState: Debug
-        match result {
-            Ok((graph, returned_path)) => {
-                assert_eq!(returned_path, repo_path, "Returned path should match input");
-                assert!(!graph.nodes.is_empty(), "Repo graph should have nodes");
-            }
-            Err(e) => panic!("Should load repo graph: {}", e),
-        }
+        let (first_graph, returned_path) = match first {
+            Ok(value) => value,
+            Err(error) => panic!("initialized external graph should build: {error}"),
+        };
+        assert_eq!(returned_path, repo_path);
+        assert!(
+            first_graph
+                .nodes
+                .iter()
+                .any(|node| node.id.file == PathBuf::from("src/lib.rs"))
+        );
+
+        let cache = repo_path.join(".oh/.cache");
+        assert_eq!(
+            std::fs::read_to_string(cache.join("business-context-mode")).unwrap(),
+            "disabled\n"
+        );
+        assert!(cache.join("lance/symbols.lance").exists());
+
+        let sentinel = cache.join("compatible-reopen-sentinel");
+        std::fs::write(&sentinel, "preserve compatible cache").unwrap();
+        let reopened = handler
+            .load_external_graph(repo_path.to_str().unwrap())
+            .await;
+        let (reopened_graph, _) = match reopened {
+            Ok(value) => value,
+            Err(error) => panic!("compatible external graph should reopen: {error}"),
+        };
+        assert!(sentinel.exists());
+        assert_eq!(reopened_graph.nodes.len(), first_graph.nodes.len());
     }
 
-    /// Verify that load_external_graph returns a clear error for a path without LanceDB.
+    /// Verify that load_external_graph returns a clear error for a missing repository.
     #[tokio::test]
-    async fn test_load_external_graph_fails_for_missing_lance() {
+    async fn test_load_external_graph_fails_for_missing_repo() {
         let handler = make_handler(&std::path::PathBuf::from("/tmp"));
         let result = handler
             .load_external_graph("/tmp/no-such-repo-rna-test")

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -34,6 +34,7 @@ use crate::service::{
 };
 
 use super::RnaHandler;
+use super::ScanEnrichmentOptions;
 use super::helpers::text_result;
 use super::state::GraphState;
 use super::store::load_graph_from_lance;
@@ -68,6 +69,33 @@ impl RnaHandler {
     /// human-readable message (e.g. the repo has not been scanned yet).
     async fn load_external_graph(&self, repo: &str) -> Result<(GraphState, PathBuf), String> {
         let repo_path = self.resolve_repo_path(repo)?;
+        let external_handler = RnaHandler {
+            repo_root: repo_path.clone(),
+            business_context: self.business_context.clone(),
+            ..RnaHandler::default()
+        };
+        let cache_disposition = external_handler.prepare_business_context_cache().map_err(
+            |error| {
+                format!(
+                    "Failed to load graph from repo \"{}\": disposable-cache validation failed: {}",
+                    repo_path.display(),
+                    error
+                )
+            },
+        )?;
+        if cache_disposition.rebuilt() {
+            let graph = external_handler
+                .build_full_graph_inner(false, ScanEnrichmentOptions::extract_only())
+                .await
+                .map_err(|error| {
+                    format!(
+                        "Failed to rebuild incompatible graph cache for repo \"{}\": {}",
+                        repo_path.display(),
+                        error
+                    )
+                })?;
+            return Ok((graph, repo_path));
+        }
         let graph = load_graph_from_lance(&repo_path).await.map_err(|e| {
             format!(
                 "Failed to load graph from repo \"{}\": {}. \

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -44,6 +44,7 @@ use rust_mcp_sdk::schema::{
     RpcError, TextContent,
 };
 
+use crate::business_context::{BusinessContextAdmission, CacheModeDisposition};
 use crate::embed::EmbeddingIndex;
 #[cfg(test)]
 use crate::graph::NodeKind;
@@ -79,6 +80,8 @@ impl PipelineResult {
 
 pub struct RnaHandler {
     pub repo_root: PathBuf,
+    /// Producer admission and disposable-cache mode shared by every scan path.
+    pub business_context: BusinessContextAdmission,
     /// Lock-free graph state via ArcSwap (#574).
     /// Readers (tool calls) load an atomic snapshot — zero blocking.
     /// Writers (pre-warm, background scanner) build a new graph and swap the pointer.
@@ -144,6 +147,7 @@ impl Default for RnaHandler {
     fn default() -> Self {
         Self {
             repo_root: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            business_context: BusinessContextAdmission::default(),
             graph: Arc::new(ArcSwap::from_pointee(None)),
             embed_index: Arc::new(ArcSwap::from_pointee(None)),
             context_injected: std::sync::atomic::AtomicBool::new(false),
@@ -172,6 +176,20 @@ impl Default for RnaHandler {
 }
 
 impl RnaHandler {
+    /// Validate the exact disposable repo cache before any cache-backed read.
+    pub fn prepare_business_context_cache(&self) -> anyhow::Result<CacheModeDisposition> {
+        let disposition = self.business_context.prepare_cache(&self.repo_root)?;
+        if disposition.rebuilt() {
+            self.graph.store(Arc::new(None));
+            self.embed_index.store(Arc::new(None));
+            tracing::info!(
+                "Rebuilt incompatible disposable cache for business context mode {}",
+                self.business_context.mode()
+            );
+        }
+        Ok(disposition)
+    }
+
     /// Create a clone of this handler that shares all `Arc`-wrapped state.
     ///
     /// Used by `start_prewarm()` to spawn a background graph build task that
@@ -181,6 +199,7 @@ impl RnaHandler {
     fn clone_shared(&self) -> Self {
         Self {
             repo_root: self.repo_root.clone(),
+            business_context: self.business_context.clone(),
             graph: Arc::clone(&self.graph),
             embed_index: Arc::clone(&self.embed_index),
             context_injected: std::sync::atomic::AtomicBool::new(false),
@@ -442,6 +461,18 @@ fn build_context_preamble(root: &Path) -> String {
     out
 }
 
+fn build_context_preamble_for_mode(
+    root: &Path,
+    mode: crate::business_context::BusinessContextMode,
+) -> Option<String> {
+    if mode.is_disabled() {
+        return None;
+    }
+
+    let preamble = build_context_preamble(root);
+    (!preamble.is_empty()).then_some(preamble)
+}
+
 #[async_trait]
 impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
     /// Called after the MCP client sends the `initialized` notification.
@@ -484,12 +515,11 @@ impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
             .context_injected
             .load(std::sync::atomic::Ordering::Relaxed)
         {
-            let ctx = build_context_preamble(root);
-            if !ctx.is_empty() {
+            if let Some(ctx) = build_context_preamble_for_mode(root, self.business_context.mode()) {
                 tracing::info!("Injecting business context preamble on first tool call");
                 Some(ctx)
             } else {
-                // Empty preamble — mark as injected so we don't retry.
+                // Empty or policy-disabled preamble — mark as injected so we don't retry.
                 self.context_injected
                     .store(true, std::sync::atomic::Ordering::Relaxed);
                 None
@@ -554,6 +584,32 @@ impl rust_mcp_sdk::mcp_server::ServerHandler for RnaHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn disabled_mode_suppresses_automatic_business_context_preamble() {
+        let repo = tempfile::tempdir().unwrap();
+        let outcomes = repo.path().join(".oh/outcomes");
+        std::fs::create_dir_all(&outcomes).unwrap();
+        std::fs::write(
+            outcomes.join("benchmark-leak.md"),
+            "---\ntitle: Benchmark leak\nstatus: active\n---\nsecret benchmark context\n",
+        )
+        .unwrap();
+
+        let enabled = build_context_preamble_for_mode(
+            repo.path(),
+            crate::business_context::BusinessContextMode::Enabled,
+        )
+        .expect("enabled mode should expose fixture business context");
+        assert!(enabled.contains("Business Context"));
+        assert_eq!(
+            build_context_preamble_for_mode(
+                repo.path(),
+                crate::business_context::BusinessContextMode::Disabled,
+            ),
+            None
+        );
+    }
 
     #[tokio::test]
     async fn test_get_graph_detects_file_edits() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -612,6 +612,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disabled_get_graph_refresh_ignores_dot_oh_and_reopen_stays_clean() {
+        use crate::business_context::{BusinessContextAdmission, BusinessContextMode};
+        use std::sync::Arc;
+
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join(".oh/outcomes")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn ordinary_symbol() {}\n").unwrap();
+        let artifact = root.join(".oh/outcomes/leak.md");
+        std::fs::write(
+            &artifact,
+            "---\ntitle: Hidden\nstatus: active\n---\ninitial hidden context\n",
+        )
+        .unwrap();
+
+        let handler = RnaHandler {
+            repo_root: root.to_path_buf(),
+            business_context: BusinessContextAdmission::new(BusinessContextMode::Disabled),
+            ..RnaHandler::default()
+        };
+        let graph = handler
+            .build_full_graph_inner(false, ScanEnrichmentOptions::extract_only())
+            .await
+            .unwrap();
+        assert!(
+            graph
+                .nodes
+                .iter()
+                .all(|node| !node.id.file.starts_with(".oh"))
+        );
+        super::store::persist_graph_to_lance(root, &graph.nodes, &graph.edges)
+            .await
+            .unwrap();
+        handler.graph.store(Arc::new(Some(Arc::new(graph))));
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(
+            &artifact,
+            "---\ntitle: Hidden\nstatus: active\n---\nmutated hidden context\n",
+        )
+        .unwrap();
+
+        let refreshed = handler.get_graph().await.unwrap();
+        assert!(
+            refreshed
+                .nodes
+                .iter()
+                .any(|node| node.id.name == "ordinary_symbol")
+        );
+        assert!(
+            refreshed
+                .nodes
+                .iter()
+                .all(|node| !node.id.file.starts_with(".oh")),
+            "disabled live refresh must not publish changed .oh artifacts"
+        );
+
+        let reopened = load_graph_from_lance(root).await.unwrap();
+        assert!(
+            reopened
+                .nodes
+                .iter()
+                .all(|node| !node.id.file.starts_with(".oh")),
+            "excluded live refresh must not contaminate the persisted graph"
+        );
+        assert!(handler.business_context.counts().business_artifact_files >= 1);
+    }
+
+    #[tokio::test]
     async fn test_get_graph_detects_file_edits() {
         use tempfile::TempDir;
 

--- a/src/server/operation_report.rs
+++ b/src/server/operation_report.rs
@@ -4,6 +4,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::business_context::{
+    BusinessContextAdmission, BusinessContextExclusionCounts, BusinessContextMode,
+};
+
 use super::enrichment_jobs::{EnrichmentCapability, EnrichmentScope};
 
 const SCHEMA_VERSION: u32 = 1;
@@ -16,6 +20,10 @@ pub struct OperationReport {
     pub operation: OperationKind,
     pub trigger: OperationTrigger,
     pub repo: String,
+    #[serde(default)]
+    pub business_context_mode: BusinessContextMode,
+    #[serde(default)]
+    pub business_context_exclusions: BusinessContextExclusionCounts,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<String>,
     pub state: OperationState,
@@ -51,6 +59,8 @@ impl OperationReport {
             operation,
             trigger,
             repo: repo.display().to_string(),
+            business_context_mode: BusinessContextMode::default(),
+            business_context_exclusions: BusinessContextExclusionCounts::default(),
             scope: None,
             state: OperationState::Running,
             started_at: unix_now(),
@@ -86,6 +96,11 @@ impl OperationReport {
     pub fn with_scope(mut self, scope: impl Into<String>) -> Self {
         self.scope = Some(scope.into());
         self
+    }
+
+    pub fn record_business_context(&mut self, business_context: &BusinessContextAdmission) {
+        self.business_context_mode = business_context.mode();
+        self.business_context_exclusions = business_context.counts();
     }
 
     pub fn add_phase(&mut self, phase: PhaseReport) {
@@ -135,6 +150,15 @@ impl OperationReport {
             scope,
             state,
             duration
+        ));
+        lines.push(format!(
+            "  business context: {}",
+            self.business_context_mode
+        ));
+        lines.push(format!(
+            "  excluded producer inputs: {} .oh file(s), {} Git-history producer(s)",
+            self.business_context_exclusions.business_artifact_files,
+            self.business_context_exclusions.git_history_producers
         ));
 
         let mut output_parts = Vec::new();
@@ -1068,6 +1092,36 @@ mod tests {
         assert!(rendered.contains("embeddings: skipped"));
         assert!(rendered.contains("semantic search: embeddings skipped"));
         assert!(rendered.contains("repo-native-alignment enrich --capability embeddings"));
+    }
+
+    #[test]
+    fn operation_report_json_and_cli_deliver_business_context_mode_and_counts() {
+        let business_context = BusinessContextAdmission::new(BusinessContextMode::Disabled);
+        let mut files = vec![PathBuf::from(".oh/outcomes/leak.md")];
+        business_context.retain_repository_files(&mut files);
+        assert!(!business_context.admit_git_history_producer());
+
+        let mut report = OperationReport::new(
+            OperationKind::ExtractOnly,
+            OperationTrigger::Test,
+            Path::new("/tmp/repo"),
+        );
+        report.record_business_context(&business_context);
+
+        let json = serde_json::to_value(&report).unwrap();
+        assert_eq!(json["business_context_mode"], "disabled");
+        assert_eq!(
+            json["business_context_exclusions"]["business_artifact_files"],
+            1
+        );
+        assert_eq!(
+            json["business_context_exclusions"]["git_history_producers"],
+            1
+        );
+
+        let rendered = report.render_cli(false);
+        assert!(rendered.contains("business context: disabled"));
+        assert!(rendered.contains("1 .oh file(s), 1 Git-history producer(s)"));
     }
 
     #[tokio::test]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -336,6 +336,7 @@ pub struct SearchContext<'a> {
     pub root_filter: Option<String>,
     pub non_code_slugs: HashSet<String>,
     pub enrichment_jobs: Vec<EnrichmentJobRecord>,
+    pub business_context: &'a crate::business_context::BusinessContextAdmission,
 }
 
 /// Returns true when a graph node's root passes the active root filter.

--- a/src/service/progress.rs
+++ b/src/service/progress.rs
@@ -20,12 +20,17 @@ pub struct OutcomeProgressParams {
 pub struct OutcomeProgressContext<'a> {
     pub graph_state: &'a crate::server::state::GraphState,
     pub repo_root: &'a Path,
+    pub business_context: &'a crate::business_context::BusinessContextAdmission,
 }
 
 pub fn outcome_progress(
     params: &OutcomeProgressParams,
     ctx: &OutcomeProgressContext<'_>,
 ) -> String {
+    if !ctx.business_context.admit_git_history_producer() {
+        return "Outcome progress unavailable because business context is disabled.".to_string();
+    }
+
     let graph_nodes: Vec<crate::graph::Node> = ctx
         .graph_state
         .nodes
@@ -104,5 +109,43 @@ pub fn outcome_progress(
             md
         }
         Err(e) => format!("Error: {}", e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::business_context::{BusinessContextAdmission, BusinessContextMode};
+    use crate::graph::index::GraphIndex;
+    use crate::server::state::GraphState;
+
+    #[test]
+    fn disabled_business_context_stops_outcome_progress_before_history_load() {
+        let graph_state = GraphState::new(
+            Vec::new(),
+            Vec::new(),
+            GraphIndex::new(),
+            None,
+            HashSet::new(),
+        );
+        let repo = tempfile::tempdir().unwrap();
+        let business_context = BusinessContextAdmission::new(BusinessContextMode::Disabled);
+        let params = OutcomeProgressParams {
+            outcome_id: "unreachable".to_string(),
+            include_impact: false,
+            root_filter: None,
+            non_code_slugs: HashSet::new(),
+        };
+        let ctx = OutcomeProgressContext {
+            graph_state: &graph_state,
+            repo_root: repo.path(),
+            business_context: &business_context,
+        };
+
+        assert_eq!(
+            outcome_progress(&params, &ctx),
+            "Outcome progress unavailable because business context is disabled."
+        );
+        assert_eq!(business_context.counts().git_history_producers, 1);
     }
 }

--- a/src/service/repomap.rs
+++ b/src/service/repomap.rs
@@ -25,6 +25,7 @@ pub struct RepoMapContext<'a> {
     pub repo_root: &'a Path,
     pub lsp_status: Option<&'a LspEnrichmentStatus>,
     pub embed_status: Option<&'a EmbeddingStatus>,
+    pub business_context: &'a crate::business_context::BusinessContextAdmission,
 }
 
 pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
@@ -298,7 +299,7 @@ pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
             sections.push(format!("## Hotspot files\n\n{}", md));
         }
     }
-    {
+    if !ctx.business_context.mode().is_disabled() {
         let outcomes = crate::oh::load_oh_artifacts(ctx.repo_root)
             .unwrap_or_default()
             .into_iter()
@@ -407,6 +408,7 @@ pub fn repo_map(params: &RepoMapParams, ctx: &RepoMapContext<'_>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::business_context::{BusinessContextAdmission, BusinessContextMode};
     use crate::graph::index::GraphIndex;
     use crate::graph::{ExtractionSource, NodeId};
     use crate::server::state::GraphState;
@@ -447,11 +449,13 @@ mod tests {
         node.metadata.insert("importance".into(), "0.5".into());
         let gs = make_graph_state(vec![node]);
         let repo_root = PathBuf::from("/tmp/test");
+        let business_context = BusinessContextAdmission::default();
         let ctx = RepoMapContext {
             graph_state: &gs,
             repo_root: &repo_root,
             lsp_status: None,
             embed_status: None,
+            business_context: &business_context,
         };
         let params = RepoMapParams {
             top_n: 15,
@@ -479,11 +483,13 @@ mod tests {
         node.metadata.insert("importance".into(), "0.5".into());
         let gs = make_graph_state(vec![node]);
         let repo_root = PathBuf::from("/tmp/test");
+        let business_context = BusinessContextAdmission::default();
         let ctx = RepoMapContext {
             graph_state: &gs,
             repo_root: &repo_root,
             lsp_status: None,
             embed_status: None,
+            business_context: &business_context,
         };
         let params = RepoMapParams {
             top_n: 15,
@@ -524,11 +530,13 @@ mod tests {
 
         let gs = make_graph_state(vec![duplicate_a, duplicate_b, distinct_same_name]);
         let repo_root = PathBuf::from("/tmp/test");
+        let business_context = BusinessContextAdmission::default();
         let ctx = RepoMapContext {
             graph_state: &gs,
             repo_root: &repo_root,
             lsp_status: None,
             embed_status: None,
+            business_context: &business_context,
         };
         let params = RepoMapParams {
             top_n: 15,
@@ -546,5 +554,43 @@ mod tests {
             result.contains("`src/extract/mod.rs`:30-40"),
             "same short name in a distinct file should remain visible: {result}"
         );
+    }
+
+    #[test]
+    fn disabled_business_context_skips_live_outcome_loading() {
+        let graph_state = make_graph_state(Vec::new());
+        let repo_root =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/business_context_isolation");
+        let params = RepoMapParams {
+            top_n: 15,
+            root_filter: None,
+            non_code_slugs: HashSet::new(),
+        };
+
+        let enabled = BusinessContextAdmission::default();
+        let enabled_result = repo_map(
+            &params,
+            &RepoMapContext {
+                graph_state: &graph_state,
+                repo_root: &repo_root,
+                lsp_status: None,
+                embed_status: None,
+                business_context: &enabled,
+            },
+        );
+        assert!(enabled_result.contains("## Active outcomes"));
+
+        let disabled = BusinessContextAdmission::new(BusinessContextMode::Disabled);
+        let disabled_result = repo_map(
+            &params,
+            &RepoMapContext {
+                graph_state: &graph_state,
+                repo_root: &repo_root,
+                lsp_status: None,
+                embed_status: None,
+                business_context: &disabled,
+            },
+        );
+        assert!(!disabled_result.contains("## Active outcomes"));
     }
 }

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -976,7 +976,13 @@ async fn search_flat(
     {
         let chunks: Vec<_> = chunks
             .into_iter()
-            .filter(|chunk| ctx.business_context.admit_repository_file(&chunk.file_path))
+            .filter(|chunk| {
+                let repository_path = chunk
+                    .file_path
+                    .strip_prefix(ctx.repo_root)
+                    .unwrap_or(&chunk.file_path);
+                ctx.business_context.admit_repository_file(repository_path)
+            })
             .collect();
         let filtered_chunks: Vec<_> = if let Some(ref slug) = ctx.root_filter {
             let workspace = crate::roots::WorkspaceConfig::load()

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -974,6 +974,10 @@ async fn search_flat(
         && !query_str.is_empty()
         && let Ok(chunks) = crate::markdown::extract_markdown_chunks(ctx.repo_root)
     {
+        let chunks: Vec<_> = chunks
+            .into_iter()
+            .filter(|chunk| ctx.business_context.admit_repository_file(&chunk.file_path))
+            .collect();
         let filtered_chunks: Vec<_> = if let Some(ref slug) = ctx.root_filter {
             let workspace = crate::roots::WorkspaceConfig::load()
                 .with_primary_root(ctx.repo_root.to_path_buf())
@@ -2662,6 +2666,9 @@ mod tests {
         graph_state: &'a GraphState,
         repo_root: &'a Path,
     ) -> SearchContext<'a> {
+        static BUSINESS_CONTEXT: std::sync::LazyLock<
+            crate::business_context::BusinessContextAdmission,
+        > = std::sync::LazyLock::new(crate::business_context::BusinessContextAdmission::default);
         SearchContext {
             graph_state,
             embed_index: None,
@@ -2671,6 +2678,7 @@ mod tests {
             root_filter: None,
             non_code_slugs: HashSet::new(),
             enrichment_jobs: Vec::new(),
+            business_context: &BUSINESS_CONTEXT,
         }
     }
 
@@ -4462,6 +4470,7 @@ mod tests {
         other.id.root = "other-project".to_string();
         let gs = make_graph_state(vec![local, other]);
         let repo_root = PathBuf::from("/tmp/test");
+        let business_context = crate::business_context::BusinessContextAdmission::default();
         let ctx = SearchContext {
             graph_state: &gs,
             embed_index: None,
@@ -4471,6 +4480,7 @@ mod tests {
             root_filter: Some("my-project".into()),
             non_code_slugs: HashSet::new(),
             enrichment_jobs: Vec::new(),
+            business_context: &business_context,
         };
         let params = SearchParams {
             query: Some("handler".into()),

--- a/src/smoke_test.rs
+++ b/src/smoke_test.rs
@@ -1968,6 +1968,7 @@ async fn run_impact_output_size_check(index: &GraphIndex, nodes: &[Node]) -> Che
         root_filter: None,
         non_code_slugs: std::collections::HashSet::new(),
         enrichment_jobs: Vec::new(),
+        business_context: &crate::business_context::BusinessContextAdmission::default(),
     };
 
     let params = crate::service::SearchParams {

--- a/tests/business_context_isolation.rs
+++ b/tests/business_context_isolation.rs
@@ -1,0 +1,270 @@
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use git2::{IndexAddOption, Repository, Signature};
+use petgraph::Direction;
+use repo_native_alignment::business_context::{BusinessContextAdmission, BusinessContextMode};
+use repo_native_alignment::graph::{ExtractionSource, NodeKind};
+use repo_native_alignment::server::{RnaHandler, ScanEnrichmentOptions};
+
+const SENTINEL: &str = "quasar_context_isolation_783";
+const ORDINARY_PATHS: &[&str] = &[
+    "README.md",
+    "docs/guide.md",
+    "notes.md",
+    "src/lib.rs",
+    "tests/isolation.rs",
+    "config.toml",
+];
+
+fn assert_rst_is_not_business_context_filtered() {
+    let admission = BusinessContextAdmission::new(BusinessContextMode::Disabled);
+    let mut producer_paths = vec![
+        PathBuf::from("reference.rst"),
+        PathBuf::from(".oh/outcomes/leak.md"),
+    ];
+
+    assert_eq!(admission.retain_repository_files(&mut producer_paths), 1);
+    assert_eq!(producer_paths, vec![PathBuf::from("reference.rst")]);
+    assert_eq!(admission.counts().business_artifact_files, 1);
+}
+
+fn copy_fixture(source: &Path, destination: &Path) {
+    fs::create_dir_all(destination).unwrap();
+    for entry in fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let target = destination.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_fixture(&entry.path(), &target);
+        } else {
+            fs::copy(entry.path(), target).unwrap();
+        }
+    }
+}
+
+fn write_index_tree(repo: &Repository) -> git2::Oid {
+    let mut index = repo.index().unwrap();
+    index
+        .add_all(["*"].iter(), IndexAddOption::DEFAULT, None)
+        .unwrap();
+    index.write().unwrap();
+    index.write_tree().unwrap()
+}
+
+fn initialize_merge_history(root: &Path) {
+    let repo = Repository::init(root).unwrap();
+    let signature = Signature::now("RNA fixture", "rna-fixture@example.invalid").unwrap();
+
+    let initial_tree_id = write_index_tree(&repo);
+    let initial_tree = repo.find_tree(initial_tree_id).unwrap();
+    let initial_oid = repo
+        .commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            "initial fixture",
+            &initial_tree,
+            &[],
+        )
+        .unwrap();
+
+    fs::write(root.join("history.txt"), format!("{SENTINEL}\n")).unwrap();
+    let feature_tree_id = write_index_tree(&repo);
+    let feature_tree = repo.find_tree(feature_tree_id).unwrap();
+    let initial_commit = repo.find_commit(initial_oid).unwrap();
+    let feature_oid = repo
+        .commit(
+            None,
+            &signature,
+            &signature,
+            &format!("feature containing {SENTINEL}"),
+            &feature_tree,
+            &[&initial_commit],
+        )
+        .unwrap();
+    let feature_commit = repo.find_commit(feature_oid).unwrap();
+
+    repo.commit(
+        Some("HEAD"),
+        &signature,
+        &signature,
+        &format!("Merge pull request #783 from fixture/context [{SENTINEL}]"),
+        &feature_tree,
+        &[&initial_commit, &feature_commit],
+    )
+    .unwrap();
+}
+
+fn disabled_handler(root: &Path) -> RnaHandler {
+    RnaHandler {
+        repo_root: root.to_path_buf(),
+        business_context: BusinessContextAdmission::new(BusinessContextMode::Disabled),
+        ..RnaHandler::default()
+    }
+}
+
+fn path_has_dot_oh(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str() == OsStr::new(".oh"))
+}
+
+async fn build_disabled(root: &Path) -> (RnaHandler, repo_native_alignment::server::GraphState) {
+    let handler = disabled_handler(root);
+    let graph = handler
+        .build_full_graph_inner(false, ScanEnrichmentOptions::extract_only())
+        .await
+        .unwrap();
+    (handler, graph)
+}
+
+fn assert_isolated_graph(graph: &repo_native_alignment::server::GraphState) {
+    for expected in ORDINARY_PATHS {
+        assert!(
+            graph
+                .nodes
+                .iter()
+                .any(|node| node.id.file == PathBuf::from(expected)),
+            "ordinary fixture path {expected} was not indexed"
+        );
+    }
+
+    assert!(
+        graph
+            .nodes
+            .iter()
+            .all(|node| !path_has_dot_oh(&node.id.file)),
+        ".oh business artifacts must never reach the disabled graph"
+    );
+    assert!(
+        graph
+            .nodes
+            .iter()
+            .all(|node| node.id.kind != NodeKind::PrMerge),
+        "Git PR-history producer must not emit disabled-mode nodes"
+    );
+    assert!(
+        graph
+            .nodes
+            .iter()
+            .all(|node| node.source != ExtractionSource::Git),
+        "Git-history provenance must not reach the disabled graph"
+    );
+    assert!(
+        graph.nodes.iter().any(|node| {
+            node.id.file == PathBuf::from("docs/guide.md")
+                && (node.body.contains(SENTINEL) || node.signature.contains(SENTINEL))
+        }),
+        "ordinary nested documentation content must remain searchable"
+    );
+
+    let traversable = graph
+        .nodes
+        .iter()
+        .find(|node| node.id.file == PathBuf::from("docs/guide.md"))
+        .expect("nested guide node");
+    assert!(
+        !graph
+            .index
+            .neighbors(&traversable.stable_id(), None, Direction::Outgoing)
+            .is_empty(),
+        "ordinary nested documentation must remain graph-traversable"
+    );
+}
+
+fn run_disabled_readme_query(root: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_repo-native-alignment"))
+        .args(["--business-context", "disabled", "search"])
+        .arg("--repo")
+        .arg(root)
+        .args(["--file", "README.md", "--include-markdown", "--limit", "5"])
+        .output()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn disabled_mode_isolates_producers_and_rebuilds_incompatible_caches() {
+    // Baseline RST extraction/LSP coverage is tracked in #784/#785. This
+    // regression proves #783 adds no RST-specific producer exclusion.
+    assert_rst_is_not_business_context_filtered();
+
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/business_context_isolation");
+    let temp = tempfile::tempdir().unwrap();
+    copy_fixture(&fixture, temp.path());
+    initialize_merge_history(temp.path());
+
+    let (fresh_handler, fresh_graph) = build_disabled(temp.path()).await;
+    assert_isolated_graph(&fresh_graph);
+    let fresh_counts = fresh_handler.business_context.counts();
+    assert!(fresh_counts.business_artifact_files >= 1);
+    assert!(fresh_counts.git_history_producers >= 1);
+
+    let cache = temp.path().join(".oh/.cache");
+    assert_eq!(
+        fs::read_to_string(cache.join("business-context-mode")).unwrap(),
+        "disabled\n"
+    );
+
+    let same_mode_sentinel = cache.join("same-mode-sentinel");
+    fs::write(&same_mode_sentinel, "preserve compatible cache").unwrap();
+    let (_, reopened_graph) = build_disabled(temp.path()).await;
+    assert!(same_mode_sentinel.exists());
+    assert_isolated_graph(&reopened_graph);
+
+    fs::write(cache.join("business-context-mode"), "enabled\n").unwrap();
+    let mismatch_sentinel = cache.join("mismatch-sentinel");
+    fs::write(&mismatch_sentinel, "must be discarded").unwrap();
+    let (_, mismatch_graph) = build_disabled(temp.path()).await;
+    assert!(!mismatch_sentinel.exists());
+    assert_isolated_graph(&mismatch_graph);
+    assert_eq!(
+        fs::read_to_string(cache.join("business-context-mode")).unwrap(),
+        "disabled\n"
+    );
+
+    fs::remove_file(cache.join("business-context-mode")).unwrap();
+    let legacy_sentinel = cache.join("legacy-sentinel");
+    fs::write(&legacy_sentinel, "must be discarded").unwrap();
+    let (_, legacy_graph) = build_disabled(temp.path()).await;
+    assert!(!legacy_sentinel.exists());
+    assert_isolated_graph(&legacy_graph);
+}
+
+#[test]
+fn direct_disabled_cli_query_rebuilds_mismatched_and_legacy_caches_first() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/business_context_isolation");
+    let temp = tempfile::tempdir().unwrap();
+    copy_fixture(&fixture, temp.path());
+    initialize_merge_history(temp.path());
+
+    let cache = temp.path().join(".oh/.cache");
+    for (case, persisted_mode) in [("mismatch", Some("enabled\n")), ("legacy", None)] {
+        fs::create_dir_all(&cache).unwrap();
+        let marker = cache.join("business-context-mode");
+        match persisted_mode {
+            Some(mode) => fs::write(&marker, mode).unwrap(),
+            None if marker.exists() => fs::remove_file(&marker).unwrap(),
+            None => {}
+        }
+        let poison = cache.join(format!("{case}-query-poison"));
+        fs::write(&poison, "must be deleted before query").unwrap();
+
+        let output = run_disabled_readme_query(temp.path());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "{case} direct query failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(!poison.exists(), "{case} cache was read without rebuild");
+        assert_eq!(fs::read_to_string(&marker).unwrap(), "disabled\n");
+        assert!(
+            stdout.contains("README.md"),
+            "{case} rebuild did not serve ordinary README content:\n{stdout}"
+        );
+        assert!(!stdout.contains(".oh/outcomes/leak.md"));
+    }
+}

--- a/tests/business_context_isolation.rs
+++ b/tests/business_context_isolation.rs
@@ -8,7 +8,9 @@ use petgraph::Direction;
 use repo_native_alignment::business_context::{BusinessContextAdmission, BusinessContextMode};
 use repo_native_alignment::graph::index::GraphIndex;
 use repo_native_alignment::graph::{ExtractionSource, NodeKind};
-use repo_native_alignment::server::{GraphState, RnaHandler, ScanEnrichmentOptions};
+use repo_native_alignment::server::{
+    GraphState, RnaHandler, ScanEnrichmentOptions, load_graph_from_lance,
+};
 use repo_native_alignment::service::{self, SearchContext, SearchParams};
 
 const SENTINEL: &str = "quasar_context_isolation_783";
@@ -181,6 +183,16 @@ fn run_disabled_readme_query(root: &Path) -> std::process::Output {
         .arg("--repo")
         .arg(root)
         .args(["--file", "README.md", "--include-markdown", "--limit", "5"])
+        .output()
+        .unwrap()
+}
+
+fn run_full_scan(root: &Path, mode: &str) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_repo-native-alignment"))
+        .args(["--business-context", mode, "scan"])
+        .arg("--repo")
+        .arg(root)
+        .args(["--full", "--extract-only"])
         .output()
         .unwrap()
 }
@@ -398,4 +410,52 @@ fn direct_disabled_cli_query_builds_or_rebuilds_then_reopens_compatible_cache() 
         assert!(reopened_stdout.contains("README.md"));
         assert!(!reopened_stdout.contains(".oh/outcomes/leak.md"));
     }
+}
+
+#[tokio::test]
+async fn disabled_full_scan_rebuilds_enabled_cache_before_lance_load() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/business_context_isolation");
+    let temp = tempfile::tempdir().unwrap();
+    copy_fixture(&fixture, temp.path());
+    initialize_merge_history(temp.path());
+
+    let enabled = run_full_scan(temp.path(), "enabled");
+    let enabled_stdout = String::from_utf8_lossy(&enabled.stdout);
+    let enabled_stderr = String::from_utf8_lossy(&enabled.stderr);
+    assert!(
+        enabled.status.success(),
+        "enabled full scan failed\nstdout:\n{enabled_stdout}\nstderr:\n{enabled_stderr}"
+    );
+
+    let cache = temp.path().join(".oh/.cache");
+    let marker = cache.join("business-context-mode");
+    assert_eq!(fs::read_to_string(&marker).unwrap(), "enabled\n");
+    let enabled_cache_sentinel = cache.join("enabled-full-scan-sentinel");
+    fs::write(&enabled_cache_sentinel, "must be deleted before Lance load").unwrap();
+
+    let disabled = run_full_scan(temp.path(), "disabled");
+    let disabled_stdout = String::from_utf8_lossy(&disabled.stdout);
+    let disabled_stderr = String::from_utf8_lossy(&disabled.stderr);
+    assert!(
+        disabled.status.success(),
+        "disabled full scan failed\nstdout:\n{disabled_stdout}\nstderr:\n{disabled_stderr}"
+    );
+    assert!(
+        !enabled_cache_sentinel.exists(),
+        "disabled full scan reused the enabled cache"
+    );
+    assert!(
+        !disabled_stderr.contains("Loaded cached graph:"),
+        "disabled full scan read Lance before mode validation:\n{disabled_stderr}"
+    );
+    assert_eq!(fs::read_to_string(&marker).unwrap(), "disabled\n");
+    assert!(disabled_stderr.contains("business context: disabled"));
+    assert!(
+        disabled_stderr
+            .contains("excluded producer inputs: 1 .oh file(s), 1 Git-history producer(s)")
+    );
+
+    let persisted = load_graph_from_lance(temp.path()).await.unwrap();
+    assert_isolated_graph(&persisted);
 }

--- a/tests/business_context_isolation.rs
+++ b/tests/business_context_isolation.rs
@@ -285,6 +285,58 @@ async fn disabled_live_markdown_search_excludes_dot_oh_only() {
     assert!(business_context.counts().business_artifact_files >= 1);
 }
 
+#[tokio::test]
+async fn disabled_live_markdown_preserves_repo_under_dot_oh_ancestor() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/business_context_isolation");
+    let temp = tempfile::tempdir().unwrap();
+    let repo_root = temp.path().join(".oh/repository");
+    copy_fixture(&fixture, &repo_root);
+
+    let graph_state = GraphState::new(
+        Vec::new(),
+        Vec::new(),
+        GraphIndex::new(),
+        None,
+        std::collections::HashSet::new(),
+    );
+    let business_context = BusinessContextAdmission::new(BusinessContextMode::Disabled);
+    let params = SearchParams {
+        query: Some(SENTINEL.to_string()),
+        include_artifacts: false,
+        include_markdown: true,
+        limit: Some(20),
+        ..SearchParams::default()
+    };
+    let ctx = SearchContext {
+        graph_state: &graph_state,
+        embed_index: None,
+        repo_root: &repo_root,
+        lsp_status: None,
+        embed_status: None,
+        root_filter: None,
+        non_code_slugs: std::collections::HashSet::new(),
+        enrichment_jobs: Vec::new(),
+        business_context: &business_context,
+    };
+
+    let result = service::search(&params, &ctx).await;
+
+    assert!(
+        result.contains("README.md"),
+        "ancestor .oh falsely excluded ordinary Markdown: {result}"
+    );
+    assert!(
+        result.contains("docs/guide.md"),
+        "ancestor .oh falsely excluded nested Markdown: {result}"
+    );
+    assert!(
+        !result.contains(".oh/outcomes/leak.md"),
+        "repository-local business artifact escaped admission: {result}"
+    );
+    assert!(business_context.counts().business_artifact_files >= 1);
+}
+
 #[test]
 fn direct_disabled_cli_query_rebuilds_mismatched_and_legacy_caches_first() {
     let fixture =

--- a/tests/business_context_isolation.rs
+++ b/tests/business_context_isolation.rs
@@ -6,8 +6,10 @@ use std::process::Command;
 use git2::{IndexAddOption, Repository, Signature};
 use petgraph::Direction;
 use repo_native_alignment::business_context::{BusinessContextAdmission, BusinessContextMode};
+use repo_native_alignment::graph::index::GraphIndex;
 use repo_native_alignment::graph::{ExtractionSource, NodeKind};
-use repo_native_alignment::server::{RnaHandler, ScanEnrichmentOptions};
+use repo_native_alignment::server::{GraphState, RnaHandler, ScanEnrichmentOptions};
+use repo_native_alignment::service::{self, SearchContext, SearchParams};
 
 const SENTINEL: &str = "quasar_context_isolation_783";
 const ORDINARY_PATHS: &[&str] = &[
@@ -230,6 +232,57 @@ async fn disabled_mode_isolates_producers_and_rebuilds_incompatible_caches() {
     let (_, legacy_graph) = build_disabled(temp.path()).await;
     assert!(!legacy_sentinel.exists());
     assert_isolated_graph(&legacy_graph);
+}
+
+#[tokio::test]
+async fn disabled_live_markdown_search_excludes_dot_oh_only() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/business_context_isolation");
+    let temp = tempfile::tempdir().unwrap();
+    copy_fixture(&fixture, temp.path());
+
+    let graph_state = GraphState::new(
+        Vec::new(),
+        Vec::new(),
+        GraphIndex::new(),
+        None,
+        std::collections::HashSet::new(),
+    );
+    let business_context = BusinessContextAdmission::new(BusinessContextMode::Disabled);
+    let params = SearchParams {
+        query: Some(SENTINEL.to_string()),
+        include_artifacts: false,
+        include_markdown: true,
+        limit: Some(20),
+        ..SearchParams::default()
+    };
+    let ctx = SearchContext {
+        graph_state: &graph_state,
+        embed_index: None,
+        repo_root: temp.path(),
+        lsp_status: None,
+        embed_status: None,
+        root_filter: None,
+        non_code_slugs: std::collections::HashSet::new(),
+        enrichment_jobs: Vec::new(),
+        business_context: &business_context,
+    };
+
+    let result = service::search(&params, &ctx).await;
+
+    assert!(
+        result.contains("README.md"),
+        "ordinary Markdown missing: {result}"
+    );
+    assert!(
+        result.contains("docs/guide.md"),
+        "nested Markdown missing: {result}"
+    );
+    assert!(
+        !result.contains(".oh/outcomes/leak.md"),
+        "business artifact escaped live Markdown admission: {result}"
+    );
+    assert!(business_context.counts().business_artifact_files >= 1);
 }
 
 #[test]

--- a/tests/business_context_isolation.rs
+++ b/tests/business_context_isolation.rs
@@ -338,24 +338,32 @@ async fn disabled_live_markdown_preserves_repo_under_dot_oh_ancestor() {
 }
 
 #[test]
-fn direct_disabled_cli_query_rebuilds_mismatched_and_legacy_caches_first() {
+fn direct_disabled_cli_query_builds_or_rebuilds_then_reopens_compatible_cache() {
     let fixture =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/business_context_isolation");
-    let temp = tempfile::tempdir().unwrap();
-    copy_fixture(&fixture, temp.path());
-    initialize_merge_history(temp.path());
 
-    let cache = temp.path().join(".oh/.cache");
-    for (case, persisted_mode) in [("mismatch", Some("enabled\n")), ("legacy", None)] {
-        fs::create_dir_all(&cache).unwrap();
-        let marker = cache.join("business-context-mode");
-        match persisted_mode {
-            Some(mode) => fs::write(&marker, mode).unwrap(),
-            None if marker.exists() => fs::remove_file(&marker).unwrap(),
-            None => {}
+    for (case, persisted_mode, poison_cache) in [
+        ("initialized", None, false),
+        ("mismatch", Some("enabled\n"), true),
+        ("legacy", None, true),
+    ] {
+        let temp = tempfile::tempdir().unwrap();
+        copy_fixture(&fixture, temp.path());
+        initialize_merge_history(temp.path());
+
+        let cache = temp.path().join(".oh/.cache");
+        if persisted_mode.is_some() || poison_cache {
+            fs::create_dir_all(&cache).unwrap();
         }
-        let poison = cache.join(format!("{case}-query-poison"));
-        fs::write(&poison, "must be deleted before query").unwrap();
+        let marker = cache.join("business-context-mode");
+        if let Some(mode) = persisted_mode {
+            fs::write(&marker, mode).unwrap();
+        }
+        let poison = poison_cache.then(|| {
+            let path = cache.join(format!("{case}-query-poison"));
+            fs::write(&path, "must be deleted before query").unwrap();
+            path
+        });
 
         let output = run_disabled_readme_query(temp.path());
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -364,12 +372,30 @@ fn direct_disabled_cli_query_rebuilds_mismatched_and_legacy_caches_first() {
             output.status.success(),
             "{case} direct query failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
         );
-        assert!(!poison.exists(), "{case} cache was read without rebuild");
+        if let Some(poison) = poison {
+            assert!(!poison.exists(), "{case} cache was read without rebuild");
+        }
         assert_eq!(fs::read_to_string(&marker).unwrap(), "disabled\n");
         assert!(
             stdout.contains("README.md"),
             "{case} rebuild did not serve ordinary README content:\n{stdout}"
         );
         assert!(!stdout.contains(".oh/outcomes/leak.md"));
+
+        let compatible_sentinel = cache.join(format!("{case}-compatible-sentinel"));
+        fs::write(&compatible_sentinel, "preserve compatible cache").unwrap();
+        let reopened = run_disabled_readme_query(temp.path());
+        let reopened_stdout = String::from_utf8_lossy(&reopened.stdout);
+        let reopened_stderr = String::from_utf8_lossy(&reopened.stderr);
+        assert!(
+            reopened.status.success(),
+            "{case} compatible reopen failed\nstdout:\n{reopened_stdout}\nstderr:\n{reopened_stderr}"
+        );
+        assert!(
+            compatible_sentinel.exists(),
+            "{case} compatible reopen unexpectedly rebuilt the cache"
+        );
+        assert!(reopened_stdout.contains("README.md"));
+        assert!(!reopened_stdout.contains(".oh/outcomes/leak.md"));
     }
 }

--- a/tests/fixtures/business_context_isolation/.oh/outcomes/leak.md
+++ b/tests/fixtures/business_context_isolation/.oh/outcomes/leak.md
@@ -1,0 +1,8 @@
+---
+type: outcome
+status: active
+---
+
+# Excluded Quasar Outcome
+
+quasar_context_isolation_783

--- a/tests/fixtures/business_context_isolation/README.md
+++ b/tests/fixtures/business_context_isolation/README.md
@@ -1,0 +1,3 @@
+# Quasar Context Isolation
+
+quasar_context_isolation_783

--- a/tests/fixtures/business_context_isolation/config.toml
+++ b/tests/fixtures/business_context_isolation/config.toml
@@ -1,0 +1,2 @@
+[context]
+sentinel = "quasar_context_isolation_783"

--- a/tests/fixtures/business_context_isolation/docs/guide.md
+++ b/tests/fixtures/business_context_isolation/docs/guide.md
@@ -1,0 +1,7 @@
+# Nested Guide
+
+quasar_context_isolation_783
+
+## Traversable Detail
+
+quasar_context_isolation_783 must remain connected through ordinary document structure.

--- a/tests/fixtures/business_context_isolation/notes.md
+++ b/tests/fixtures/business_context_isolation/notes.md
@@ -1,0 +1,3 @@
+# Arbitrary Project Notes
+
+quasar_context_isolation_783

--- a/tests/fixtures/business_context_isolation/reference.rst
+++ b/tests/fixtures/business_context_isolation/reference.rst
@@ -1,0 +1,4 @@
+Quasar Context Isolation
+========================
+
+quasar_context_isolation_783

--- a/tests/fixtures/business_context_isolation/src/lib.rs
+++ b/tests/fixtures/business_context_isolation/src/lib.rs
@@ -1,0 +1,5 @@
+pub const QUASAR_CONTEXT_ISOLATION_783: &str = "quasar_context_isolation_783";
+
+pub fn fixture_entry() -> &'static str {
+    QUASAR_CONTEXT_ISOLATION_783
+}

--- a/tests/fixtures/business_context_isolation/tests/isolation.rs
+++ b/tests/fixtures/business_context_isolation/tests/isolation.rs
@@ -1,0 +1,4 @@
+#[test]
+fn quasar_context_isolation_783_test() {
+    assert_eq!("quasar_context_isolation_783", "quasar_context_isolation_783");
+}


### PR DESCRIPTION
Closes #783

## Problem

Benchmark runs need to remove RNA-specific `.oh` and Git-history context without changing the ordinary repository-document candidate universe. A Markdown-level switch would incorrectly remove README and Markdown; policy duplicated through every query path would overengineer a disposable derived index. Ordinary RST paths must likewise remain admitted, while baseline RST extraction/LSP completeness stays with #784/#785 rather than expanding this PR.

## Chosen solution

Use a strict typed `BusinessContextMode` at the CLI/harness and enforce disabled mode at event admission: do not emit `.oh` business-artifact events and do not launch or emit Git commit/PR-merge/history producers. Existing indexers and query consumers process the remaining event stream unchanged.

Persist the selected mode with the repo cache/index identity or metadata. Same-mode reopen is valid. Missing, legacy, invalid, or mismatched mode fails closed by deleting the exact disposable repository cache/index and rebuilding before any query is served. Suppress automatic business-context preamble injection and report mode plus producer exclusion counts in diagnostics/manifests.

This supersedes the earlier mixed-index sanitization design. There will be no business-context filters in search, source-span, batch, neighbors/impact, repo-map, outcome-progress, persistence, embedding, rerank, or delivery rendering.

## Verification intent

Use an adversarial identical-term fixture across `.oh`, Git/PR history, README, nested/arbitrary Markdown, RST, source, tests, and config. Prove fresh disabled scan, same-mode reopen, supported-surface search/traversal, direct preamble suppression, diagnostics, exact mismatched/legacy cache deletion plus rebuild, and that `.rst` survives shared admission without being counted as excluded. Baseline RST extraction/LSP completeness plus hybrid/semantic/reranked paid-run proof remain tracked by #784/#785.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--business-context enabled|disabled` to CLI, viewer, enrichment, and MCP workflows (default: `enabled`).
  * `disabled` now excludes `.oh/**` business artifacts and Git-history producers while preserving normal repo docs (including README/Markdown/RST).
  * Mode-aware cache validation with automatic rebuild on incompatibility/legacy; business-context details are shown in operation output.

* **Bug Fixes**
  * Prevented disabled-mode leakage across search, repo maps, outcome progress, and live refresh flows.

* **Tests**
  * Added isolation and fail-closed cache rebuild coverage, plus CLI/progress/diagnostics assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->