### PR TITLE
Honor LSP capabilities and fail fast on unsupported workspace/symbol

### DIFF
--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -2599,6 +2599,63 @@ pub async fn emit_enrichment_pipeline(
     std::collections::HashSet<String>,
     Vec<String>,
 )> {
+    let (nodes, edges, frameworks, diagnostics, _) = emit_enrichment_pipeline_inner(
+        nodes,
+        edges,
+        root_pairs,
+        primary_slug,
+        repo_root,
+        opts,
+        dirty_slugs,
+    )
+    .await?;
+    Ok((nodes, edges, frameworks, diagnostics))
+}
+
+/// Run the enrichment pipeline and return readiness evidence emitted by this
+/// invocation only. Foreground jobs use this instead of reading cumulative scan stats.
+pub(crate) async fn emit_enrichment_pipeline_with_validations(
+    nodes: Vec<crate::graph::Node>,
+    edges: Vec<crate::graph::Edge>,
+    root_pairs: Vec<(String, PathBuf)>,
+    primary_slug: String,
+    repo_root: PathBuf,
+    opts: BusOptions,
+    dirty_slugs: Option<std::collections::HashSet<String>>,
+) -> anyhow::Result<(
+    Vec<crate::graph::Node>,
+    Vec<crate::graph::Edge>,
+    std::collections::HashSet<String>,
+    Vec<String>,
+    Vec<crate::extract::scan_stats::LspValidationEvidence>,
+)> {
+    emit_enrichment_pipeline_inner(
+        nodes,
+        edges,
+        root_pairs,
+        primary_slug,
+        repo_root,
+        opts,
+        dirty_slugs,
+    )
+    .await
+}
+
+async fn emit_enrichment_pipeline_inner(
+    nodes: Vec<crate::graph::Node>,
+    edges: Vec<crate::graph::Edge>,
+    root_pairs: Vec<(String, PathBuf)>,
+    primary_slug: String,
+    repo_root: PathBuf,
+    opts: BusOptions,
+    dirty_slugs: Option<std::collections::HashSet<String>>,
+) -> anyhow::Result<(
+    Vec<crate::graph::Node>,
+    Vec<crate::graph::Edge>,
+    std::collections::HashSet<String>,
+    Vec<String>,
+    Vec<crate::extract::scan_stats::LspValidationEvidence>,
+)> {
     use crate::extract::event_bus::ExtractionEvent;
 
     // Wrap into Arc<[T]> for zero-copy bus fan-out.
@@ -2616,6 +2673,24 @@ pub async fn emit_enrichment_pipeline(
             dirty_slugs,
         })
         .await;
+
+    let mut validations = events
+        .iter()
+        .filter_map(|event| match event {
+            ExtractionEvent::EnrichmentComplete {
+                validation: Some(validation),
+                ..
+            } => Some(validation.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    validations.sort_by(|left, right| {
+        (&left.language, &left.server_name, left.method.as_deref()).cmp(&(
+            &right.language,
+            &right.server_name,
+            right.method.as_deref(),
+        ))
+    });
 
     // Collect PassesComplete — produced by EnrichmentFinalizer.
     // PassesComplete is a pipeline invariant: EnrichmentFinalizer always emits it.
@@ -2636,6 +2711,7 @@ pub async fn emit_enrichment_pipeline(
             edges.to_vec(),
             detected_frameworks,
             enrichment_diagnostics.to_vec(),
+            validations,
         )),
         _ => {
             anyhow::bail!(

--- a/src/extract/consumers.rs
+++ b/src/extract/consumers.rs
@@ -1576,6 +1576,7 @@ impl ExtractionConsumer for LspConsumer {
                         remediation: self.enricher.toolchain_remediation().map(str::to_string),
                         aborted: enrichment.aborted,
                         diagnostic: enrichment.diagnostic,
+                        validation: enrichment.lsp_validation,
                     },
                     ExtractionEvent::LspQueryMetrics {
                         slug: slug.clone(),
@@ -1623,6 +1624,13 @@ impl ExtractionConsumer for LspConsumer {
                         slug,
                         err_text
                     )),
+                    validation: Some(
+                        crate::extract::scan_stats::LspValidationEvidence::not_validated(
+                            self.language.clone(),
+                            self.enricher.name(),
+                            err_text,
+                        ),
+                    ),
                 }])
             }
         }
@@ -2925,6 +2933,7 @@ mod tests {
             remediation: None,
             aborted: false,
             diagnostic: None,
+            validation: None,
         };
         let finished = gate.on_event(&complete).await.unwrap();
         assert_eq!(finished.len(), 1);
@@ -3856,6 +3865,7 @@ mod tests {
             remediation: None,
             aborted: false,
             diagnostic: None,
+            validation: None,
         };
         let result = gate.on_event(&enrichment_done).await.unwrap();
         assert_eq!(
@@ -3939,6 +3949,7 @@ mod tests {
             remediation: None,
             aborted: false,
             diagnostic: None,
+            validation: None,
         };
         let result = gate.on_event(&enrichment_done).await.unwrap();
         // Should fire now: expected=1 (rust), received=1 (rust).
@@ -4020,6 +4031,7 @@ mod tests {
             remediation: None,
             aborted: false,
             diagnostic: None,
+            validation: None,
         };
         let result = gate.on_event(&rust_done).await.unwrap();
         assert!(
@@ -4040,6 +4052,7 @@ mod tests {
             remediation: None,
             aborted: false,
             diagnostic: None,
+            validation: None,
         };
         let result = gate.on_event(&python_done).await.unwrap();
         assert_eq!(

--- a/src/extract/event_bus.rs
+++ b/src/extract/event_bus.rs
@@ -125,6 +125,9 @@ pub enum ExtractionEvent {
         aborted: bool,
         /// Actionable failure detail for a degraded/aborted completion.
         diagnostic: Option<String>,
+        /// Capability-driven validation evidence. A processed result may carry
+        /// `symbol_count = Some(0)`; absence means validation did not run.
+        validation: Option<crate::extract::scan_stats::LspValidationEvidence>,
     },
 
     /// Query-yield measurements emitted separately from graph enrichment output.
@@ -1421,6 +1424,7 @@ mod tests {
                 server_missing: false,
                 remediation: None,
                 diagnostic: None,
+                validation: None,
             }
         };
 

--- a/src/extract/event_bus.rs
+++ b/src/extract/event_bus.rs
@@ -360,6 +360,7 @@ impl ExtractionEvent {
                 new_nodes,
                 updated_nodes,
                 diagnostic,
+                validation,
                 ..
             } => {
                 buf.extend_from_slice(slug.as_bytes());
@@ -403,6 +404,29 @@ impl ExtractionEvent {
                 if let Some(diagnostic) = diagnostic {
                     buf.push(b'\n');
                     buf.extend_from_slice(diagnostic.as_bytes());
+                }
+                if let Some(validation) = validation {
+                    buf.extend_from_slice(b"\nvalidation\t");
+                    buf.extend_from_slice(validation.language.as_bytes());
+                    buf.push(b'\t');
+                    buf.extend_from_slice(validation.server_name.as_bytes());
+                    buf.push(b'\t');
+                    buf.extend_from_slice(match validation.status {
+                        crate::extract::scan_stats::LspValidationStatus::Processed => b"processed",
+                        crate::extract::scan_stats::LspValidationStatus::Quiescent => b"quiescent",
+                        crate::extract::scan_stats::LspValidationStatus::NotValidated => {
+                            b"not_validated"
+                        }
+                    });
+                    buf.push(b'\t');
+                    buf.extend_from_slice(validation.method.as_deref().unwrap_or("-").as_bytes());
+                    buf.push(b'\t');
+                    match validation.symbol_count {
+                        Some(count) => buf.extend_from_slice(count.to_string().as_bytes()),
+                        None => buf.push(b'-'),
+                    }
+                    buf.push(b'\t');
+                    buf.extend_from_slice(validation.detail.as_deref().unwrap_or("-").as_bytes());
                 }
             }
             ExtractionEvent::LspQueryMetrics {
@@ -1435,6 +1459,45 @@ mod tests {
             e1.canonical_bytes(),
             e2.canonical_bytes(),
             "canonical_bytes must differ when patch values change (same node ID, different inferred type)"
+        );
+    }
+
+    #[test]
+    fn test_canonical_bytes_enrichment_complete_includes_validation() {
+        let make_enrichment = |validation| ExtractionEvent::EnrichmentComplete {
+            slug: "test".to_string(),
+            language: "rust".to_string(),
+            added_edges: Arc::from(vec![].into_boxed_slice()),
+            new_nodes: Arc::from(vec![].into_boxed_slice()),
+            updated_nodes: Arc::from(vec![].into_boxed_slice()),
+            server_name: Some("fixture-server".to_string()),
+            error_count: 0,
+            aborted: false,
+            server_missing: false,
+            remediation: None,
+            diagnostic: None,
+            validation: Some(validation),
+        };
+        let processed = make_enrichment(
+            crate::extract::scan_stats::LspValidationEvidence::processed(
+                "rust",
+                "fixture-server",
+                "workspace/symbol",
+                0,
+            ),
+        );
+        let quiescent = make_enrichment(
+            crate::extract::scan_stats::LspValidationEvidence::quiescent(
+                "rust",
+                "fixture-server",
+                "experimental/serverStatus",
+            ),
+        );
+
+        assert_ne!(
+            processed.canonical_bytes(),
+            quiescent.canonical_bytes(),
+            "canonical_bytes must include readiness evidence"
         );
     }
 

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -1171,8 +1171,8 @@ impl LspEnricher {
         // a project; pyright uses it to trigger import-graph indexing.
         // Save the URI for use as a documentSymbol validation fallback.
         let warmup_uri: Option<String> = if let Some(warmup_path) = warmup_path {
-            let uri_str = path_to_uri(&warmup_path).ok().map(|u| u.to_string());
-            match self.send_did_open(transport, &warmup_path).await {
+            let uri_str = path_to_uri(warmup_path).ok().map(|u| u.to_string());
+            match self.send_did_open(transport, warmup_path).await {
                 Ok(()) => {
                     tracing::info!(
                         "{} sent didOpen for '{}'",

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use policy::{LspBroadReferenceBudget, LspBroadReferenceBudgetSnapshot
 use policy::{LspQueryProfile, LspServerCapabilities};
 mod transport;
 pub(crate) mod work_items;
-use transport::{LspTransport, PipelinedTransport, path_to_uri};
+use transport::{LspTransport, PipelinedTransport, is_method_not_found, path_to_uri};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -37,7 +37,8 @@ use tokio::sync::Mutex;
 
 use lsp_types::{
     ClientCapabilities, GotoDefinitionParams, GotoDefinitionResponse, InitializeParams,
-    InitializeResult, Location, Position, TextDocumentIdentifier, TextDocumentPositionParams, Uri,
+    InitializeResult, Location, OneOf, Position, ServerCapabilities, TextDocumentIdentifier,
+    TextDocumentPositionParams, Uri,
 };
 
 use super::{Enricher, EnrichmentResult};
@@ -374,6 +375,10 @@ struct LspState {
     /// Whether the language server supports inlay hints
     /// (`textDocument/inlayHint`, LSP 3.17+).
     has_inlay_hints: bool,
+    /// Exact capabilities retained from the initialize response.
+    server_capabilities: Option<ServerCapabilities>,
+    /// Capability-driven readiness proof for this server.
+    validation_evidence: Option<crate::extract::scan_stats::LspValidationEvidence>,
     /// Whether the server reached quiescent=true during initialization.
     /// When false, the quiescence deadline expired before the server finished
     /// indexing. In that case Pass 3 (diagnostics) is skipped to avoid flooding
@@ -412,6 +417,167 @@ const ZERO_EDGE_MIN_WARMUP: std::time::Duration = std::time::Duration::from_secs
 /// node-count threshold can take 100+ minutes. This caps the wait at 2 minutes.
 const ZERO_EDGE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
+const READINESS_REQUEST_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(10);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReadinessValidationMethod {
+    WorkspaceSymbol,
+    DocumentSymbol,
+}
+
+impl ReadinessValidationMethod {
+    fn method(self) -> &'static str {
+        match self {
+            Self::WorkspaceSymbol => "workspace/symbol",
+            Self::DocumentSymbol => "textDocument/documentSymbol",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReadinessValidationCapabilities {
+    workspace_symbols: bool,
+    document_symbols: bool,
+}
+
+impl ReadinessValidationCapabilities {
+    fn from_server_capabilities(capabilities: &ServerCapabilities) -> Self {
+        Self {
+            workspace_symbols: provider_is_enabled(&capabilities.workspace_symbol_provider),
+            document_symbols: provider_is_enabled(&capabilities.document_symbol_provider),
+        }
+    }
+
+    fn primary(self) -> Option<ReadinessValidationMethod> {
+        if self.workspace_symbols {
+            Some(ReadinessValidationMethod::WorkspaceSymbol)
+        } else if self.document_symbols {
+            Some(ReadinessValidationMethod::DocumentSymbol)
+        } else {
+            None
+        }
+    }
+}
+
+fn provider_is_enabled<T>(provider: &Option<OneOf<bool, T>>) -> bool {
+    match provider {
+        Some(OneOf::Left(enabled)) => *enabled,
+        Some(OneOf::Right(_)) => true,
+        None => false,
+    }
+}
+
+#[async_trait::async_trait]
+trait ReadinessRequester: Send {
+    async fn readiness_request(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value>;
+}
+
+#[async_trait::async_trait]
+impl ReadinessRequester for LspTransport {
+    async fn readiness_request(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        self.request(method, params).await
+    }
+}
+
+async fn execute_readiness_validation(
+    requester: &mut dyn ReadinessRequester,
+    method: ReadinessValidationMethod,
+    warmup_uri: Option<&str>,
+    workspace_query: &str,
+    timeout: tokio::time::Duration,
+) -> Result<usize> {
+    let params = match method {
+        ReadinessValidationMethod::WorkspaceSymbol => {
+            serde_json::json!({ "query": workspace_query })
+        }
+        ReadinessValidationMethod::DocumentSymbol => {
+            let uri = warmup_uri.context(
+                "server advertises documentSymbol validation but no deterministic warm-up file was available",
+            )?;
+            serde_json::json!({ "textDocument": { "uri": uri } })
+        }
+    };
+    match tokio::time::timeout(
+        timeout,
+        requester.readiness_request(method.method(), params),
+    )
+    .await
+    {
+        Ok(Ok(response)) => Ok(response.as_array().map_or(0, Vec::len)),
+        Ok(Err(error)) if is_method_not_found(&error) => Err(anyhow::anyhow!(
+            "server advertised {} but returned unsupported method (-32601)",
+            method.method()
+        )),
+        Ok(Err(error)) => Err(anyhow::anyhow!(
+            "server advertised {} but validation failed: {}",
+            method.method(),
+            error
+        )),
+        Err(_) => Err(anyhow::anyhow!(
+            "server advertised {} but validation timed out after {}ms",
+            method.method(),
+            timeout.as_millis()
+        )),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReadinessValidationResult {
+    method: ReadinessValidationMethod,
+    symbol_count: usize,
+}
+
+async fn execute_indexing_validation_once(
+    requester: &mut dyn ReadinessRequester,
+    capabilities: ReadinessValidationCapabilities,
+    warmup_uri: Option<&str>,
+    workspace_query: &str,
+    timeout: tokio::time::Duration,
+) -> Result<Option<ReadinessValidationResult>> {
+    let Some(primary) = capabilities.primary() else {
+        return Err(anyhow::anyhow!(
+            "server advertises neither workspace/symbol nor textDocument/documentSymbol"
+        ));
+    };
+    let primary_count = execute_readiness_validation(
+        requester,
+        primary,
+        warmup_uri,
+        workspace_query,
+        timeout,
+    )
+    .await?;
+    if primary == ReadinessValidationMethod::DocumentSymbol || primary_count > 0 {
+        return Ok(Some(ReadinessValidationResult {
+            method: primary,
+            symbol_count: primary_count,
+        }));
+    }
+    if capabilities.document_symbols {
+        let symbol_count = execute_readiness_validation(
+            requester,
+            ReadinessValidationMethod::DocumentSymbol,
+            warmup_uri,
+            "",
+            timeout,
+        )
+        .await?;
+        return Ok(Some(ReadinessValidationResult {
+            method: ReadinessValidationMethod::DocumentSymbol,
+            symbol_count,
+        }));
+    }
+    Ok(None)
+}
+
 impl LspEnricher {
     /// Create a new LSP enricher for the given language server.
     ///
@@ -447,6 +613,8 @@ impl LspEnricher {
                 has_document_links: false,
                 has_pull_diagnostics: false,
                 has_inlay_hints: false,
+                server_capabilities: None,
+                validation_evidence: None,
                 was_quiescent: false,
                 type_hierarchy_strikes: 0,
                 diagnostics_sink: Arc::new(std::sync::Mutex::new(HashMap::new())),
@@ -664,9 +832,13 @@ impl LspEnricher {
             if depth > 4 {
                 return None;
             }
-            let entries = std::fs::read_dir(dir).ok()?;
+            let mut entries = std::fs::read_dir(dir)
+                .ok()?
+                .flatten()
+                .collect::<Vec<_>>();
+            entries.sort_by_key(|entry| entry.file_name());
             let mut subdirs = Vec::new();
-            for entry in entries.flatten() {
+            for entry in entries {
                 let name = entry.file_name();
                 let name_str = name.to_string_lossy();
                 if name_str.starts_with('.')
@@ -730,7 +902,7 @@ impl LspEnricher {
         walk(root, &extensions, 0)
     }
 
-    fn lsp_language_id_for_path(&self, path: &Path) -> &'static str {
+    fn lsp_language_id_for_path<'a>(&'a self, path: &Path) -> &'a str {
         match path.extension().and_then(|e| e.to_str()) {
             Some("py") => "python",
             Some("ts") => "typescript",
@@ -744,7 +916,7 @@ impl LspEnricher {
                 "typescript" | "deno" => "typescript",
                 "rust" => "rust",
                 "go" => "go",
-                _ => "plaintext",
+                language => language,
             },
         }
     }
@@ -791,6 +963,8 @@ impl LspEnricher {
         if state.pipelined.is_none() {
             state.transport.take();
             state.root_path = None;
+            state.server_capabilities = None;
+            state.validation_evidence = None;
         }
     }
 
@@ -1010,6 +1184,9 @@ impl LspEnricher {
 
         let init_result_parsed: InitializeResult =
             serde_json::from_value(init_result).context("Failed to parse initialize result")?;
+        let server_capabilities = init_result_parsed.capabilities.clone();
+        let validation_capabilities =
+            ReadinessValidationCapabilities::from_server_capabilities(&server_capabilities);
 
         let has_references = init_result_parsed
             .capabilities
@@ -1024,7 +1201,7 @@ impl LspEnricher {
             .document_link_provider
             .is_some();
         tracing::info!(
-            "{} capabilities: references={}, call_hierarchy={}, implementation={}, type_hierarchy={}, document_links={}, pull_diagnostics={}, inlay_hints={}",
+            "{} capabilities: references={}, call_hierarchy={}, implementation={}, type_hierarchy={}, document_links={}, pull_diagnostics={}, inlay_hints={}, workspace_symbols={}, document_symbols={}",
             self.server_command,
             has_references,
             has_call_hierarchy,
@@ -1032,7 +1209,9 @@ impl LspEnricher {
             has_type_hierarchy,
             has_document_links,
             has_pull_diagnostics,
-            has_inlay_hints
+            has_inlay_hints,
+            validation_capabilities.workspace_symbols,
+            validation_capabilities.document_symbols
         );
 
         state.has_type_hierarchy = has_type_hierarchy;
@@ -1042,6 +1221,8 @@ impl LspEnricher {
         state.has_references = has_references;
         state.has_pull_diagnostics = has_pull_diagnostics;
         state.has_inlay_hints = has_inlay_hints;
+        state.server_capabilities = Some(server_capabilities);
+        state.validation_evidence = None;
 
         // Send initialized notification
         let transport = state.transport.as_mut().unwrap();
@@ -1077,6 +1258,19 @@ impl LspEnricher {
             } else {
                 None
             };
+
+        let readiness_method = validation_capabilities.primary().ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} advertises neither workspace/symbol nor textDocument/documentSymbol; readiness was not validated",
+                self.server_command
+            )
+        })?;
+        if readiness_method == ReadinessValidationMethod::DocumentSymbol && warmup_uri.is_none() {
+            return Err(anyhow::anyhow!(
+                "{} advertises documentSymbol but no deterministic included warm-up file was available; readiness was not validated",
+                self.server_command
+            ));
+        }
 
         tracing::info!(
             "{} initialized, waiting for indexing...",
@@ -1137,6 +1331,7 @@ impl LspEnricher {
         // by sending workspace/symbol with non-empty queries. A server that responds
         // to probes but returns 0 symbols for real queries hasn't finished indexing.
         let mut server_responsive = false;
+        let mut validation_evidence = None;
 
         while tokio::time::Instant::now() < circuit_breaker {
             let elapsed = start.elapsed().as_secs();
@@ -1203,6 +1398,14 @@ impl LspEnricher {
                                 // not about compilation health (which may be "warning" or "error").
                                 if quiescent {
                                     saw_quiescent = true;
+                                    validation_evidence = Some(
+                                        crate::extract::scan_stats::LspValidationEvidence::processed(
+                                            self.language.clone(),
+                                            self.server_command.clone(),
+                                            "experimental/serverStatus",
+                                            0,
+                                        ),
+                                    );
                                 }
 
                                 if Self::server_status_is_ready(&msg) {
@@ -1274,31 +1477,46 @@ impl LspEnricher {
                         continue;
                     }
 
-                    // No serverStatus — use the probe strategy.
-                    // Send a lightweight workspace/symbol request to test responsiveness.
-                    // An empty query returns quickly and is safe on all LSP servers.
+                    // No serverStatus — probe only an advertised validation method.
                     if tokio::time::Instant::now() >= next_probe {
                         // Schedule next probe from probe start so cadence is ~5s regardless
                         // of whether the probe request itself times out or succeeds quickly.
                         next_probe =
                             tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
 
-                        let probe_result = tokio::time::timeout(
+                        let symbol_count = execute_readiness_validation(
+                            transport,
+                            readiness_method,
+                            warmup_uri.as_deref(),
+                            "",
                             tokio::time::Duration::from_secs(5),
-                            transport
-                                .request("workspace/symbol", serde_json::json!({ "query": "" })),
                         )
-                        .await;
+                        .await
+                        .with_context(|| {
+                            format!("{} readiness probe failed", self.server_command)
+                        })?;
 
-                        match probe_result {
-                            Ok(Ok(_)) | Ok(Err(_)) => {
-                                if let Ok(Err(e)) = &probe_result {
-                                    tracing::debug!(
-                                        "{} probe returned error (server responsive): {}",
-                                        self.server_command,
-                                        e
-                                    );
-                                }
+                        match readiness_method {
+                            ReadinessValidationMethod::DocumentSymbol => {
+                                validation_evidence =
+                                    Some(crate::extract::scan_stats::LspValidationEvidence::processed(
+                                        self.language.clone(),
+                                        self.server_command.clone(),
+                                        readiness_method.method(),
+                                        symbol_count,
+                                    ));
+                                server_responsive = true;
+                                server_ready = true;
+                                saw_quiescent = true;
+                                tracing::info!(
+                                    "{} indexing validated via documentSymbol: {} symbols in deterministic warm-up file ({}s elapsed)",
+                                    self.server_command,
+                                    symbol_count,
+                                    elapsed
+                                );
+                                break;
+                            }
+                            ReadinessValidationMethod::WorkspaceSymbol => {
                                 probe_success_count += 1;
                                 if probe_success_count >= 2 {
                                     server_responsive = true;
@@ -1313,15 +1531,6 @@ impl LspEnricher {
                                     "{} probe {}/2 succeeded ({}s elapsed), waiting for second confirmation...",
                                     self.server_command,
                                     probe_success_count,
-                                    elapsed
-                                );
-                            }
-                            Err(_) => {
-                                // Probe timed out — server still starting up.
-                                probe_success_count = 0;
-                                tracing::debug!(
-                                    "{} probe timed out ({}s elapsed), server still starting...",
-                                    self.server_command,
                                     elapsed
                                 );
                             }
@@ -1414,6 +1623,14 @@ impl LspEnricher {
                                 );
                                 server_ready = true;
                                 saw_quiescent = true;
+                                validation_evidence = Some(
+                                    crate::extract::scan_stats::LspValidationEvidence::processed(
+                                        self.language.clone(),
+                                        self.server_command.clone(),
+                                        "experimental/serverStatus",
+                                        0,
+                                    ),
+                                );
                             }
                         }
                     }
@@ -1424,99 +1641,48 @@ impl LspEnricher {
                     break;
                 }
 
-                let validation_result = tokio::time::timeout(
-                    tokio::time::Duration::from_secs(10),
-                    transport.request("workspace/symbol", serde_json::json!({ "query": query })),
-                )
-                .await;
-
                 let elapsed = start.elapsed().as_secs();
-
-                match validation_result {
-                    Ok(Ok(ref response)) => {
-                        let symbol_count = response.as_array().map(|a| a.len()).unwrap_or(0);
-                        if symbol_count > 0 {
-                            tracing::info!(
-                                "{} indexing validated: workspace/symbol(\"{}\") returned {} symbols ({}s elapsed)",
-                                self.server_command,
-                                query,
-                                symbol_count,
-                                elapsed
-                            );
-                            server_ready = true;
-                            saw_quiescent = true;
-                            break;
-                        }
-                        // workspace/symbol returned 0 — try documentSymbol on the
-                        // warmup file as a fallback. pyright's workspace/symbol
-                        // is unreliable (returns 0 even when fully indexed), but
-                        // documentSymbol works.
-                        if let Some(ref uri) = warmup_uri {
-                            let doc_result = tokio::time::timeout(
-                                tokio::time::Duration::from_secs(10),
-                                transport.request(
-                                    "textDocument/documentSymbol",
-                                    serde_json::json!({
-                                        "textDocument": { "uri": uri }
-                                    }),
-                                ),
-                            )
-                            .await;
-                            if let Ok(Ok(ref resp)) = doc_result {
-                                let doc_count = resp.as_array().map(|a| a.len()).unwrap_or(0);
-                                if doc_count > 0 {
-                                    tracing::info!(
-                                        "{} indexing validated via documentSymbol fallback: {} symbols in warmup file ({}s elapsed)",
-                                        self.server_command,
-                                        doc_count,
-                                        elapsed
-                                    );
-                                    server_ready = true;
-                                    saw_quiescent = true;
-                                    break;
-                                }
-                            }
-                        }
-                        consecutive_empty += 1;
-                        tracing::info!(
-                            "{} indexing validation {}/{}: workspace/symbol(\"{}\") returned 0 symbols ({}s elapsed, waiting {}s)",
-                            self.server_command,
-                            attempt,
-                            MAX_INDEXING_VALIDATION_ATTEMPTS,
-                            query,
-                            elapsed,
-                            validation_delay.as_secs()
-                        );
-                    }
-                    Ok(Err(e)) => {
-                        // Error response — the server is responsive but the query
-                        // may not be supported. Count it as non-indexed.
-                        consecutive_empty += 1;
-                        tracing::info!(
-                            "{} indexing validation {}/{}: workspace/symbol(\"{}\") returned error: {} ({}s elapsed)",
-                            self.server_command,
-                            attempt,
-                            MAX_INDEXING_VALIDATION_ATTEMPTS,
-                            query,
-                            e,
-                            elapsed
-                        );
-                    }
-                    Err(_) => {
-                        // Timeout — server is busy indexing. Do NOT count toward
-                        // consecutive_empty: a timeout means the server is actively
-                        // working (not that it returned empty results). Let the
-                        // attempt counter and circuit breaker handle slow servers.
-                        tracing::info!(
-                            "{} indexing validation {}/{}: workspace/symbol(\"{}\") timed out ({}s elapsed, not counting as empty)",
-                            self.server_command,
-                            attempt,
-                            MAX_INDEXING_VALIDATION_ATTEMPTS,
-                            query,
-                            elapsed
-                        );
-                    }
+                if let Some(validation) = execute_indexing_validation_once(
+                    transport,
+                    validation_capabilities,
+                    warmup_uri.as_deref(),
+                    query,
+                    READINESS_REQUEST_TIMEOUT,
+                )
+                .await
+                .with_context(|| {
+                    format!("{} indexing validation failed", self.server_command)
+                })? {
+                    tracing::info!(
+                        "{} indexing validated via {}: {} symbols ({}s elapsed)",
+                        self.server_command,
+                        validation.method.method(),
+                        validation.symbol_count,
+                        elapsed
+                    );
+                    validation_evidence = Some(
+                        crate::extract::scan_stats::LspValidationEvidence::processed(
+                            self.language.clone(),
+                            self.server_command.clone(),
+                            validation.method.method(),
+                            validation.symbol_count,
+                        ),
+                    );
+                    server_ready = true;
+                    saw_quiescent = true;
+                    break;
                 }
+
+                consecutive_empty += 1;
+                tracing::info!(
+                    "{} indexing validation {}/{}: workspace/symbol(\"{}\") returned 0 symbols ({}s elapsed, waiting {}s)",
+                    self.server_command,
+                    attempt,
+                    MAX_INDEXING_VALIDATION_ATTEMPTS,
+                    query,
+                    elapsed,
+                    validation_delay.as_secs()
+                );
 
                 // After consecutive empty responses on different queries,
                 // the server may not have finished indexing yet. Only bail
@@ -1578,6 +1744,13 @@ impl LspEnricher {
         // on validation (e.g., pyright before indexing completes) is NOT treated
         // as quiescent — Pass 1 and Pass 3 would produce 0 edges.
         state.was_quiescent = saw_quiescent || (!seen_server_status && server_ready);
+        state.validation_evidence = Some(validation_evidence.unwrap_or_else(|| {
+            crate::extract::scan_stats::LspValidationEvidence::not_validated(
+                self.language.clone(),
+                self.server_command.clone(),
+                "server did not complete an advertised readiness validation method",
+            )
+        }));
         if !state.was_quiescent {
             tracing::warn!(
                 "{} did not reach quiescent state — Pass 3 (diagnostics) will be skipped this session",
@@ -2771,6 +2944,7 @@ impl Enricher for LspEnricher {
             has_pull_diagnostics,
             has_inlay_hints,
             was_quiescent,
+            validation_evidence,
             diag_sink,
         ) = {
             let state = self.state.lock().await;
@@ -2796,9 +2970,18 @@ impl Enricher for LspEnricher {
                 state.has_pull_diagnostics,
                 state.has_inlay_hints,
                 was_quiescent,
+                state.validation_evidence.clone(),
                 diag_sink,
             )
         };
+        result.lsp_validation = validation_evidence;
+        if let Some(validation) = result.lsp_validation.as_ref() {
+            tracing::info!(
+                "{} readiness validation evidence: {}",
+                self.server_command,
+                validation.summary()
+            );
+        }
 
         // Pass 0: crate-level dependency graph (Rust only, no quiescence needed)
         if let Err(detail) = self
@@ -3003,11 +3186,228 @@ impl Enricher for LspEnricher {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, VecDeque};
     use std::str::FromStr;
 
-    use super::transport::{find_enclosing_symbol, uri_to_relative_path};
+    use super::transport::{LspRpcError, find_enclosing_symbol, uri_to_relative_path};
     use super::*;
+
+    enum ValidationFixtureResponse {
+        Success(serde_json::Value),
+        RpcError(i64),
+        Crash,
+        Timeout,
+    }
+
+    struct ValidationFixture {
+        responses: VecDeque<ValidationFixtureResponse>,
+        calls: Vec<String>,
+    }
+
+    impl ValidationFixture {
+        fn new(responses: impl IntoIterator<Item = ValidationFixtureResponse>) -> Self {
+            Self {
+                responses: responses.into_iter().collect(),
+                calls: Vec::new(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ReadinessRequester for ValidationFixture {
+        async fn readiness_request(
+            &mut self,
+            method: &str,
+            _params: serde_json::Value,
+        ) -> Result<serde_json::Value> {
+            self.calls.push(method.to_string());
+            match self.responses.pop_front().expect("fixture response") {
+                ValidationFixtureResponse::Success(value) => Ok(value),
+                ValidationFixtureResponse::RpcError(code) => {
+                    Err(LspRpcError::new(code, "fixture RPC error").into())
+                }
+                ValidationFixtureResponse::Crash => Err(anyhow::anyhow!("server exited")),
+                ValidationFixtureResponse::Timeout => {
+                    std::future::pending::<Result<serde_json::Value>>().await
+                }
+            }
+        }
+    }
+
+    fn validation_capabilities(
+        workspace_symbols: bool,
+        document_symbols: bool,
+    ) -> ReadinessValidationCapabilities {
+        ReadinessValidationCapabilities {
+            workspace_symbols,
+            document_symbols,
+        }
+    }
+
+    fn parsed_validation_capabilities(
+        initialize_result: serde_json::Value,
+    ) -> ReadinessValidationCapabilities {
+        let result: InitializeResult =
+            serde_json::from_value(initialize_result).expect("valid initialize fixture");
+        ReadinessValidationCapabilities::from_server_capabilities(&result.capabilities)
+    }
+
+    #[tokio::test]
+    async fn readiness_absent_or_false_workspace_capability_uses_only_document_symbols() {
+        let absent = parsed_validation_capabilities(
+            serde_json::json!({"capabilities": {"documentSymbolProvider": true}}),
+        );
+        let explicit_false = parsed_validation_capabilities(
+            serde_json::json!({"capabilities": {
+                "workspaceSymbolProvider": false,
+                "documentSymbolProvider": {"label": "supported"}
+            }}),
+        );
+        assert_eq!(absent.primary(), Some(ReadinessValidationMethod::DocumentSymbol));
+        assert_eq!(
+            explicit_false.primary(),
+            Some(ReadinessValidationMethod::DocumentSymbol)
+        );
+
+        let mut fixture = ValidationFixture::new([ValidationFixtureResponse::Success(
+            serde_json::json!([]),
+        )]);
+        let outcome = execute_indexing_validation_once(
+            &mut fixture,
+            explicit_false,
+            Some("file:///fixture.json"),
+            "main",
+            tokio::time::Duration::from_millis(50),
+        )
+        .await
+        .expect("document validation should succeed")
+        .expect("document validation is terminal");
+        assert_eq!(outcome.method, ReadinessValidationMethod::DocumentSymbol);
+        assert_eq!(fixture.calls, ["textDocument/documentSymbol"]);
+    }
+
+    #[tokio::test]
+    async fn readiness_document_symbol_fallback_is_deterministic_and_accepts_zero_symbols() {
+        let mut fixture = ValidationFixture::new([
+            ValidationFixtureResponse::Success(serde_json::json!([])),
+            ValidationFixtureResponse::Success(serde_json::json!([])),
+        ]);
+        let outcome = execute_indexing_validation_once(
+            &mut fixture,
+            validation_capabilities(true, true),
+            Some("file:///fixture.html"),
+            "main",
+            tokio::time::Duration::from_millis(50),
+        )
+        .await
+        .expect("fallback should succeed")
+        .expect("fallback should be terminal");
+        assert_eq!(outcome.method, ReadinessValidationMethod::DocumentSymbol);
+        assert_eq!(outcome.symbol_count, 0);
+        assert_eq!(
+            fixture.calls,
+            ["workspace/symbol", "textDocument/documentSymbol"]
+        );
+
+        let evidence = crate::extract::scan_stats::LspValidationEvidence::processed(
+            "html",
+            "fixture-server",
+            outcome.method.method(),
+            outcome.symbol_count,
+        );
+        assert_eq!(evidence.symbol_count, Some(0));
+        assert!(evidence.summary().contains("processed"));
+    }
+
+    #[tokio::test]
+    async fn readiness_workspace_symbol_server_uses_advertised_method() {
+        let mut fixture = ValidationFixture::new([ValidationFixtureResponse::Success(
+            serde_json::json!([{"name": "one"}, {"name": "two"}]),
+        )]);
+        let outcome = execute_indexing_validation_once(
+            &mut fixture,
+            validation_capabilities(true, false),
+            None,
+            "main",
+            tokio::time::Duration::from_millis(50),
+        )
+        .await
+        .expect("workspace validation should succeed")
+        .expect("non-empty workspace symbols should be terminal");
+        assert_eq!(outcome.method, ReadinessValidationMethod::WorkspaceSymbol);
+        assert_eq!(outcome.symbol_count, 2);
+        assert_eq!(fixture.calls, ["workspace/symbol"]);
+    }
+
+    #[tokio::test]
+    async fn readiness_method_not_found_fails_immediately_without_retry() {
+        let mut fixture = ValidationFixture::new([ValidationFixtureResponse::RpcError(-32601)]);
+        let result = tokio::time::timeout(
+            tokio::time::Duration::from_millis(50),
+            execute_indexing_validation_once(
+                &mut fixture,
+                validation_capabilities(true, false),
+                None,
+                "main",
+                tokio::time::Duration::from_secs(30),
+            ),
+        )
+        .await
+        .expect("-32601 must complete within the deterministic 50ms bound");
+        let error = result.expect_err("advertised unsupported method is a hard error");
+        assert!(error.to_string().contains("-32601"));
+        assert_eq!(fixture.calls, ["workspace/symbol"]);
+    }
+
+    #[tokio::test]
+    async fn readiness_advertised_capability_crash_is_a_hard_error() {
+        let mut fixture = ValidationFixture::new([ValidationFixtureResponse::Crash]);
+        let error = execute_indexing_validation_once(
+            &mut fixture,
+            validation_capabilities(false, true),
+            Some("file:///fixture.json"),
+            "",
+            tokio::time::Duration::from_millis(50),
+        )
+        .await
+        .expect_err("server crash must not become success");
+        assert!(error.to_string().contains("validation failed"));
+    }
+
+    #[tokio::test]
+    async fn readiness_advertised_capability_timeout_is_a_hard_error() {
+        let mut fixture = ValidationFixture::new([ValidationFixtureResponse::Timeout]);
+        let result = tokio::time::timeout(
+            tokio::time::Duration::from_millis(100),
+            execute_indexing_validation_once(
+                &mut fixture,
+                validation_capabilities(false, true),
+                Some("file:///fixture.json"),
+                "",
+                tokio::time::Duration::from_millis(10),
+            ),
+        )
+        .await
+        .expect("fixture timeout must stay within the deterministic 100ms bound");
+        let error = result.expect_err("timeout must not become success");
+        assert!(error.to_string().contains("timed out after 10ms"));
+    }
+
+    #[test]
+    fn readiness_warmup_file_selection_is_deterministic() {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::write(temp.path().join("z.json"), "{}").unwrap();
+        std::fs::write(temp.path().join("a.json"), "{}").unwrap();
+        let enricher = LspEnricher::new("json", "fixture-server", &[], &["json"]);
+        assert_eq!(
+            enricher
+                .find_warmup_file(temp.path())
+                .unwrap()
+                .file_name()
+                .unwrap(),
+            "a.json"
+        );
+    }
 
     /// Verify the Enricher trait can be implemented (compile-time check).
     #[tokio::test]

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -814,92 +814,24 @@ impl LspEnricher {
             .unwrap_or(false)
     }
 
-    /// Find a representative source file in `root` to open via didOpen.
-    /// Picks a short, non-test, non-generated file from the enricher's configured
-    /// extensions — we just need one file to trigger project detection and indexing.
-    fn find_warmup_file(&self, root: &Path) -> Option<PathBuf> {
-        let extensions: std::collections::HashSet<&str> =
-            self.extensions.iter().map(String::as_str).collect();
-        if extensions.is_empty() {
-            return None;
-        }
-
-        fn walk(
-            dir: &Path,
-            extensions: &std::collections::HashSet<&str>,
-            depth: u8,
-        ) -> Option<PathBuf> {
-            if depth > 4 {
-                return None;
-            }
-            let mut entries = std::fs::read_dir(dir)
-                .ok()?
-                .flatten()
-                .collect::<Vec<_>>();
-            entries.sort_by_key(|entry| entry.file_name());
-            let mut subdirs = Vec::new();
-            for entry in entries {
-                let name = entry.file_name();
-                let name_str = name.to_string_lossy();
-                if name_str.starts_with('.')
-                    || matches!(
-                        name_str.as_ref(),
-                        "node_modules" | "__pycache__" | "target" | ".venv" | "venv" | "env"
-                    )
-                {
-                    continue;
-                }
-                let ft = match entry.file_type() {
-                    Ok(ft) => ft,
-                    Err(_) => continue,
-                };
-                if ft.is_dir() {
-                    subdirs.push(entry.path());
-                    continue;
-                }
-                if !ft.is_file() {
-                    continue;
-                }
-                let path = entry.path();
-                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-                if !extensions.contains(ext) {
-                    continue;
-                }
-                if name_str.starts_with("test_")
-                    || name_str.contains(".test.")
-                    || name_str.contains(".spec.")
-                    || name_str.contains(".gen.")
-                    || name_str.contains("_pb2")
-                    || name_str.starts_with("conftest")
-                    || name_str.ends_with(".d.ts")
-                {
-                    continue;
-                }
-                let entry_path = entry.path();
-                let in_test_dir = entry_path.components().any(|c| {
-                    matches!(
-                        c,
-                        std::path::Component::Normal(seg)
-                            if seg == "tests" || seg == "test" || seg == "__tests__"
-                    )
-                });
-                if in_test_dir {
-                    continue;
-                }
-                let size = entry.metadata().map(|m| m.len()).unwrap_or(u64::MAX);
-                if size > 0 && size < 50_000 {
-                    return Some(path);
-                }
-            }
-            for subdir in subdirs {
-                if let Some(found) = walk(&subdir, extensions, depth + 1) {
-                    return Some(found);
-                }
-            }
-            None
-        }
-
-        walk(root, &extensions, 0)
+    /// Pick a deterministic didOpen file from the nodes admitted to this invocation.
+    ///
+    /// The current admitted cohort already carries dirty-root and node-scope filtering,
+    /// so selecting from it cannot warm up an excluded or unrelated file.
+    fn find_warmup_file(&self, repo_root: &Path, matching_nodes: &[&Node]) -> Option<PathBuf> {
+        let startup_root = self
+            .startup_root_override
+            .get()
+            .map(PathBuf::as_path)
+            .unwrap_or(repo_root);
+        let mut candidates = matching_nodes
+            .iter()
+            .map(|node| repo_root.join(&node.id.file))
+            .filter(|path| path.starts_with(startup_root) && path.is_file())
+            .collect::<Vec<_>>();
+        candidates.sort_unstable();
+        candidates.dedup();
+        candidates.into_iter().next()
     }
 
     fn lsp_language_id_for_path<'a>(&'a self, path: &Path) -> &'a str {
@@ -950,8 +882,8 @@ impl LspEnricher {
             .unwrap_or_default()
     }
 
-    async fn ensure_initialized(&self, repo_root: &Path) -> Result<()> {
-        let result = self.ensure_initialized_inner(repo_root).await;
+    async fn ensure_initialized(&self, repo_root: &Path, warmup_path: Option<&Path>) -> Result<()> {
+        let result = self.ensure_initialized_inner(repo_root, warmup_path).await;
         if result.is_err() {
             self.reset_incomplete_initialization().await;
         }
@@ -969,7 +901,11 @@ impl LspEnricher {
     }
 
     /// Initialize the language server if not already running.
-    async fn ensure_initialized_inner(&self, repo_root: &Path) -> Result<()> {
+    async fn ensure_initialized_inner(
+        &self,
+        repo_root: &Path,
+        warmup_path: Option<&Path>,
+    ) -> Result<()> {
         let mut state = self.state.lock().await;
 
         if state.pipelined.is_some() {
@@ -1234,38 +1170,34 @@ impl LspEnricher {
         // context. tsserver requires at least one open file before it creates
         // a project; pyright uses it to trigger import-graph indexing.
         // Save the URI for use as a documentSymbol validation fallback.
-        let warmup_uri: Option<String> =
-            if let Some(warmup_path) = Self::find_warmup_file(self, startup_root) {
-                let uri_str = path_to_uri(&warmup_path).ok().map(|u| u.to_string());
-                match self.send_did_open(transport, &warmup_path).await {
-                    Ok(()) => {
-                        tracing::info!(
-                            "{} sent didOpen for '{}'",
-                            self.server_command,
-                            warmup_path.display()
-                        );
-                        uri_str
-                    }
-                    Err(e) => {
-                        tracing::debug!(
-                            "{} didOpen warmup failed (non-fatal): {}",
-                            self.server_command,
-                            e
-                        );
-                        None
-                    }
+        let warmup_uri: Option<String> = if let Some(warmup_path) = warmup_path {
+            let uri_str = path_to_uri(&warmup_path).ok().map(|u| u.to_string());
+            match self.send_did_open(transport, &warmup_path).await {
+                Ok(()) => {
+                    tracing::info!(
+                        "{} sent didOpen for '{}'",
+                        self.server_command,
+                        warmup_path.display()
+                    );
+                    uri_str
                 }
-            } else {
-                None
-            };
+                Err(e) => {
+                    tracing::debug!(
+                        "{} didOpen warmup failed (non-fatal): {}",
+                        self.server_command,
+                        e
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
 
-        let readiness_method = validation_capabilities.primary().ok_or_else(|| {
-            anyhow::anyhow!(
-                "{} advertises neither workspace/symbol nor textDocument/documentSymbol; readiness was not validated",
-                self.server_command
-            )
-        })?;
-        if readiness_method == ReadinessValidationMethod::DocumentSymbol && warmup_uri.is_none() {
+        let readiness_method = validation_capabilities.primary();
+        if readiness_method == Some(ReadinessValidationMethod::DocumentSymbol)
+            && warmup_uri.is_none()
+        {
             return Err(anyhow::anyhow!(
                 "{} advertises documentSymbol but no deterministic included warm-up file was available; readiness was not validated",
                 self.server_command
@@ -1399,11 +1331,10 @@ impl LspEnricher {
                                 if quiescent {
                                     saw_quiescent = true;
                                     validation_evidence = Some(
-                                        crate::extract::scan_stats::LspValidationEvidence::processed(
+                                        crate::extract::scan_stats::LspValidationEvidence::quiescent(
                                             self.language.clone(),
                                             self.server_command.clone(),
                                             "experimental/serverStatus",
-                                            0,
                                         ),
                                     );
                                 }
@@ -1484,6 +1415,12 @@ impl LspEnricher {
                         next_probe =
                             tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
 
+                        let readiness_method = readiness_method.ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "{} sent no experimental/serverStatus and advertises neither workspace/symbol nor textDocument/documentSymbol; readiness was not validated",
+                                self.server_command
+                            )
+                        })?;
                         let symbol_count = execute_readiness_validation(
                             transport,
                             readiness_method,
@@ -1498,13 +1435,14 @@ impl LspEnricher {
 
                         match readiness_method {
                             ReadinessValidationMethod::DocumentSymbol => {
-                                validation_evidence =
-                                    Some(crate::extract::scan_stats::LspValidationEvidence::processed(
+                                validation_evidence = Some(
+                                    crate::extract::scan_stats::LspValidationEvidence::processed(
                                         self.language.clone(),
                                         self.server_command.clone(),
                                         readiness_method.method(),
                                         symbol_count,
-                                    ));
+                                    ),
+                                );
                                 server_responsive = true;
                                 server_ready = true;
                                 saw_quiescent = true;
@@ -1624,11 +1562,10 @@ impl LspEnricher {
                                 server_ready = true;
                                 saw_quiescent = true;
                                 validation_evidence = Some(
-                                    crate::extract::scan_stats::LspValidationEvidence::processed(
+                                    crate::extract::scan_stats::LspValidationEvidence::quiescent(
                                         self.language.clone(),
                                         self.server_command.clone(),
                                         "experimental/serverStatus",
-                                        0,
                                     ),
                                 );
                             }
@@ -2906,6 +2843,8 @@ impl Enricher for LspEnricher {
             return Ok(result);
         }
 
+        let warmup_file = self.find_warmup_file(repo_root, &matching_nodes);
+
         // Try to initialize the language server using the repo root from --repo.
         // Scoped requests enforce their shared deadline here rather than at the
         // event-bus boundary, where cancellation would discard Pass 1 output.
@@ -2913,7 +2852,7 @@ impl Enricher for LspEnricher {
             .within_enrichment_deadline(
                 job_deadline,
                 "language-server initialization",
-                self.ensure_initialized(repo_root),
+                self.ensure_initialized(repo_root, warmup_file.as_deref()),
             )
             .await
         {
@@ -3399,13 +3338,60 @@ mod tests {
         std::fs::write(temp.path().join("z.json"), "{}").unwrap();
         std::fs::write(temp.path().join("a.json"), "{}").unwrap();
         let enricher = LspEnricher::new("json", "fixture-server", &[], &["json"]);
+        let admitted = Node {
+            id: NodeId {
+                root: "primary".to_string(),
+                file: PathBuf::from("z.json"),
+                name: "value".to_string(),
+                kind: NodeKind::Function,
+            },
+            language: "json".to_string(),
+            line_start: 1,
+            line_end: 1,
+            signature: String::new(),
+            body: String::new(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::TreeSitter,
+        };
         assert_eq!(
             enricher
-                .find_warmup_file(temp.path())
+                .find_warmup_file(temp.path(), &[&admitted])
                 .unwrap()
                 .file_name()
                 .unwrap(),
-            "a.json"
+            "z.json",
+            "warm-up must come from the invocation's admitted cohort"
+        );
+    }
+
+    #[test]
+    fn readiness_warmup_accepts_only_admitted_test_or_large_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let tests_dir = temp.path().join("tests");
+        std::fs::create_dir(&tests_dir).unwrap();
+        let relative_path = PathBuf::from("tests/only.test.json");
+        std::fs::write(temp.path().join(&relative_path), vec![b'x'; 60_000]).unwrap();
+        let enricher = LspEnricher::new("json", "fixture-server", &[], &["json"]);
+        let admitted = Node {
+            id: NodeId {
+                root: "primary".to_string(),
+                file: relative_path.clone(),
+                name: "value".to_string(),
+                kind: NodeKind::Function,
+            },
+            language: "json".to_string(),
+            line_start: 1,
+            line_end: 1,
+            signature: String::new(),
+            body: String::new(),
+            metadata: BTreeMap::new(),
+            source: ExtractionSource::TreeSitter,
+        };
+
+        assert_eq!(
+            enricher.find_warmup_file(temp.path(), &[&admitted]),
+            Some(temp.path().join(relative_path)),
+            "scope-valid files must not be rejected by test-name or size heuristics"
         );
     }
 

--- a/src/extract/lsp/mod.rs
+++ b/src/extract/lsp/mod.rs
@@ -827,11 +827,11 @@ impl LspEnricher {
         let mut candidates = matching_nodes
             .iter()
             .map(|node| repo_root.join(&node.id.file))
-            .filter(|path| path.starts_with(startup_root) && path.is_file())
+            .filter(|path| path.starts_with(startup_root))
             .collect::<Vec<_>>();
         candidates.sort_unstable();
         candidates.dedup();
-        candidates.into_iter().next()
+        candidates.into_iter().find(|path| path.is_file())
     }
 
     fn lsp_language_id_for_path<'a>(&'a self, path: &Path) -> &'a str {

--- a/src/extract/lsp/transport.rs
+++ b/src/extract/lsp/transport.rs
@@ -122,6 +122,47 @@ pub(super) fn uri_to_relative_path(uri: &Uri, root: &Path) -> PathBuf {
 // LSP JSON-RPC transport
 // ---------------------------------------------------------------------------
 
+/// Structured JSON-RPC error returned by a language server.
+///
+/// Keeping the numeric code intact lets readiness distinguish an unsupported
+/// method (`-32601`) from an empty-but-successful response without parsing an
+/// error string.
+#[derive(Debug)]
+pub(super) struct LspRpcError {
+    pub(super) code: i64,
+    message: String,
+    data: Option<serde_json::Value>,
+}
+
+impl LspRpcError {
+    #[cfg(test)]
+    pub(super) fn new(code: i64, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+}
+
+impl std::fmt::Display for LspRpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LSP JSON-RPC error {}: {}", self.code, self.message)?;
+        if let Some(data) = &self.data {
+            write!(f, " ({data})")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for LspRpcError {}
+
+pub(super) fn is_method_not_found(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<LspRpcError>()
+        .is_some_and(|rpc| rpc.code == -32601)
+}
+
 /// Minimal JSON-RPC message framing for LSP over stdin/stdout.
 pub(super) struct LspTransport {
     pub(super) child: Child,
@@ -222,7 +263,19 @@ impl LspTransport {
                 && id.as_i64() == Some(expected_id)
             {
                 if let Some(error) = msg.get("error") {
-                    return Err(anyhow::anyhow!("LSP error: {}", error));
+                    return Err(LspRpcError {
+                        code: error
+                            .get("code")
+                            .and_then(serde_json::Value::as_i64)
+                            .unwrap_or_default(),
+                        message: error
+                            .get("message")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("unknown JSON-RPC error")
+                            .to_string(),
+                        data: error.get("data").cloned(),
+                    }
+                    .into());
                 }
                 return Ok(msg
                     .get("result")

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -215,6 +215,8 @@ pub struct EnrichmentResult {
     pub lsp_entries: Vec<scan_stats::LspEnrichmentEntry>,
     /// Operation/declaration query-yield measurements from LSP enrichers.
     pub lsp_query_metrics: Vec<lsp::LspQueryMetric>,
+    /// Capability-driven readiness evidence for the language server.
+    pub lsp_validation: Option<scan_stats::LspValidationEvidence>,
 }
 
 /// Phase 2: Asynchronous enrichment after initial extraction.
@@ -734,6 +736,7 @@ impl EnricherRegistry {
                     let node_count = enrichment.new_nodes.len();
                     let error_count = enrichment.error_count;
                     let query_metrics = enrichment.lsp_query_metrics;
+                    let validation = enrichment.lsp_validation;
                     let status = if enrichment.aborted {
                         scan_stats::LspStatus::Aborted
                     } else {
@@ -754,6 +757,7 @@ impl EnricherRegistry {
                         status,
                         remediation: enricher.toolchain_remediation().map(str::to_string),
                         query_metrics,
+                        validation,
                     });
                 }
                 Err(e) => {
@@ -770,6 +774,11 @@ impl EnricherRegistry {
                     } else {
                         scan_stats::LspStatus::Failed
                     };
+                    let validation = scan_stats::LspValidationEvidence::not_validated(
+                        lang.clone(),
+                        server.clone(),
+                        err_msg,
+                    );
                     result.lsp_entries.push(scan_stats::LspEnrichmentEntry {
                         language: lang,
                         server_name: server,
@@ -781,6 +790,7 @@ impl EnricherRegistry {
                         status,
                         remediation: enricher.toolchain_remediation().map(str::to_string),
                         query_metrics: Vec::new(),
+                        validation: Some(validation),
                     });
                 }
             }

--- a/src/extract/scan_stats.rs
+++ b/src/extract/scan_stats.rs
@@ -61,6 +61,74 @@ pub enum LspStatus {
     Failed,
 }
 
+/// Durable evidence that readiness validation either processed a document or
+/// never reached a supported validation method. `symbol_count: Some(0)` is a
+/// successful processed-zero result; `None` is reserved for not-validated.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LspValidationStatus {
+    Processed,
+    NotValidated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LspValidationEvidence {
+    pub language: String,
+    pub server_name: String,
+    pub status: LspValidationStatus,
+    pub method: Option<String>,
+    pub symbol_count: Option<usize>,
+    pub detail: Option<String>,
+}
+
+impl LspValidationEvidence {
+    pub fn processed(
+        language: impl Into<String>,
+        server_name: impl Into<String>,
+        method: impl Into<String>,
+        symbol_count: usize,
+    ) -> Self {
+        Self {
+            language: language.into(),
+            server_name: server_name.into(),
+            status: LspValidationStatus::Processed,
+            method: Some(method.into()),
+            symbol_count: Some(symbol_count),
+            detail: None,
+        }
+    }
+
+    pub fn not_validated(
+        language: impl Into<String>,
+        server_name: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            language: language.into(),
+            server_name: server_name.into(),
+            status: LspValidationStatus::NotValidated,
+            method: None,
+            symbol_count: None,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn summary(&self) -> String {
+        match (&self.status, self.method.as_deref(), self.symbol_count) {
+            (LspValidationStatus::Processed, Some(method), Some(count)) => {
+                format!("processed via {method} ({count} symbols)")
+            }
+            _ => format!(
+                "not validated{}",
+                self.detail
+                    .as_deref()
+                    .map(|detail| format!(": {detail}"))
+                    .unwrap_or_default()
+            ),
+        }
+    }
+}
+
 impl std::fmt::Display for LspStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -85,6 +153,7 @@ pub struct LspEnrichmentEntry {
     pub status: LspStatus,
     pub remediation: Option<String>,
     pub query_metrics: Vec<crate::extract::lsp::LspQueryMetric>,
+    pub validation: Option<LspValidationEvidence>,
 }
 
 impl LspEnrichmentEntry {
@@ -144,6 +213,10 @@ impl LspEnrichmentEntry {
                 " -- query yield {non_empty}/{scheduled} non-empty"
             ));
         }
+        if let Some(validation) = &self.validation {
+            line.push_str(" -- validation ");
+            line.push_str(&validation.summary());
+        }
         line
     }
 }
@@ -176,6 +249,9 @@ pub struct LspLanguageStats {
     pub remediation: Option<String>,
     /// Query-yield measurements grouped by operation and declaration class.
     pub query_metrics: Vec<crate::extract::lsp::LspQueryMetric>,
+    /// Capability-driven readiness evidence. `Some(0)` symbols means the
+    /// server processed the validation request successfully and found none.
+    pub validation: Option<LspValidationEvidence>,
 }
 
 /// Per-root stats populated after `RootExtracted`.
@@ -401,6 +477,7 @@ impl ExtractionConsumer for ScanStatsConsumer {
                 aborted,
                 server_missing,
                 remediation,
+                validation,
                 ..
             } => {
                 // Remove from in-flight.
@@ -443,14 +520,19 @@ impl ExtractionConsumer for ScanStatsConsumer {
                             server_missing: *server_missing,
                             remediation: remediation.clone(),
                             query_metrics: Vec::new(),
+                            validation: validation.clone(),
                         },
                     );
                 }
                 tracing::debug!(
-                    "ScanStatsConsumer: EnrichmentComplete '{}' for '{}': {} LSP edges",
+                    "ScanStatsConsumer: EnrichmentComplete '{}' for '{}': {} LSP edges, validation={}",
                     language,
                     slug,
                     added_edges.len(),
+                    validation
+                        .as_ref()
+                        .map(LspValidationEvidence::summary)
+                        .unwrap_or_else(|| "not recorded".to_string()),
                 );
             }
 
@@ -652,6 +734,7 @@ mod tests {
             remediation: None,
             aborted: false,
             diagnostic: None,
+            validation: None,
         })
         .await
         .unwrap();
@@ -721,6 +804,12 @@ mod tests {
             remediation: None,
             aborted: false,
             diagnostic: None,
+            validation: Some(LspValidationEvidence::processed(
+                "rust",
+                "rust-analyzer",
+                "workspace/symbol",
+                0,
+            )),
         })
         .await
         .unwrap();
@@ -734,6 +823,12 @@ mod tests {
             .copied()
             .unwrap_or(0);
         assert_eq!(count, 3, "lsp_edge_count should reflect added_edges length");
+        let validation = stats.lsp_stats["api"]["rust"]
+            .validation
+            .as_ref()
+            .expect("validation evidence should be delivered");
+        assert_eq!(validation.status, LspValidationStatus::Processed);
+        assert_eq!(validation.symbol_count, Some(0));
     }
 
     #[tokio::test]
@@ -775,6 +870,7 @@ mod tests {
             remediation: None,
             aborted: false,
             diagnostic: None,
+            validation: None,
         })
         .await
         .unwrap();
@@ -856,6 +952,7 @@ mod tests {
                 remediation: None,
                 aborted: false,
                 diagnostic: None,
+                validation: None,
             })
             .await;
         assert!(
@@ -922,6 +1019,11 @@ mod tests {
             remediation: Some("fix rust".to_string()),
             aborted: true,
             diagnostic: Some("forced abort".to_string()),
+            validation: Some(LspValidationEvidence::not_validated(
+                "rust",
+                "rust-analyzer",
+                "forced abort",
+            )),
         })
         .await
         .unwrap();
@@ -938,6 +1040,12 @@ mod tests {
         assert_eq!(lsp.node_count, 0);
         assert_eq!(lsp.error_count, 5);
         assert!(lsp.aborted);
+        let validation = lsp
+            .validation
+            .as_ref()
+            .expect("not-validated evidence should be delivered");
+        assert_eq!(validation.status, LspValidationStatus::NotValidated);
+        assert_eq!(validation.symbol_count, None);
         // Duration is non-zero because LanguageDetected fires before EnrichmentComplete.
         // (In practice the test runs so fast this may be 0, so just assert it parsed.)
         let _ = lsp.duration;
@@ -958,6 +1066,7 @@ mod tests {
             remediation: None,
             aborted: false,
             diagnostic: None,
+            validation: None,
         })
         .await
         .unwrap();
@@ -1006,6 +1115,7 @@ mod tests {
             remediation: None,
             aborted: false,
             diagnostic: None,
+            validation: None,
         })
         .await
         .unwrap();
@@ -1030,11 +1140,18 @@ mod tests {
             status: LspStatus::Ok,
             remediation: None,
             query_metrics: Vec::new(),
+            validation: Some(LspValidationEvidence::processed(
+                "rust",
+                "rust-analyzer",
+                "textDocument/documentSymbol",
+                0,
+            )),
         };
         let l = e.summary_line();
         assert!(l.contains("rust (rust-analyzer)"));
         assert!(l.contains("OK"));
         assert!(l.contains("150 edges"));
+        assert!(l.contains("processed via textDocument/documentSymbol (0 symbols)"));
     }
 
     #[test]
@@ -1050,6 +1167,7 @@ mod tests {
             status: LspStatus::NotFound,
             remediation: Some("install json ls".to_string()),
             query_metrics: Vec::new(),
+            validation: None,
         };
         let line = e.summary_line();
         assert!(line.contains("not found"));

--- a/src/extract/scan_stats.rs
+++ b/src/extract/scan_stats.rs
@@ -61,13 +61,16 @@ pub enum LspStatus {
     Failed,
 }
 
-/// Durable evidence that readiness validation either processed a document or
-/// never reached a supported validation method. `symbol_count: Some(0)` is a
-/// successful processed-zero result; `None` is reserved for not-validated.
+/// Durable evidence that readiness validation processed a symbol request,
+/// observed an authoritative quiescence signal, or never reached a supported
+/// validation method. `symbol_count: Some(0)` is a successful processed-zero
+/// result; the status distinguishes quiescence from not-validated when no
+/// symbol count applies.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LspValidationStatus {
     Processed,
+    Quiescent,
     NotValidated,
 }
 
@@ -113,10 +116,28 @@ impl LspValidationEvidence {
         }
     }
 
+    pub fn quiescent(
+        language: impl Into<String>,
+        server_name: impl Into<String>,
+        method: impl Into<String>,
+    ) -> Self {
+        Self {
+            language: language.into(),
+            server_name: server_name.into(),
+            status: LspValidationStatus::Quiescent,
+            method: Some(method.into()),
+            symbol_count: None,
+            detail: None,
+        }
+    }
+
     pub fn summary(&self) -> String {
         match (&self.status, self.method.as_deref(), self.symbol_count) {
             (LspValidationStatus::Processed, Some(method), Some(count)) => {
                 format!("processed via {method} ({count} symbols)")
+            }
+            (LspValidationStatus::Quiescent, Some(method), None) => {
+                format!("quiescent via {method}")
             }
             _ => format!(
                 "not validated{}",
@@ -250,7 +271,8 @@ pub struct LspLanguageStats {
     /// Query-yield measurements grouped by operation and declaration class.
     pub query_metrics: Vec<crate::extract::lsp::LspQueryMetric>,
     /// Capability-driven readiness evidence. `Some(0)` symbols means the
-    /// server processed the validation request successfully and found none.
+    /// server processed the validation request successfully and found none;
+    /// authoritative quiescence signals do not fabricate a symbol count.
     pub validation: Option<LspValidationEvidence>,
 }
 
@@ -1152,6 +1174,19 @@ mod tests {
         assert!(l.contains("OK"));
         assert!(l.contains("150 edges"));
         assert!(l.contains("processed via textDocument/documentSymbol (0 symbols)"));
+    }
+
+    #[test]
+    fn test_quiescent_validation_has_no_symbol_count() {
+        let evidence =
+            LspValidationEvidence::quiescent("rust", "rust-analyzer", "experimental/serverStatus");
+
+        assert_eq!(evidence.status, LspValidationStatus::Quiescent);
+        assert_eq!(evidence.symbol_count, None);
+        assert_eq!(
+            evidence.summary(),
+            "quiescent via experimental/serverStatus"
+        );
     }
 
     #[test]

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -145,7 +145,13 @@ fn build_pipeline_operation_report(
     report
 }
 
-type LspBusOutput = (Vec<Node>, Vec<Edge>, HashSet<String>, Vec<String>);
+type LspBusOutput = (
+    Vec<Node>,
+    Vec<Edge>,
+    HashSet<String>,
+    Vec<String>,
+    Vec<crate::extract::scan_stats::LspValidationEvidence>,
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EnrichmentContinuation {
@@ -314,6 +320,7 @@ fn lsp_evidence(
     declared_node_count: usize,
     budget: Option<&crate::extract::lsp::LspBroadReferenceBudgetSnapshot>,
     detail: Option<String>,
+    validations: Vec<crate::extract::scan_stats::LspValidationEvidence>,
 ) -> LspEvidenceCoverage {
     LspEvidenceCoverage {
         readiness,
@@ -325,6 +332,7 @@ fn lsp_evidence(
         elapsed_ms: budget.map_or(0, |snapshot| snapshot.elapsed_ms),
         circuit_open: budget.is_some_and(|snapshot| snapshot.circuit_open),
         detail,
+        validations,
     }
 }
 
@@ -407,6 +415,7 @@ fn plan_explicit_lsp_scope(
 async fn emit_lsp_pipeline_with_budget(
     input: LspPipelineInput,
 ) -> Result<LspBusOutput, LspPipelineFailure> {
+    let scan_stats = Arc::clone(&input.scan_stats);
     let fut = crate::extract::consumers::emit_enrichment_pipeline(
         input.nodes,
         input.edges,
@@ -425,14 +434,22 @@ async fn emit_lsp_pipeline_with_budget(
         input.dirty_slugs,
     );
 
-    if input.skip_lsp {
-        return fut.await.map_err(LspPipelineFailure);
-    }
-
     // The LSP work-item/pass layer owns its timeout and abort diagnostics. Wrapping the
     // entire event bus in `timeout` drops the future before AllEnrichmentsDone and
     // PassesComplete can preserve partial output, violating the finalization contract.
-    fut.await.map_err(LspPipelineFailure)
+    let (nodes, edges, frameworks, diagnostics) = fut.await.map_err(LspPipelineFailure)?;
+    let mut validations = scan_stats
+        .read()
+        .unwrap_or_else(|error| error.into_inner())
+        .lsp_stats
+        .values()
+        .flat_map(|by_language| by_language.values())
+        .filter_map(|language_stats| language_stats.validation.clone())
+        .collect::<Vec<_>>();
+    validations.sort_by(|left, right| {
+        (&left.language, &left.server_name).cmp(&(&right.language, &right.server_name))
+    });
+    Ok((nodes, edges, frameworks, diagnostics, validations))
 }
 
 impl RnaHandler {
@@ -716,7 +733,13 @@ impl RnaHandler {
             .await;
 
             match result {
-                Ok((mut enriched_nodes, mut enriched_edges, enriched_frameworks, diagnostics)) => {
+                Ok((
+                    mut enriched_nodes,
+                    mut enriched_edges,
+                    enriched_frameworks,
+                    diagnostics,
+                    _validations,
+                )) => {
                     // Update LSP status
                     let lsp_edge_count = enriched_edges
                         .iter()
@@ -1189,8 +1212,13 @@ impl RnaHandler {
             })
             .await;
 
-            let (mut enriched_nodes, mut enriched_edges, _detected_frameworks, diagnostics) =
-                match result {
+            let (
+                mut enriched_nodes,
+                mut enriched_edges,
+                _detected_frameworks,
+                diagnostics,
+                _validations,
+            ) = match result {
                     Ok(r) => r,
                     Err(e) => {
                         tracing::error!("[cache-hit bus] emit_enrichment_pipeline failed: {:#}", e);
@@ -1733,7 +1761,13 @@ impl RnaHandler {
 
         let lsp_edge_count;
         match bus_result {
-            Ok((mut enriched_nodes, mut enriched_edges, detected_frameworks, diagnostics)) => {
+            Ok((
+                mut enriched_nodes,
+                mut enriched_edges,
+                detected_frameworks,
+                diagnostics,
+                _lsp_validations,
+            )) => {
                 // Dedup: passes can re-emit cached entries.
                 {
                     let mut seen_nodes = std::collections::HashSet::new();
@@ -2154,6 +2188,7 @@ impl RnaHandler {
 
         let mut lsp_stage_completed = false;
         let mut lsp_degraded_detail = None;
+        let lsp_validations;
         let ((embed_count, embed_time), (bus_result, bus_time)) = tokio::join!(embed_fut, bus_fut);
 
         on_progress(&format!(
@@ -2165,7 +2200,14 @@ impl RnaHandler {
         let lsp_edge_count;
 
         match bus_result {
-            Ok((mut enriched_nodes, mut enriched_edges, detected_frameworks, diagnostics)) => {
+            Ok((
+                mut enriched_nodes,
+                mut enriched_edges,
+                detected_frameworks,
+                diagnostics,
+                bus_validations,
+            )) => {
+                lsp_validations = bus_validations;
                 // Dedup: passes can re-emit cached entries.
                 {
                     let mut seen_nodes = std::collections::HashSet::new();
@@ -2352,6 +2394,27 @@ impl RnaHandler {
                             edges.len(),
                         );
                     }
+                    self.enrichment_jobs.record_lsp_evidence(
+                        &self.repo_root,
+                        job_id,
+                        lsp_evidence(
+                            if lsp_degraded_detail.is_some() {
+                                LspEvidenceReadiness::Partial
+                            } else {
+                                LspEvidenceReadiness::DefaultProfile
+                            },
+                            &EnrichmentScope::Repo.stable_key(),
+                            0,
+                            None,
+                            lsp_degraded_detail.clone().or_else(|| {
+                                Some(
+                                    "repo-wide default query profile completed; broad references were omitted"
+                                        .to_string(),
+                                )
+                            }),
+                            lsp_validations.clone(),
+                        ),
+                    );
                 }
             }
         }
@@ -2565,7 +2628,13 @@ impl RnaHandler {
         .await;
 
         match bus_result {
-            Ok((mut enriched_nodes, mut enriched_edges, detected_frameworks, diagnostics)) => {
+            Ok((
+                mut enriched_nodes,
+                mut enriched_edges,
+                detected_frameworks,
+                diagnostics,
+                lsp_validations,
+            )) => {
                 // Dedup: passes can re-emit cached entries.
                 {
                     let mut seen_nodes = std::collections::HashSet::new();
@@ -2741,6 +2810,7 @@ impl RnaHandler {
                             declared_node_count,
                             budget_snapshot.as_ref(),
                             Some(format!("persistence failed: {e}")),
+                            lsp_validations.clone(),
                         ),
                     );
                     return Err(e.context("LSP persist failed during foreground pipeline"));
@@ -2792,6 +2862,7 @@ impl RnaHandler {
                                     .to_string()
                             })
                         }),
+                        lsp_validations,
                     ),
                 );
 
@@ -2833,6 +2904,7 @@ impl RnaHandler {
                         declared_node_count,
                         budget_snapshot.as_ref(),
                         Some(e.to_string()),
+                        Vec::new(),
                     ),
                 );
                 if fail_on_lsp_error {
@@ -3576,6 +3648,7 @@ mod tests {
                     server_missing: false,
                     remediation: None,
                     query_metrics: Vec::new(),
+                    validation: None,
                 },
             )]
             .into_iter()
@@ -3595,6 +3668,7 @@ mod tests {
                     server_missing: false,
                     remediation: None,
                     query_metrics: Vec::new(),
+                    validation: None,
                 },
             )]
             .into_iter()

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -314,7 +314,7 @@ struct LspPipelineInput {
     broad_reference_budget: Option<Arc<crate::extract::lsp::LspBroadReferenceBudget>>,
 }
 
-fn lsp_evidence(
+pub(super) fn lsp_evidence(
     readiness: LspEvidenceReadiness,
     scope: &str,
     declared_node_count: usize,
@@ -725,7 +725,7 @@ impl RnaHandler {
                     mut enriched_edges,
                     enriched_frameworks,
                     diagnostics,
-                    _validations,
+                    validations,
                 )) => {
                     // Update LSP status
                     let lsp_edge_count = enriched_edges
@@ -921,7 +921,20 @@ impl RnaHandler {
                         .await
                         {
                             tracing::error!("[background-lsp] LanceDB persist failed: {}", e);
-                            jobs.mark_failed(&repo_root, &job_id, format!("{}", e));
+                            let detail = format!("persistence failed: {e}");
+                            jobs.mark_failed(&repo_root, &job_id, detail.clone());
+                            jobs.record_lsp_evidence(
+                                &repo_root,
+                                &job_id,
+                                lsp_evidence(
+                                    LspEvidenceReadiness::Partial,
+                                    &EnrichmentScope::ChangedFiles.stable_key(),
+                                    0,
+                                    None,
+                                    Some(detail.clone()),
+                                    validations.clone(),
+                                ),
+                            );
                         } else {
                             super::sentinel::write_extract_sentinel(
                                 &repo_root,
@@ -961,6 +974,22 @@ impl RnaHandler {
                                     enriched_edges.len(),
                                 );
                             }
+                            jobs.record_lsp_evidence(
+                                &repo_root,
+                                &job_id,
+                                lsp_evidence(
+                                    if degraded_detail.is_some() {
+                                        LspEvidenceReadiness::Partial
+                                    } else {
+                                        LspEvidenceReadiness::Scoped
+                                    },
+                                    &EnrichmentScope::ChangedFiles.stable_key(),
+                                    0,
+                                    None,
+                                    degraded_detail.clone(),
+                                    validations.clone(),
+                                ),
+                            );
                         }
                     }
 
@@ -1204,21 +1233,21 @@ impl RnaHandler {
                 mut enriched_edges,
                 _detected_frameworks,
                 diagnostics,
-                _validations,
+                validations,
             ) = match result {
-                    Ok(r) => r,
-                    Err(e) => {
-                        tracing::error!("[cache-hit bus] emit_enrichment_pipeline failed: {:#}", e);
-                        if e.is_timeout() {
-                            bg_lsp_status.set_timed_out(&format!("{}", e));
-                            bg_jobs.mark_timed_out(&bg_repo_root, &job_id, format!("{}", e));
-                        } else {
-                            bg_lsp_status.set_failed(&format!("{}", e));
-                            bg_jobs.mark_failed(&bg_repo_root, &job_id, format!("{}", e));
-                        }
-                        return;
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::error!("[cache-hit bus] emit_enrichment_pipeline failed: {:#}", e);
+                    if e.is_timeout() {
+                        bg_lsp_status.set_timed_out(&format!("{}", e));
+                        bg_jobs.mark_timed_out(&bg_repo_root, &job_id, format!("{}", e));
+                    } else {
+                        bg_lsp_status.set_failed(&format!("{}", e));
+                        bg_jobs.mark_failed(&bg_repo_root, &job_id, format!("{}", e));
                     }
-                };
+                    return;
+                }
+            };
 
             // Dedup: PassesComplete can re-emit cached entries when the cached graph already
             // contains output from a previous pass run. Dedup avoids duplicate rows in LanceDB
@@ -1339,11 +1368,45 @@ impl RnaHandler {
                             enriched_edges.len(),
                         );
                     }
+                    bg_jobs.record_lsp_evidence(
+                        &bg_repo_root,
+                        &job_id,
+                        lsp_evidence(
+                            if degraded_detail.is_some() {
+                                LspEvidenceReadiness::Partial
+                            } else {
+                                LspEvidenceReadiness::DefaultProfile
+                            },
+                            &EnrichmentScope::Repo.stable_key(),
+                            0,
+                            None,
+                            degraded_detail.clone().or_else(|| {
+                                Some(
+                                    "repo-wide default query profile completed; broad references were omitted"
+                                        .to_string(),
+                                )
+                            }),
+                            validations.clone(),
+                        ),
+                    );
                 }
                 Err(e) => {
                     tracing::error!("[cache-hit bus] LSP persist failed: {:#}", e);
                     bg_lsp_status.set_complete_persist_failed(lsp_call_edge_count);
-                    bg_jobs.mark_failed(&bg_repo_root, &job_id, format!("{}", e));
+                    let detail = format!("persistence failed: {e}");
+                    bg_jobs.mark_failed(&bg_repo_root, &job_id, detail.clone());
+                    bg_jobs.record_lsp_evidence(
+                        &bg_repo_root,
+                        &job_id,
+                        lsp_evidence(
+                            LspEvidenceReadiness::Partial,
+                            &EnrichmentScope::Repo.stable_key(),
+                            0,
+                            None,
+                            Some(detail.clone()),
+                            validations,
+                        ),
+                    );
                 }
             }
         });
@@ -1665,8 +1728,8 @@ impl RnaHandler {
                 .ensure_node(&node.stable_id(), &node.id.kind.to_string());
         }
 
-        let _persist_succeeded = self
-            .update_graph_with_scan(&mut cached_state, Some(scan), enrichment)
+        let incremental_update = self
+            .update_graph_with_scan_outcome(&mut cached_state, Some(scan), enrichment)
             .await?;
         self.graph.store(Arc::new(Some(Arc::new(cached_state))));
 
@@ -1730,6 +1793,7 @@ impl RnaHandler {
 
         let mut lsp_stage_completed = false;
         let mut lsp_degraded_detail = None;
+        let mut lsp_validations = Vec::new();
         let t2 = std::time::Instant::now();
         let bus_result = emit_lsp_pipeline_with_budget(LspPipelineInput {
             nodes: all_nodes,
@@ -1753,8 +1817,9 @@ impl RnaHandler {
                 mut enriched_edges,
                 detected_frameworks,
                 diagnostics,
-                _lsp_validations,
+                bus_validations,
             )) => {
+                lsp_validations = bus_validations;
                 // Dedup: passes can re-emit cached entries.
                 {
                     let mut seen_nodes = std::collections::HashSet::new();
@@ -1837,6 +1902,33 @@ impl RnaHandler {
                     } else {
                         self.lsp_status.set_unavailable();
                     }
+                    if let Some(job_id) = incremental_update.lsp_job_id.as_deref() {
+                        if e.is_timeout() {
+                            self.enrichment_jobs.mark_timed_out(
+                                &self.repo_root,
+                                job_id,
+                                e.to_string(),
+                            );
+                        } else {
+                            self.enrichment_jobs.mark_failed(
+                                &self.repo_root,
+                                job_id,
+                                e.to_string(),
+                            );
+                        }
+                        self.enrichment_jobs.record_lsp_evidence(
+                            &self.repo_root,
+                            job_id,
+                            lsp_evidence(
+                                LspEvidenceReadiness::Unavailable,
+                                &EnrichmentScope::ChangedFiles.stable_key(),
+                                0,
+                                None,
+                                Some(e.to_string()),
+                                Vec::new(),
+                            ),
+                        );
+                    }
                 }
                 lsp_edge_count = 0;
             }
@@ -1859,6 +1951,30 @@ impl RnaHandler {
                 );
                 if let Err(e) = persist_graph_to_lance(&self.repo_root, &nodes, &edges).await {
                     tracing::error!("Foreground incremental persist failed: {}", e);
+                    if lsp_stage_completed
+                        && let Some(job_id) = incremental_update.lsp_job_id.as_deref()
+                    {
+                        let detail = format!(
+                            "full persist failed during incremental foreground pipeline: {e}"
+                        );
+                        self.enrichment_jobs.mark_failed(
+                            &self.repo_root,
+                            job_id,
+                            detail.clone(),
+                        );
+                        self.enrichment_jobs.record_lsp_evidence(
+                            &self.repo_root,
+                            job_id,
+                            lsp_evidence(
+                                LspEvidenceReadiness::Partial,
+                                &EnrichmentScope::ChangedFiles.stable_key(),
+                                0,
+                                None,
+                                Some(detail.clone()),
+                                lsp_validations.clone(),
+                            ),
+                        );
+                    }
                     super::sentinel::clear_lsp_sentinel(&self.repo_root);
                     return Err(
                         e.context("Full persist failed during incremental foreground pipeline")
@@ -1872,6 +1988,42 @@ impl RnaHandler {
                     super::sentinel::write_lsp_sentinel(&self.repo_root, nodes.len(), edges.len());
                 } else {
                     super::sentinel::clear_lsp_sentinel(&self.repo_root);
+                }
+                if lsp_stage_completed
+                    && let Some(job_id) = incremental_update.lsp_job_id.as_deref()
+                {
+                    if let Some(detail) = lsp_degraded_detail.as_deref() {
+                        self.enrichment_jobs.mark_degraded(
+                            &self.repo_root,
+                            job_id,
+                            nodes.len(),
+                            edges.len(),
+                            detail,
+                        );
+                    } else {
+                        self.enrichment_jobs.mark_completed(
+                            &self.repo_root,
+                            job_id,
+                            nodes.len(),
+                            edges.len(),
+                        );
+                    }
+                    self.enrichment_jobs.record_lsp_evidence(
+                        &self.repo_root,
+                        job_id,
+                        lsp_evidence(
+                            if lsp_degraded_detail.is_some() {
+                                LspEvidenceReadiness::Partial
+                            } else {
+                                LspEvidenceReadiness::Scoped
+                            },
+                            &EnrichmentScope::ChangedFiles.stable_key(),
+                            0,
+                            None,
+                            lsp_degraded_detail.clone(),
+                            lsp_validations.clone(),
+                        ),
+                    );
                 }
             }
         }
@@ -1921,7 +2073,11 @@ impl RnaHandler {
                 "skipped by scan options",
             ));
         }
-        let related_job_ids = Vec::new();
+        let related_job_ids = incremental_update
+            .lsp_job_id
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
         let (lsp_state, lsp_detail) = lsp_capability_from_status(
             enrichment,
             self.lsp_status.current_state(),
@@ -2346,10 +2502,23 @@ impl RnaHandler {
                 if let Err(e) = persist_graph_to_lance(&self.repo_root, &nodes, &edges).await {
                     tracing::error!("Foreground full persist failed: {}", e);
                     if lsp_stage_completed && let Some(job_id) = lsp_job_id.as_deref() {
+                        let detail = format!("Full persist failed during foreground pipeline: {e}");
                         self.enrichment_jobs.mark_failed(
                             &self.repo_root,
                             job_id,
-                            format!("Full persist failed during foreground pipeline: {}", e),
+                            detail.clone(),
+                        );
+                        self.enrichment_jobs.record_lsp_evidence(
+                            &self.repo_root,
+                            job_id,
+                            lsp_evidence(
+                                LspEvidenceReadiness::Partial,
+                                &EnrichmentScope::Repo.stable_key(),
+                                0,
+                                None,
+                                Some(detail.clone()),
+                                lsp_validations.clone(),
+                            ),
                         );
                     }
                     super::sentinel::clear_lsp_sentinel(&self.repo_root);

--- a/src/server/enrichment.rs
+++ b/src/server/enrichment.rs
@@ -415,8 +415,7 @@ fn plan_explicit_lsp_scope(
 async fn emit_lsp_pipeline_with_budget(
     input: LspPipelineInput,
 ) -> Result<LspBusOutput, LspPipelineFailure> {
-    let scan_stats = Arc::clone(&input.scan_stats);
-    let fut = crate::extract::consumers::emit_enrichment_pipeline(
+    let fut = crate::extract::consumers::emit_enrichment_pipeline_with_validations(
         input.nodes,
         input.edges,
         input.root_pairs,
@@ -437,19 +436,7 @@ async fn emit_lsp_pipeline_with_budget(
     // The LSP work-item/pass layer owns its timeout and abort diagnostics. Wrapping the
     // entire event bus in `timeout` drops the future before AllEnrichmentsDone and
     // PassesComplete can preserve partial output, violating the finalization contract.
-    let (nodes, edges, frameworks, diagnostics) = fut.await.map_err(LspPipelineFailure)?;
-    let mut validations = scan_stats
-        .read()
-        .unwrap_or_else(|error| error.into_inner())
-        .lsp_stats
-        .values()
-        .flat_map(|by_language| by_language.values())
-        .filter_map(|language_stats| language_stats.validation.clone())
-        .collect::<Vec<_>>();
-    validations.sort_by(|left, right| {
-        (&left.language, &left.server_name).cmp(&(&right.language, &right.server_name))
-    });
-    Ok((nodes, edges, frameworks, diagnostics, validations))
+    fut.await.map_err(LspPipelineFailure)
 }
 
 impl RnaHandler {
@@ -3681,5 +3668,60 @@ mod tests {
         assert_eq!(failures.len(), 1);
         assert!(failures[0].contains("current/rust"));
         assert!(!failures[0].contains("stale/rust"));
+    }
+
+    #[tokio::test]
+    async fn validation_evidence_is_invocation_local() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let scan_stats = Arc::new(std::sync::RwLock::new(
+            crate::extract::scan_stats::ScanStats::default(),
+        ));
+        scan_stats.write().unwrap().lsp_stats.insert(
+            "stale".to_string(),
+            [(
+                "rust".to_string(),
+                crate::extract::scan_stats::LspLanguageStats {
+                    server_name: "rust-analyzer".to_string(),
+                    edge_count: 0,
+                    node_count: 0,
+                    duration: Duration::from_secs(1),
+                    error_count: 0,
+                    aborted: false,
+                    server_missing: false,
+                    remediation: None,
+                    query_metrics: Vec::new(),
+                    validation: Some(
+                        crate::extract::scan_stats::LspValidationEvidence::processed(
+                            "rust",
+                            "rust-analyzer",
+                            "workspace/symbol",
+                            9,
+                        ),
+                    ),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        );
+
+        let (_, _, _, _, validations) = emit_lsp_pipeline_with_budget(LspPipelineInput {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            root_pairs: vec![("current".to_string(), temp.path().to_path_buf())],
+            primary_slug: "current".to_string(),
+            repo_root: temp.path().to_path_buf(),
+            scan_stats,
+            skip_lsp: true,
+            dirty_slugs: None,
+            lsp_node_filter: None,
+            broad_reference_budget: None,
+        })
+        .await
+        .expect("empty invocation should finalize");
+
+        assert!(
+            validations.is_empty(),
+            "current job must not inherit readiness evidence from cumulative scan stats"
+        );
     }
 }

--- a/src/server/enrichment_jobs.rs
+++ b/src/server/enrichment_jobs.rs
@@ -168,6 +168,10 @@ pub struct LspEvidenceCoverage {
     pub elapsed_ms: u64,
     pub circuit_open: bool,
     pub detail: Option<String>,
+    /// Per-language readiness validation evidence. This is deliberately
+    /// language-level; #784 owns the later per-file completeness expansion.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub validations: Vec<crate::extract::scan_stats::LspValidationEvidence>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -732,6 +736,7 @@ impl EnrichmentJobLedger {
                                 .to_string()
                         })
                     }),
+                    validations: Vec::new(),
                 });
             }
             job.updated_at = now;
@@ -1098,6 +1103,14 @@ mod tests {
                 elapsed_ms: 15,
                 circuit_open: true,
                 detail: Some("request budget exhausted".to_string()),
+                validations: vec![
+                    crate::extract::scan_stats::LspValidationEvidence::processed(
+                        "json",
+                        "vscode-json-language-server",
+                        "textDocument/documentSymbol",
+                        0,
+                    ),
+                ],
             },
         );
 
@@ -1108,6 +1121,8 @@ mod tests {
         assert_eq!(evidence.scheduled_requests, 2);
         assert!(evidence.circuit_open);
         assert_eq!(evidence.scope, scope.stable_key());
+        assert_eq!(evidence.validations.len(), 1);
+        assert_eq!(evidence.validations[0].symbol_count, Some(0));
     }
 
     #[test]

--- a/src/server/enrichment_jobs.rs
+++ b/src/server/enrichment_jobs.rs
@@ -1126,6 +1126,80 @@ mod tests {
     }
 
     #[test]
+    fn later_lsp_pass_replaces_terminal_job_validation_with_its_invocation() {
+        let tmp = TempDir::new().unwrap();
+        let ledger = EnrichmentJobLedger::default();
+        let scope = EnrichmentScope::ChangedFiles;
+        let job = match ledger
+            .begin_job(
+                tmp.path(),
+                EnrichmentCapability::CallReferences,
+                scope.clone(),
+                EnrichmentTrigger::IncrementalRefresh,
+                None,
+            )
+            .unwrap()
+        {
+            JobStart::Started(job) => job,
+            JobStart::Joined { .. } => panic!("first job should start"),
+        };
+
+        ledger.mark_completed(tmp.path(), &job.job_id, 4, 5);
+        ledger.record_lsp_evidence(
+            tmp.path(),
+            &job.job_id,
+            LspEvidenceCoverage {
+                readiness: LspEvidenceReadiness::Scoped,
+                scope: scope.stable_key(),
+                declared_node_count: 0,
+                max_requests: None,
+                max_duration_ms: None,
+                scheduled_requests: 0,
+                elapsed_ms: 0,
+                circuit_open: false,
+                detail: None,
+                validations: vec![
+                    crate::extract::scan_stats::LspValidationEvidence::processed(
+                        "rust",
+                        "rust-analyzer",
+                        "workspace/symbol",
+                        3,
+                    ),
+                ],
+            },
+        );
+        ledger.record_lsp_evidence(
+            tmp.path(),
+            &job.job_id,
+            LspEvidenceCoverage {
+                readiness: LspEvidenceReadiness::Scoped,
+                scope: scope.stable_key(),
+                declared_node_count: 0,
+                max_requests: None,
+                max_duration_ms: None,
+                scheduled_requests: 0,
+                elapsed_ms: 0,
+                circuit_open: false,
+                detail: None,
+                validations: vec![
+                    crate::extract::scan_stats::LspValidationEvidence::processed(
+                        "json",
+                        "vscode-json-language-server",
+                        "textDocument/documentSymbol",
+                        0,
+                    ),
+                ],
+            },
+        );
+
+        let restored = ledger.recent_jobs(tmp.path(), 1).pop().unwrap();
+        let evidence = restored.lsp_evidence.unwrap();
+        assert_eq!(evidence.validations.len(), 1);
+        assert_eq!(evidence.validations[0].language, "json");
+        assert_eq!(evidence.validations[0].symbol_count, Some(0));
+    }
+
+    #[test]
     fn broad_reference_budget_rejects_invisible_or_zero_limits() {
         assert!(
             BroadReferenceBudget {

--- a/src/server/graph.rs
+++ b/src/server/graph.rs
@@ -9,6 +9,12 @@ use anyhow::Context as _;
 /// Shared with service.rs for filtering.
 pub(crate) const SUBSYSTEM_KEY: &str = "subsystem";
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct IncrementalUpdateOutcome {
+    pub(super) persist_succeeded: bool,
+    pub(super) lsp_job_id: Option<String>,
+}
+
 use crate::embed::EmbeddingIndex;
 use crate::extract::ExtractorRegistry;
 use crate::graph::index::GraphIndex;
@@ -2308,6 +2314,18 @@ impl RnaHandler {
         pending_scan: Option<ScanResult>,
         enrichment: ScanEnrichmentOptions,
     ) -> anyhow::Result<bool> {
+        Ok(self
+            .update_graph_with_scan_outcome(graph, pending_scan, enrichment)
+            .await?
+            .persist_succeeded)
+    }
+
+    pub(super) async fn update_graph_with_scan_outcome(
+        &self,
+        graph: &mut GraphState,
+        pending_scan: Option<ScanResult>,
+        enrichment: ScanEnrichmentOptions,
+    ) -> anyhow::Result<IncrementalUpdateOutcome> {
         // If no pre-computed scan, create a fresh scanner. We hold it so we
         // can commit state after successful processing.
         let mut fallback_scanner: Option<Scanner> = None;
@@ -2336,7 +2354,10 @@ impl RnaHandler {
             if let Some(scanner) = fallback_scanner {
                 scanner.commit_state()?;
             }
-            return Ok(true);
+            return Ok(IncrementalUpdateOutcome {
+                persist_succeeded: true,
+                lsp_job_id: None,
+            });
         }
 
         tracing::info!(
@@ -2513,25 +2534,26 @@ impl RnaHandler {
                 plan_lsp_node_ids_for_touched_files(&files_to_remove, &graph.nodes)
                     .context("failed to plan changed-file LSP nodes")?;
 
-            let pipeline_result = crate::extract::consumers::emit_enrichment_pipeline(
-                std::mem::take(&mut graph.nodes),
-                std::mem::take(&mut graph.edges),
-                root_pairs_incremental,
-                primary_slug.clone(),
-                self.repo_root.clone(),
-                crate::extract::consumers::BusOptions {
-                    business_context: self.business_context.clone(),
-                    scan_stats: Some(Arc::clone(&self.scan_stats)),
-                    embed_idx: None, // embed handled below via targeted reindex_nodes after PageRank
-                    lance_repo_root: None, // LanceDB persist handled below via persist_graph_incremental
-                    skip_lsp: !enrichment.runs_lsp(),
-                    lsp_node_filter: Some(Arc::clone(&lsp_node_filter)),
-                    broad_reference_budget: None,
-                },
-                dirty_slugs,
-            )
-            .await;
-            let (enriched_nodes, enriched_edges, detected_frameworks, diagnostics) =
+            let pipeline_result =
+                crate::extract::consumers::emit_enrichment_pipeline_with_validations(
+                    std::mem::take(&mut graph.nodes),
+                    std::mem::take(&mut graph.edges),
+                    root_pairs_incremental,
+                    primary_slug.clone(),
+                    self.repo_root.clone(),
+                    crate::extract::consumers::BusOptions {
+                        business_context: self.business_context.clone(),
+                        scan_stats: Some(Arc::clone(&self.scan_stats)),
+                        embed_idx: None, // embed handled below via targeted reindex_nodes after PageRank
+                        lance_repo_root: None, // LanceDB persist handled below via persist_graph_incremental
+                        skip_lsp: !enrichment.runs_lsp(),
+                        lsp_node_filter: Some(Arc::clone(&lsp_node_filter)),
+                        broad_reference_budget: None,
+                    },
+                    dirty_slugs,
+                )
+                .await;
+            let (enriched_nodes, enriched_edges, detected_frameworks, diagnostics, validations) =
                 match pipeline_result {
                     Ok(result) => result,
                     Err(error) => {
@@ -2540,6 +2562,20 @@ impl RnaHandler {
                                 &self.repo_root,
                                 job_id,
                                 format!("incremental enrichment pipeline failed: {error:#}"),
+                            );
+                            self.enrichment_jobs.record_lsp_evidence(
+                                &self.repo_root,
+                                job_id,
+                                super::enrichment::lsp_evidence(
+                                    super::enrichment_jobs::LspEvidenceReadiness::Unavailable,
+                                    &EnrichmentScope::ChangedFiles.stable_key(),
+                                    0,
+                                    None,
+                                    Some(format!(
+                                        "incremental enrichment pipeline failed: {error:#}"
+                                    )),
+                                    Vec::new(),
+                                ),
                             );
                         }
                         // Pipeline invariant violated — abort the incremental update so the
@@ -2556,7 +2592,7 @@ impl RnaHandler {
             let lsp_call_edge_count = scoped_lsp_call_edge_count(&graph.edges, &lsp_node_filter);
             let degraded_detail = (!diagnostics.is_empty()).then(|| diagnostics.join("; "));
             if enrichment.runs_lsp() {
-                incremental_lsp_outcome = Some((lsp_call_edge_count, degraded_detail));
+                incremental_lsp_outcome = Some((lsp_call_edge_count, degraded_detail, validations));
             }
         }
 
@@ -2866,50 +2902,82 @@ impl RnaHandler {
             Ok(false) => true,
         };
 
-        if persist_succeeded
-            && let Some((lsp_call_edge_count, degraded_detail)) = incremental_lsp_outcome
-        {
-            if let Some(detail) = degraded_detail.as_deref() {
-                let existing_coverage = self.lsp_status.coverage_edge_count();
-                self.lsp_status.set_degraded_scoped(
-                    lsp_call_edge_count,
-                    existing_coverage,
-                    EnrichmentScope::ChangedFiles.stable_key(),
-                    detail,
-                );
-                if let Some(job_id) = incremental_lsp_job_id.as_deref() {
-                    self.enrichment_jobs.mark_degraded(
-                        &self.repo_root,
-                        job_id,
-                        graph.nodes.len(),
-                        graph.edges.len(),
+        if let Some((lsp_call_edge_count, degraded_detail, validations)) = incremental_lsp_outcome {
+            if persist_succeeded {
+                if let Some(detail) = degraded_detail.as_deref() {
+                    let existing_coverage = self.lsp_status.coverage_edge_count();
+                    self.lsp_status.set_degraded_scoped(
+                        lsp_call_edge_count,
+                        existing_coverage,
+                        EnrichmentScope::ChangedFiles.stable_key(),
                         detail,
                     );
+                    if let Some(job_id) = incremental_lsp_job_id.as_deref() {
+                        self.enrichment_jobs.mark_degraded(
+                            &self.repo_root,
+                            job_id,
+                            graph.nodes.len(),
+                            graph.edges.len(),
+                            detail,
+                        );
+                    }
+                } else {
+                    // A clean, durable incremental pass supersedes any prior
+                    // degraded/running state, including the valid zero-edge case.
+                    let existing_coverage = self.lsp_status.coverage_edge_count();
+                    self.lsp_status.set_complete_scoped(
+                        lsp_call_edge_count,
+                        existing_coverage,
+                        EnrichmentScope::ChangedFiles.stable_key(),
+                    );
+                    if let Some(job_id) = incremental_lsp_job_id.as_deref() {
+                        self.enrichment_jobs.mark_completed(
+                            &self.repo_root,
+                            job_id,
+                            graph.nodes.len(),
+                            graph.edges.len(),
+                        );
+                    }
                 }
-            } else {
-                // A clean, durable incremental pass supersedes any prior
-                // degraded/running state, including the valid zero-edge case.
-                let existing_coverage = self.lsp_status.coverage_edge_count();
-                self.lsp_status.set_complete_scoped(
-                    lsp_call_edge_count,
-                    existing_coverage,
-                    EnrichmentScope::ChangedFiles.stable_key(),
-                );
                 if let Some(job_id) = incremental_lsp_job_id.as_deref() {
-                    self.enrichment_jobs.mark_completed(
+                    self.enrichment_jobs.record_lsp_evidence(
                         &self.repo_root,
                         job_id,
-                        graph.nodes.len(),
-                        graph.edges.len(),
+                        super::enrichment::lsp_evidence(
+                            if degraded_detail.is_some() {
+                                super::enrichment_jobs::LspEvidenceReadiness::Partial
+                            } else {
+                                super::enrichment_jobs::LspEvidenceReadiness::Scoped
+                            },
+                            &EnrichmentScope::ChangedFiles.stable_key(),
+                            0,
+                            None,
+                            degraded_detail.clone(),
+                            validations,
+                        ),
                     );
                 }
+            } else if let Some(job_id) = incremental_lsp_job_id.as_deref() {
+                let detail =
+                    "incremental call-reference output was not durably persisted".to_string();
+                self.enrichment_jobs.mark_failed(
+                    &self.repo_root,
+                    job_id,
+                    detail.clone(),
+                );
+                self.enrichment_jobs.record_lsp_evidence(
+                    &self.repo_root,
+                    job_id,
+                    super::enrichment::lsp_evidence(
+                        super::enrichment_jobs::LspEvidenceReadiness::Partial,
+                        &EnrichmentScope::ChangedFiles.stable_key(),
+                        0,
+                        None,
+                        Some(detail.clone()),
+                        validations,
+                    ),
+                );
             }
-        } else if !persist_succeeded && let Some(job_id) = incremental_lsp_job_id.as_deref() {
-            self.enrichment_jobs.mark_failed(
-                &self.repo_root,
-                job_id,
-                "incremental call-reference output was not durably persisted",
-            );
         }
 
         if persist_succeeded && !enrichment.runs_lsp() {
@@ -2925,6 +2993,9 @@ impl RnaHandler {
 
         graph.last_scan_completed_at = Some(std::time::Instant::now());
 
-        Ok(persist_succeeded)
+        Ok(IncrementalUpdateOutcome {
+            persist_succeeded,
+            lsp_job_id: incremental_lsp_job_id,
+        })
     }
 }

--- a/src/service/roots.rs
+++ b/src/service/roots.rs
@@ -260,6 +260,12 @@ pub fn list_roots_from_slugs(
                     if ls.aborted {
                         detail_parts.push("aborted".to_string());
                     }
+                    detail_parts.push(
+                        ls.validation
+                            .as_ref()
+                            .map(|validation| format!("validation {}", validation.summary()))
+                            .unwrap_or_else(|| "validation not recorded".to_string()),
+                    );
                     if let Some(remediation) = &ls.remediation
                         && (ls.server_missing || ls.aborted || ls.error_count > 0)
                     {
@@ -1347,6 +1353,14 @@ mod tests {
                     timeouts: 1,
                     errors: 2,
                 }],
+                validation: Some(
+                    crate::extract::scan_stats::LspValidationEvidence::processed(
+                        "rust",
+                        "rust-analyzer",
+                        "textDocument/documentSymbol",
+                        0,
+                    ),
+                ),
             },
         );
         stats.lsp_stats.insert(primary_slug.clone(), root_lsp);
@@ -1375,6 +1389,11 @@ mod tests {
         assert!(
             result.contains("45s"),
             "should show duration, got: {}",
+            result
+        );
+        assert!(
+            result.contains("validation processed via textDocument/documentSymbol (0 symbols)"),
+            "should distinguish processed-zero validation, got: {}",
             result
         );
         assert!(
@@ -1426,6 +1445,13 @@ mod tests {
                 server_missing: false,
                 remediation: Some("install pyright".to_string()),
                 query_metrics: Vec::new(),
+                validation: Some(
+                    crate::extract::scan_stats::LspValidationEvidence::not_validated(
+                        "python",
+                        "pyright-langserver",
+                        "server exited before validation",
+                    ),
+                ),
             },
         );
         stats.lsp_stats.insert(primary_slug.clone(), root_lsp);
@@ -1459,6 +1485,11 @@ mod tests {
         assert!(
             result.contains("2m"),
             "should show duration, got: {}",
+            result
+        );
+        assert!(
+            result.contains("validation not validated: server exited before validation"),
+            "should expose not-validated evidence, got: {}",
             result
         );
     }
@@ -1501,6 +1532,7 @@ mod tests {
                 server_missing: false,
                 remediation: None,
                 query_metrics: Vec::new(),
+                validation: None,
             },
         );
         stats.lsp_stats.insert(primary_slug.clone(), root_lsp);

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -582,8 +582,26 @@ fn format_enrichment_jobs(ctx: &SearchContext<'_>) -> String {
             .lsp_evidence
             .as_ref()
             .map(|evidence| {
+                let validations = if evidence.validations.is_empty() {
+                    String::new()
+                } else {
+                    let summaries = evidence
+                        .validations
+                        .iter()
+                        .map(|validation| {
+                            format!(
+                                "{}/{}: {}",
+                                validation.language,
+                                validation.server_name,
+                                validation.summary()
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!(" validation=[{summaries}]")
+                };
                 format!(
-                    " evidence={} declared_nodes={} requests={}/{} elapsed_ms={}/{} circuit_open={}",
+                    " evidence={} declared_nodes={} requests={}/{} elapsed_ms={}/{} circuit_open={}{}",
                     evidence.readiness.as_str(),
                     evidence.declared_node_count,
                     evidence.scheduled_requests,
@@ -595,6 +613,7 @@ fn format_enrichment_jobs(ctx: &SearchContext<'_>) -> String {
                         .max_duration_ms
                         .map_or_else(|| "n/a".to_string(), |value| value.to_string()),
                     evidence.circuit_open,
+                    validations,
                 )
             })
             .unwrap_or_default();
@@ -3129,6 +3148,14 @@ mod tests {
                 elapsed_ms: 12,
                 circuit_open: false,
                 detail: Some("broad references were omitted".to_string()),
+                validations: vec![
+                    crate::extract::scan_stats::LspValidationEvidence::processed(
+                        "json",
+                        "vscode-json-languageserver",
+                        "textDocument/documentSymbol",
+                        0,
+                    ),
+                ],
             },
         );
         let mut ctx = make_search_context(&gs, &repo_root);
@@ -3147,6 +3174,9 @@ mod tests {
         assert!(result.contains("default query profile"));
         assert!(result.contains("broad references were omitted"));
         assert!(result.contains("evidence=default_profile"));
+        assert!(result.contains(
+            "validation=[json/vscode-json-languageserver: processed via textDocument/documentSymbol (0 symbols)]"
+        ));
         assert!(!result.contains("LSP call/reference coverage**: ready"));
     }
 
@@ -3218,6 +3248,7 @@ mod tests {
                     elapsed_ms: 10,
                     circuit_open,
                     detail: None,
+                    validations: Vec::new(),
                 },
             );
         }

--- a/tests/fixtures/lsp_capability_repo/sample.json
+++ b/tests/fixtures/lsp_capability_repo/sample.json
@@ -1,0 +1,5 @@
+{
+  "fixture": {
+    "enabled": true
+  }
+}

--- a/tests/fixtures/lsp_capability_server.py
+++ b/tests/fixtures/lsp_capability_server.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Deterministic stdio LSP fixture for capability/readiness CLI checks.
+
+Set RNA_LSP_FIXTURE_SCENARIO to document_zero (default), workspace,
+method_not_found, crash, or timeout. The fixture deliberately advertises only
+the readiness capability exercised by the scenario.
+"""
+
+import json
+import os
+import sys
+import time
+
+
+def read_message():
+    headers = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        name, value = line.decode("ascii").split(":", 1)
+        headers[name.lower()] = value.strip()
+    length = int(headers["content-length"])
+    payload = sys.stdin.buffer.read(length)
+    if len(payload) != length:
+        return None
+    return json.loads(payload)
+
+
+def send_message(payload):
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    sys.stdout.buffer.write(f"Content-Length: {len(encoded)}\r\n\r\n".encode("ascii"))
+    sys.stdout.buffer.write(encoded)
+    sys.stdout.buffer.flush()
+
+
+def result(request_id, value):
+    send_message({"jsonrpc": "2.0", "id": request_id, "result": value})
+
+
+def rpc_error(request_id, code, message):
+    send_message(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        }
+    )
+
+
+def main():
+    scenario = os.environ.get("RNA_LSP_FIXTURE_SCENARIO", "document_zero")
+    while True:
+        message = read_message()
+        if message is None:
+            return 0
+        method = message.get("method")
+        request_id = message.get("id")
+
+        if method == "initialize":
+            capabilities = (
+                {"workspaceSymbolProvider": True}
+                if scenario == "workspace"
+                else {"documentSymbolProvider": True}
+            )
+            result(request_id, {"capabilities": capabilities})
+        elif method in ("workspace/symbol", "textDocument/documentSymbol"):
+            if scenario == "method_not_found":
+                rpc_error(request_id, -32601, "fixture method not found")
+            elif scenario == "crash":
+                return 17
+            elif scenario == "timeout":
+                time.sleep(60)
+            elif scenario == "workspace":
+                result(request_id, [{"name": "fixture-symbol"}])
+            else:
+                result(request_id, [])
+        elif method == "shutdown":
+            result(request_id, None)
+        elif method == "exit":
+            return 0
+        elif request_id is not None:
+            rpc_error(request_id, -32601, "fixture method not found")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #781

## Problem

LSP readiness probed and validated every server with `workspace/symbol`, even when initialization said that method was unsupported. Method-not-found responses were then treated like empty indexing results, causing long retries, false non-quiescent state, and skipped supported passes.

## Chosen solution

Retain typed `ServerCapabilities` and select a generic validation path from the advertised workspace/document-symbol providers. Use deterministic `textDocument/documentSymbol` validation on an included warm-up document when workspace symbols are unavailable, fail immediately on JSON-RPC `-32601`, preserve hard failures for advertised capabilities, and persist an explicit validation outcome that distinguishes processed-zero from skipped/not-validated.

## Scope

This PR is limited to #781 capability-driven LSP validation, terminal state, diagnostics/status evidence, regression fixtures, and CLI proof. It does not implement #784 cohort-wide per-file completeness or #785 server provisioning.

## Verification

- `cargo check --lib`
- `cargo test --lib readiness_ -- --nocapture` — 31 passed
- `cargo test` — 2,066 library tests passed; 0 failed; integration suites passed
- RNA CLI fixture proof with `scan --full --no-embed` against the document-only JSON server:
  - capabilities: `workspace_symbols=false, document_symbols=true`
  - terminal log: `validated via documentSymbol: 0 symbols`
  - Pass 1 and Pass 4 completed
  - a fresh CLI query rendered persisted evidence: `processed via textDocument/documentSymbol (0 symbols)`
- Unsupported-method unit fixture is bounded at 50 ms and asserts exactly one request/no retries.

The PR remains draft for the parent #784 gate; it has not entered `/ship`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LSP readiness validation details to scan results and enrichment evidence.
  * Search and root views now display validation status, server details, and related evidence.
  * Persisted enrichment records now retain validation information for later reporting.

* **Bug Fixes**
  * Improved deterministic LSP warmup selection and capability-based readiness checks.
  * Enhanced handling of LSP protocol errors, unsupported methods, timeouts, and failures.

* **Tests**
  * Added coverage for validation reporting, persistence, deterministic selection, and LSP capability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->