### PR TITLE
Improve agent retrieval projection, ranking, and task context

### DIFF
--- a/.github/scripts/mcp-smoke.mjs
+++ b/.github/scripts/mcp-smoke.mjs
@@ -21,34 +21,49 @@ const workItemLedgerPath = path.join(
 const previousWorkItemLedger = fs.existsSync(workItemLedgerPath)
   ? fs.readFileSync(workItemLedgerPath)
   : null;
-const now = Date.now();
-fs.mkdirSync(path.dirname(workItemLedgerPath), { recursive: true });
-fs.writeFileSync(
-  workItemLedgerPath,
-  JSON.stringify({
-    schema_version: 4,
-    records: {
-      "mcp-smoke:0": {
-        schema_version: 4,
-        job_id: "mcp-smoke",
-        item_id: 0,
-        repo: repoPath,
-        root: "fixture",
-        file: "src/main.rs",
-        node_id: "fixture:src/main.rs:main:function",
-        node_name: "main",
-        node_kind: "function",
-        requested_operations: ["textDocument/references"],
-        state: "in_flight",
-        attempt_count: 1,
-        current_phase: "mcp_smoke_probe",
-        created_at_ms: now,
-        updated_at_ms: now,
-        started_at_ms: now,
+let syntheticWorkItemLedgerInstalled = false;
+
+function installSyntheticWorkItemLedger() {
+  const now = Date.now();
+  fs.mkdirSync(path.dirname(workItemLedgerPath), { recursive: true });
+  fs.writeFileSync(
+    workItemLedgerPath,
+    JSON.stringify({
+      schema_version: 4,
+      records: {
+        "mcp-smoke:0": {
+          schema_version: 4,
+          job_id: "mcp-smoke",
+          item_id: 0,
+          repo: repoPath,
+          root: "fixture",
+          file: "src/main.rs",
+          node_id: "fixture:src/main.rs:main:function",
+          node_name: "main",
+          node_kind: "function",
+          requested_operations: ["textDocument/references"],
+          state: "in_flight",
+          attempt_count: 1,
+          current_phase: "mcp_smoke_probe",
+          created_at_ms: now,
+          updated_at_ms: now,
+          started_at_ms: now,
+        },
       },
-    },
-  }),
-);
+    }),
+  );
+  syntheticWorkItemLedgerInstalled = true;
+}
+
+function restoreWorkItemLedger() {
+  if (!syntheticWorkItemLedgerInstalled) return;
+  if (previousWorkItemLedger) {
+    fs.writeFileSync(workItemLedgerPath, previousWorkItemLedger);
+  } else {
+    fs.rmSync(workItemLedgerPath, { force: true });
+  }
+  syntheticWorkItemLedgerInstalled = false;
+}
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -653,6 +668,10 @@ try {
 
   // ── 6. list_roots ───────────────────────────────────────────────────────
   console.log("\n── list_roots ──");
+  // The durable work ledger is part of semantic readiness identity. Install
+  // this synthetic queue only for the list_roots assertion, after every
+  // semantic query, then restore it before any later search.
+  installSyntheticWorkItemLedger();
   const rootsResult = await client.callTool({ name: "list_roots", arguments: {} });
   const rootsText = extractText(rootsResult);
   assertContains("list_roots response contains 'Workspace Roots'", rootsText, "Workspace Roots");
@@ -667,6 +686,7 @@ try {
     rootsText,
     "mcp_smoke_probe=1",
   );
+  restoreWorkItemLedger();
 
   // ── 7. search (neighbors depth=2) ──────────────────────────────────────
   // Verifies that the depth parameter is accepted and processed through the
@@ -718,11 +738,7 @@ try {
   fs.rmSync(path.join(repoPath, ".oh", ".cache", "construction_error.rmeta"), {
     force: true,
   });
-  if (previousWorkItemLedger) {
-    fs.writeFileSync(workItemLedgerPath, previousWorkItemLedger);
-  } else {
-    fs.rmSync(workItemLedgerPath, { force: true });
-  }
+  restoreWorkItemLedger();
 }
 
 if (failures > 0) process.exit(1);

--- a/.github/scripts/mcp-smoke.mjs
+++ b/.github/scripts/mcp-smoke.mjs
@@ -176,18 +176,30 @@ function assertTaskRoleOrDegradation(text, role) {
     pass(`task context delivers role ${role}`);
     return;
   }
-  const hasOmissionSurface = text.includes("## Omissions and degradation");
+  const omissionHeading = "\n## Omissions and degradation\n";
+  const omissionStart = text.indexOf(omissionHeading);
+  const omissionRemainder =
+    omissionStart === -1
+      ? ""
+      : text.slice(omissionStart + omissionHeading.length);
+  const nextHeading = omissionRemainder.indexOf("\n## ");
+  const omissionSection = omissionRemainder.slice(
+    0,
+    nextHeading === -1 ? omissionRemainder.length : nextHeading,
+  );
   const debugRole = role
     .split("_")
     .map((word) => word[0].toUpperCase() + word.slice(1))
     .join("");
-  const roleNamed = [role, debugRole].some((name) =>
-    text.toLowerCase().includes(name.toLowerCase()),
-  );
-  const truthfullyDegraded = /\b(?:degraded|unavailable|missing|omitted|not covered)\b/i.test(
-    text,
-  );
-  if (hasOmissionSurface && roleNamed && truthfullyDegraded) {
+  const roleNames = [role, debugRole].map((name) => name.toLowerCase());
+  const roleSpecificDegradation = omissionSection
+    .split(/\n(?=- )/)
+    .some(
+      (entry) =>
+        roleNames.some((name) => entry.toLowerCase().includes(name)) &&
+        /\b(?:degraded|unavailable|missing|omitted|not covered)\b/i.test(entry),
+    );
+  if (roleSpecificDegradation) {
     pass(`task context truthfully degrades role ${role}`);
   } else {
     fail(

--- a/.github/scripts/mcp-smoke.mjs
+++ b/.github/scripts/mcp-smoke.mjs
@@ -221,7 +221,10 @@ async function callSearchWithRetry(args) {
     });
     text = extractText(result);
 
-    if (!text.includes("Index building")) {
+    const prewarmStillAttachingSemanticIndex = text.includes(
+      "Strict semantic qualification FAILED: `embedding index is not attached`",
+    );
+    if (!text.includes("Index building") && !prewarmStillAttachingSemanticIndex) {
       return text;
     }
 
@@ -230,9 +233,14 @@ async function callSearchWithRetry(args) {
     }
   }
 
-  if (text.includes("Index building")) {
+  if (
+    text.includes("Index building") ||
+    text.includes(
+      "Strict semantic qualification FAILED: `embedding index is not attached`",
+    )
+  ) {
     throw new Error(
-      `search remained in "Index building" state after ${maxAttempts} attempts`
+      `search remained in a transient prewarm state after ${maxAttempts} attempts`
     );
   }
   return text;

--- a/.github/scripts/mcp-smoke.mjs
+++ b/.github/scripts/mcp-smoke.mjs
@@ -1,6 +1,7 @@
 import process from "node:process";
 import fs from "node:fs";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
@@ -74,6 +75,38 @@ function assertContains(label, text, needle) {
   }
 }
 
+function assertNotContains(label, text, needle) {
+  if (typeof text !== "string") {
+    fail(label, `Expected string, got ${typeof text}`);
+    return;
+  }
+  if (text.includes(needle)) {
+    fail(label, `Did not expect "${needle}" in response`);
+  } else {
+    pass(label);
+  }
+}
+
+function assertMatches(label, text, pattern) {
+  if (typeof text !== "string") {
+    fail(label, `Expected string, got ${typeof text}`);
+    return;
+  }
+  if (!pattern.test(text)) {
+    fail(label, `Expected ${pattern} in response (got ${text.length} chars)`);
+  } else {
+    pass(label);
+  }
+}
+
+function assertEqual(label, actual, expected) {
+  if (actual !== expected) {
+    fail(label, `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  } else {
+    pass(label);
+  }
+}
+
 function assertNonEmpty(label, items) {
   if (!Array.isArray(items) || items.length === 0) {
     fail(label, `Expected non-empty array, got ${JSON.stringify(items)}`);
@@ -89,6 +122,79 @@ function extractText(result) {
     .filter((c) => c.type === "text")
     .map((c) => c.text ?? "")
     .join("\n");
+}
+
+function sha256File(filePath) {
+  return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function assertRenderedBudget(label, text, maxBytes) {
+  const actualBytes = Buffer.byteLength(text, "utf8");
+  if (actualBytes > maxBytes) {
+    fail(label, `Rendered ${actualBytes} UTF-8 bytes, budget was ${maxBytes}`);
+    return;
+  }
+  const accounting = text.match(
+    /- total: bytes=(\d+) chars=(\d+) estimated_tokens=(\d+)/,
+  );
+  if (!accounting) {
+    fail(label, "Missing final render accounting");
+    return;
+  }
+  const accountedBytes = Number.parseInt(accounting[1], 10);
+  if (accountedBytes !== actualBytes) {
+    fail(
+      label,
+      `Footer accounts for ${accountedBytes} bytes, actual MCP text is ${actualBytes}`,
+    );
+    return;
+  }
+  pass(label);
+}
+
+function sourceBodyBytes(text) {
+  const start = text.indexOf("\n## Source bodies\n");
+  if (start === -1) return 0;
+  const remainder = text.slice(start + "\n## Source bodies\n".length);
+  const sectionEnds = [
+    remainder.indexOf("\n## Relationships\n"),
+    remainder.indexOf("\n## Render accounting\n"),
+  ].filter((offset) => offset >= 0);
+  const section = remainder.slice(
+    0,
+    sectionEnds.length > 0 ? Math.min(...sectionEnds) : remainder.length,
+  );
+  let bytes = 0;
+  for (const match of section.matchAll(/^(`{3,})text\n([\s\S]*?)\1$/gm)) {
+    bytes += Buffer.byteLength(match[2], "utf8");
+  }
+  return bytes;
+}
+
+function assertTaskRoleOrDegradation(text, role) {
+  if (text.includes(`role: ${role}`)) {
+    pass(`task context delivers role ${role}`);
+    return;
+  }
+  const hasOmissionSurface = text.includes("## Omissions and degradation");
+  const debugRole = role
+    .split("_")
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join("");
+  const roleNamed = [role, debugRole].some((name) =>
+    text.toLowerCase().includes(name.toLowerCase()),
+  );
+  const truthfullyDegraded = /\b(?:degraded|unavailable|missing|omitted|not covered)\b/i.test(
+    text,
+  );
+  if (hasOmissionSurface && roleNamed && truthfullyDegraded) {
+    pass(`task context truthfully degrades role ${role}`);
+  } else {
+    fail(
+      `task context delivers or degrades role ${role}`,
+      "Role was absent without a role-specific capability/omission explanation",
+    );
+  }
 }
 
 async function callSearchWithRetry(args) {
@@ -164,6 +270,34 @@ try {
     }
   }
 
+  const searchTool = tools.find((tool) => tool.name === "search");
+  const searchProperties = searchTool?.inputSchema?.properties ?? {};
+  for (const property of [
+    "projection",
+    "body_policy",
+    "max_output_bytes",
+    "max_output_tokens",
+    "max_body_bytes",
+    "max_total_body_bytes",
+    "context_mode",
+    "context_roles",
+    "context_facets",
+    "proposal",
+  ]) {
+    if (Object.hasOwn(searchProperties, property)) {
+      pass(`search MCP schema exposes ${property}`);
+    } else {
+      fail(`search MCP schema exposes ${property}`, "property missing from inputSchema");
+    }
+  }
+  for (const contractTerm of ["agent", "evidence", "task", "graph-delta-beta"]) {
+    assertContains(
+      `search MCP description advertises ${contractTerm}`,
+      searchTool?.description ?? "",
+      contractTerm,
+    );
+  }
+
   // ── 2. search (with artifacts) ──────────────────────────────────────────
   console.log("\n── search (artifacts) ──");
   const searchCtxText = await callSearchWithRetry({
@@ -207,7 +341,199 @@ try {
     "benchmark per-file LSP completeness",
   );
 
-  // ── 4a. persisted local-knowledge provenance ────────────────────────────
+  // ── 4a. projected search contract ───────────────────────────────────────
+  console.log("\n── search (agent/evidence projections) ──");
+  const agentProjectionText = await callSearchWithRetry({
+    query: "hello",
+    body_policy: "signature_only",
+    max_output_bytes: 8192,
+    include_artifacts: false,
+    include_markdown: false,
+    top_k: 3,
+  });
+  assertContains("default action projection is agent", agentProjectionText, "- projection: agent");
+  assertContains(
+    "agent projection reports final render cost",
+    agentProjectionText,
+    "## Render accounting",
+  );
+  for (const auditOnly of [
+    "evidence.candidate_rank",
+    "evidence.content_hash",
+    "evidence.score.",
+    "evidence.provenance",
+    "evidence.diagnostic.",
+    "## Candidate audit",
+  ]) {
+    assertNotContains(`agent projection omits ${auditOnly}`, agentProjectionText, auditOnly);
+  }
+
+  const evidenceProjectionText = await callSearchWithRetry({
+    query: "hello",
+    projection: "evidence",
+    body_policy: "signature_only",
+    max_output_bytes: 16384,
+    include_artifacts: false,
+    include_markdown: false,
+    top_k: 3,
+  });
+  assertContains(
+    "explicit audit projection is evidence",
+    evidenceProjectionText,
+    "- projection: evidence",
+  );
+  assertMatches(
+    "evidence projection exposes typed selection audit",
+    evidenceProjectionText,
+    /evidence\.(?:candidate_rank|content_hash|score\.|provenance|diagnostic\.)/,
+  );
+  assertContains(
+    "evidence projection exposes bounded candidate dispositions",
+    evidenceProjectionText,
+    "## Candidate audit",
+  );
+  assertRenderedBudget("evidence projection accounts for final MCP bytes", evidenceProjectionText, 16384);
+
+  // A one-byte body budget is intentionally binding for every source symbol in
+  // the fixture. The final output budget is checked against the actual MCP text,
+  // not a pre-render estimate.
+  console.log("\n── search (render/body budgets) ──");
+  const outputBudgetBytes = 8192;
+  const bodyBudgetBytes = 1;
+  const budgetedProjectionText = await callSearchWithRetry({
+    query: "hello",
+    projection: "agent",
+    body_policy: "complete",
+    max_output_bytes: outputBudgetBytes,
+    max_body_bytes: bodyBudgetBytes,
+    max_total_body_bytes: bodyBudgetBytes,
+    include_artifacts: false,
+    include_markdown: false,
+    top_k: 3,
+  });
+  assertRenderedBudget(
+    "MCP search honors final rendered output budget",
+    budgetedProjectionText,
+    outputBudgetBytes,
+  );
+  const emittedBodyBytes = sourceBodyBytes(budgetedProjectionText);
+  if (emittedBodyBytes <= bodyBudgetBytes) {
+    pass("MCP search honors per-record and aggregate body budgets");
+  } else {
+    fail(
+      "MCP search honors per-record and aggregate body budgets",
+      `Rendered ${emittedBodyBytes} source-body bytes, budget was ${bodyBudgetBytes}`,
+    );
+  }
+  assertNotContains(
+    "binding body budget is not mislabeled complete",
+    budgetedProjectionText,
+    "- body: complete",
+  );
+  assertMatches(
+    "binding body budget reports a typed omission",
+    budgetedProjectionText,
+    /- (?:per_record_body_cap|total_body_cap):/,
+  );
+
+  // ── 4b. role-aware task context ─────────────────────────────────────────
+  console.log("\n── search (task context) ──");
+  const taskContextText = await callSearchWithRetry({
+    query: "Fix `hello` in lib.rs and update `test_hello`",
+    projection: "agent",
+    context_mode: "task",
+    context_roles: ["editable_source", "test", "caller_or_impact"],
+    context_facets: ["behavior", "test"],
+    body_policy: "focused_span",
+    max_output_bytes: 16384,
+    include_artifacts: false,
+    include_markdown: false,
+  });
+  assertContains(
+    "task mode reports exact-reference capability",
+    taskContextText,
+    "task_exact_reference_resolution",
+  );
+  assertContains(
+    "task mode reports bounded selection capability",
+    taskContextText,
+    "task_context_selection",
+  );
+  assertMatches("task mode emits a typed role", taskContextText, /\n   - role: [a-z_]+\n/);
+  assertMatches("task mode emits a typed retrieval lane", taskContextText, /\n   - lane: [a-z_]+\n/);
+  assertTaskRoleOrDegradation(taskContextText, "editable_source");
+  assertTaskRoleOrDegradation(taskContextText, "test");
+  assertTaskRoleOrDegradation(taskContextText, "caller_or_impact");
+  assertRenderedBudget("task context honors the final output budget", taskContextText, 16384);
+
+  // ── 4c. non-mutating graph-delta beta ───────────────────────────────────
+  console.log("\n── search (graph-delta beta) ──");
+  const proposalTarget = path.join(repoPath, "lib.rs");
+  const proposalTargetBefore = sha256File(proposalTarget);
+  const stableGraphQuery = {
+    query: "hello",
+    projection: "agent",
+    body_policy: "none",
+    max_output_bytes: 8192,
+    include_artifacts: false,
+    include_markdown: false,
+    top_k: 1,
+  };
+  const graphViewBefore = await callSearchWithRetry(stableGraphQuery);
+  const graphDeltaText = await callSearchWithRetry({
+    query: "Review the proposed hello behavior change",
+    projection: "evidence",
+    context_mode: "graph-delta-beta",
+    proposal: [
+      "diff --git a/lib.rs b/lib.rs",
+      "--- a/lib.rs",
+      "+++ b/lib.rs",
+      "@@ -2,1 +2,1 @@",
+      '-pub fn hello() -> &\'static str { "world" }',
+      '+pub fn hello() -> &\'static str { "rna" }',
+    ].join("\n"),
+    body_policy: "signature_only",
+    max_output_bytes: 16384,
+    include_artifacts: false,
+    include_markdown: false,
+  });
+  assertContains("graph-delta returns the canonical card projection", graphDeltaText, "role: proposal_delta");
+  assertContains("graph-delta returns the proposal lane", graphDeltaText, "lane: proposal_delta");
+  assertContains("graph-delta returns capability state", graphDeltaText, "## Capability status");
+  for (const capability of [
+    "graph_delta_proposal_parsing",
+    "graph_delta_live_graph_inference",
+    "graph_delta_route_analysis",
+    "graph_delta_card_coverage",
+    "graph_delta_changed_files",
+    "graph_delta_affected_locus_checklist",
+    "proposal_overlay_persistence",
+  ]) {
+    assertMatches(
+      `graph-delta reports ${capability} capability`,
+      graphDeltaText,
+      new RegExp(`${capability}: (?:ready|degraded|unavailable)`),
+    );
+  }
+  assertContains(
+    "graph-delta returns explicit omissions/degradation",
+    graphDeltaText,
+    "## Omissions and degradation",
+  );
+  assertRenderedBudget("graph-delta honors the final output budget", graphDeltaText, 16384);
+  assertEqual(
+    "graph-delta does not mutate its proposed source file",
+    sha256File(proposalTarget),
+    proposalTargetBefore,
+  );
+  const graphViewAfter = await callSearchWithRetry(stableGraphQuery);
+  assertEqual(
+    "graph-delta does not mutate the published graph view",
+    createHash("sha256").update(graphViewAfter).digest("hex"),
+    createHash("sha256").update(graphViewBefore).digest("hex"),
+  );
+
+  // ── 4d. persisted local-knowledge provenance ────────────────────────────
   console.log("\n── search (local-knowledge provenance) ──");
   const provenanceText = await callSearchWithRetry({
     query: "quote.mcp-provenance",

--- a/.oh/sessions/810-dev.md
+++ b/.oh/sessions/810-dev.md
@@ -1,0 +1,124 @@
+---
+session: 810-dev
+outcome: context-assembly
+issues:
+  - 810
+  - 811
+  - 812
+  - 813
+  - 814
+pr: 822
+status: verification
+---
+
+# Dev Pipeline — agent retrieval context batch
+
+## Aim
+
+**Aim:** Coding agents receive compact, source-grounded, role-complete repository context per token and can inspect likely edit consequences without repeated broad retrieval loops.
+
+**Current state:** Unified search mixes action context with audit evidence, can repeat overlapping source, ranks unlike evidence on incompatible scales, and returns a flat top-k that can omit distinct implementation obligations.
+
+**Desired state:** One deterministic shared-service contract selects and renders concise context with explicit roles, provenance, completeness, cost, hydration handles, and an opt-in pre-edit graph-delta view.
+
+**Mechanism:** Separate selection evidence from action projection; plan source spans under a final-render budget; fuse channels by invariant rank evidence; compose exact, semantic, and graph lanes by task role; evaluate proposed edits in an ephemeral beta overlay.
+
+**Feedback signal:** Golden and real-repository fixtures show byte-stable output, no duplicated source bytes, higher required-role coverage at lower rendered cost, scale-invariant fusion, and source-grounded graph-delta diagnostics through both CLI and MCP.
+
+**Guardrails:**
+
+- Keep frozen #779 strict packet behavior and evidence unchanged.
+- Keep ordinary graph-delta behavior unchanged unless the caller explicitly opts into beta mode.
+- Source remains authoritative; summaries never substitute for required behavioral evidence.
+- Preserve strict semantic fail-closed behavior and prohibit fallback in strict mode.
+- Deliver agent-visible fields through the shared service and both CLI/MCP adapters.
+
+## Problem Space
+
+We are optimizing useful implementation evidence per model-visible byte, not raw retrieval score or the number of returned records.
+
+| Constraint | Type | Reason |
+|---|---|---|
+| One PR for #810–#814 | hard | The contracts and fixtures overlap; repeated compile/review cycles are the dominant feedback cost. |
+| Shared CLI/MCP service contract | hard | Capability drift would make cost and selection evidence untrustworthy. |
+| Frozen #779 strict behavior unchanged | hard | The preregistered experiment must not be retroactively changed. |
+| Deterministic output and bounded work | hard | Agent context and beta proposal analysis must be reproducible and safe. |
+| #814 opt-in beta | hard | Counterfactual analysis is exploratory and cannot alter ordinary search defaults. |
+| No persisted overlay mutation | hard | A proposed edit is diagnostic input, not repository truth. |
+| One cargo process per target directory | hard | Avoid silent build-lock serialization. |
+
+The shared terrain is `SearchParams`, flat/traversal selection in `src/service/search.rs`, node formatting, semantic retrieval/reranking, graph traversal/path primitives, CLI/MCP schemas, and golden/real-repository fixtures.
+
+## Problem Statement
+
+Coding agents need compact context that covers the distinct evidence required to implement a task, but RNA currently spends budget on duplicated source and audit internals while ranking unlike signals and task obligations as one flat list. The batch must establish one deterministic selection/projection contract and an isolated beta edit-risk view without changing frozen strict benchmark behavior.
+
+## Solution Space
+
+| Option | Level | Approach | Trade-off |
+|---|---|---|---|
+| A | Local optimum | Deliver five serial PRs over the same search seams. | Repeats contract churn, compilation, review, and CI; high integration risk. |
+| B | Reframe | Build one layered shared-service pipeline with internal module boundaries and one delivery lifecycle. | Larger single diff, requiring disciplined pure modules and focused gates. |
+| C | Redesign | Replace unified search and graph traversal with a new query engine. | Unnecessary migration and unacceptable risk to existing/frozen behavior. |
+
+**Selected:** Option B. Implement projection/cost, span planning, calibrated fusion, task lanes, and graph-delta as separate deterministic modules, then integrate them once through `SearchParams` and the shared service. Strict semantic requests retain their frozen renderer/ordering. Graph-delta remains an explicit beta mode.
+
+### Selected module boundaries
+
+- `model.rs`: typed intent, projection, body, budget, role, lane, evidence, omission, and hydration contracts.
+- `fusion.rs`: scale-invariant within-channel rank fusion with stable-ID tie breaking and strict-mode isolation.
+- `source.rs`: root-safe bounded reads shared by exact spans and hydration.
+- `projection.rs`: deterministic path grouping, overlap coalescing, body degradation, and budget admission.
+- `render.rs`: canonical action/evidence rendering and self-inclusive category accounting.
+- `task_context.rs`: exact-first parsing, bounded role lanes, graph expansion, and coverage-per-marginal-cost selection.
+- `graph_delta.rs`: bounded ephemeral proposal overlay and deterministic before/after path diagnostics.
+
+Selection remains typed until the final renderer. Query-time evidence stays in the response contract rather than being persisted on graph nodes. CLI and MCP adapt the same canonical output. The existing frozen strict semantic path bypasses the new product policy.
+
+## Execute Pre-flight
+
+- [x] Aim is clear.
+- [x] Acceptance criteria exist on open issues #810–#814.
+- [x] Issues are assigned and one draft PR exists before implementation.
+- [x] Dedicated worktree is indexed with a non-zero extracted graph.
+- [x] Scope is bounded to the five issues and excludes frozen #779 changes.
+- [x] Solution-space and architecture sub-agent findings incorporated.
+- [x] Module ownership and focused test gates finalized.
+
+## RNA Tool Friction Log
+
+| Phase | Tool path | Severity | Friction | Impact / response |
+|---|---|---:|---|---|
+| Context load | RNA source-span lookup | low | The first bounded requests used an end line beyond EOF; the tool failed closed and reported exact file lengths. | Retried with exact bounds; no raw file fallback was needed. |
+| Execute integration | RNA refresh/search → bounded raw fallback | medium | The installed RNA scanner retained the prior 50,598-symbol snapshot and did not index the new untracked module files, so exact searches returned no new APIs. | Used a bounded `rg` signature inventory and targeted `sed` ranges only for the new untracked modules; tracked-code exploration continued through RNA. |
+| Execute integration | RNA incremental LSP enrichment | medium | The later 52,192-symbol refresh indexed the modules, but Python and TypeScript enrichment degraded on missing `Content-Length` headers. | Continued with the verifier-clean extracted graph and exact source-span interface; no readiness claim depends on partial LSP evidence, and this unrelated scanner friction is not broadened into #810–#814. |
+| Consolidated remediation | RNA exact search → bounded raw source fallback | low | RNA located the changed symbols and exact ranges but does not return full function bodies needed for compiler-directed edits. | Read only the located ranges and current diff with `sed`/`git diff`; no broad source search or unrelated files. |
+| Consolidated service integration | RNA exact graph → bounded `sed`/`rg` fallback | low | RNA located the search, embedding, hydration, and capability seams but could not expose the complete function bodies required for a coordinated edit. | The service agent read only RNA-located ranges in `search.rs`/`embed*.rs`; no unrelated source fallback, and Rust extracted-graph evidence remained ready. |
+| Task/delta adapter audit | RNA exact graph → bounded source ranges | low | RNA exposed the pure selector/analyzer symbols and service call sites, but acceptance tracing required the adapter bodies and return-field mappings. | The fresh auditor read only the located `search.rs` ranges, identified dropped lanes/card fields before compilation, and made no edits during audit. |
+| Verification planning | RNA workflow search → bounded workflow/config fallback | low | Workflow YAML, exact Cargo invocations, and the MCP smoke script were not represented in RNA search results. | Read only `.github/workflows`, `Cargo.toml`, and the MCP script with bounded `git grep`/`sed`; froze one progressive local gate and one full CI-equivalent gate without running Cargo. |
+| Focused failure remediation | RNA test-symbol lookup → bounded test-body fallback | low | RNA found the exact model, MCP schema, and handler regression symbols but did not expose their assertion bodies. | Read only those located test ranges with `sed`/`rg`; repaired checksum-shape, unknown-field, and canonical MCP-output assertions without changing production behavior. |
+| Final consolidated review | RNA 52,612-symbol snapshot → current-diff fallback | medium | The extracted snapshot lagged the final remediation and initially surfaced findings already fixed in current bytes. | Re-ran the issue matrix against the bounded current diff, cleared stale findings, and retained only five actionable #811–#814 defects for the single consolidated remediation batch. |
+| Full-suite regression | Compiler/test location → bounded source ranges | low | The new projection initially omitted live Markdown when the graph was empty or the query used only a file filter. | Reused the existing root-confined live Markdown admission, made current source supersede indexed duplicates, and proved disabled-mode rebuild/reopen behavior before resuming the full suite. |
+
+## Execution Result
+
+- #810: deterministic agent/evidence projections, truthful capability state, canonical cost accounting, and checksum-bound evidence hydration.
+- #811: overlap-aware source planning, bounded body policies, complete paginated hydration, and authoritative union identities.
+- #812: scale-invariant typed fusion with native BM25/cosine-distance/hybrid-RRF provenance kept separate from product adjustments.
+- #813: exact-first task assembly with source/type-backed role eligibility, explicit lane misses, graph expansion, and bounded maximum-coverage selection.
+- #814: opt-in bounded graph-delta cards with immutable overlays, deterministic route/impact analysis, and exhaustive selected/omitted locus audit.
+- Frozen strict semantic qualification bypasses every new product control and retains its existing renderer and ordering.
+- Current root-confined Markdown/RST remains live and git-aware; current source supersedes an indexed duplicate rather than disappearing from the new projection.
+
+## Verification
+
+- `cargo check --lib --no-default-features`
+- `cargo check --bin repo-native-alignment --no-default-features`
+- `cargo test --lib --no-default-features search`: 260 passed
+- `cargo check --lib --features embeddings`
+- focused embedding score/provenance tests: 3 passed
+- `cargo clippy --no-default-features -- -D warnings`
+- `cargo test --no-default-features`: 2,305 library tests passed, 4 ignored; all binary/integration/doc tests passed
+- SWE-bench Python harness suites: 42 passed
+- changed Rust modules are rustfmt-clean; the untouched baseline formatting drift in `src/smoke_test.rs` was preserved
+- `git diff --check` and MCP smoke script syntax check passed

--- a/.oh/sessions/822-ship.md
+++ b/.oh/sessions/822-ship.md
@@ -1,0 +1,55 @@
+## Ship Pipeline — PR #822
+
+**Started:** 2026-07-21
+**Reviewed head:** `2fd9d2fee77783b45a9b40814fee2c195ad055f9`
+
+### Pre-flight
+
+- PR #822 batches and closes #810–#814 from `issue/810`.
+- Worktree index is live with 52,612 extracted symbols.
+- LSP caller/reference coverage is explicitly degraded for Python and TypeScript; exact graph/source review remains available and no conclusion below relies on complete LSP coverage.
+- Existing external review contains only CodeRabbit's draft-skip boilerplate; CodeRabbit is advisory and is not being triggered or awaited.
+
+### Step 1: RNA-Grounded Review
+
+**Verdict:** CONTINUE
+
+- Full #810–#814 acceptance matrix posted at <https://github.com/open-horizon-labs/repo-native-alignment/pull/822#issuecomment-5037808700>.
+- Relevant metis/guardrails are honored structurally.
+- RNA impact confirms one shared service entry for CLI/MCP/viewer dispatch.
+- Six concrete high-risk concerns were checked; no unresolved actionable finding remains.
+
+### Step 2: Independent Code Review
+
+**Reviewer:** `/root/ship_822/pr822_step2_review`
+**Reviewed commit:** `2fd9d2fee77783b45a9b40814fee2c195ad055f9`
+**Verdict:** REQUEST CHANGES
+
+- Review posted at <https://github.com/open-horizon-labs/repo-native-alignment/pull/822#issuecomment-5037920136>.
+- Four P1 findings: legacy traversal control bypass, token-only task admission, incomplete live diff relationship/behavior inference, and missing comparative outcome assertions.
+- No ship edit was made before reporting the bounded findings to the root implementer for the authorized remediation decision.
+
+### Step 3: Consolidated Ship Remediation
+
+- Legacy node/nodes/traversal/target-subsystem dispatch now rejects explicit product projection/body/budget/task/delta controls while a direct regression proves default legacy bytes/order are unchanged.
+- Task admission converts token-only bounds to the deterministic `chars / 4` estimate's byte currency and uses the tighter byte/token bound; the final canonical renderer remains authoritative.
+- Evidence projection reports exact coalesced per-span bytes/chars/token estimate without adding audit data to the agent projection.
+- Live graph-delta consumes canonical proposal-grounded call/reference/registration/state facts, uniquely corroborates endpoints, emits five grounded behavior classes, and discovers only the nearest affected test layer.
+- Two real RNA task fixtures now cover four explicit obligations at lower rendered cost than a larger flat top-k; the real RNA graph-delta fixture is smaller and more role-specific than the source-body neighbors/impact views required for every covered locus.
+- The default/compact/evidence matrix and the truthful non-measured four-query channel diagnostic close the remaining review evidence gaps.
+
+### Focused Verification
+
+- `cargo check --lib --no-default-features`: pass.
+- `cargo test --lib --no-default-features service::search`: 183 passed, 0 failed.
+- Rust 2024 formatting and `git diff --check`: pass.
+- The first comparative fixture execution correctly failed because the baseline already covered the requested test and because a one-seed body-free traversal was not context-equivalent. The fixture-only correction now uses exact named tests plus dependency/impact obligations, and compares the graph card with all source-bearing raw views needed to reproduce it.
+
+### RNA Tool Friction Log
+
+| Time | Tool path | Severity | Friction | Impact / response |
+|---|---|---:|---|---|
+| 2026-07-21 | Ship metis prerequisite | low | `.claude/agents/ship.md` names `.oh/metis/computed-but-not-delivered.md`, while the current canonical artifact is `.oh/guardrails/computed-but-not-delivered.md`. | RNA artifact search found and supplied the canonical hard guardrail; no code-navigation fallback was used. |
+| 2026-07-21 | RNA exact-symbol search | low | Several exact new function-name queries returned empty despite the live index. | Used RNA's file-scoped function inventory and graph-neighbor queries; no raw source fallback was needed. |
+| 2026-07-21 | Remediation integration inspection | low | The live RNA snapshot exposed signatures but lagged the uncommitted remediation bodies. | Used only the exact four-file current diff and one RNA-located bounded `search.rs` range to verify the combined adapter/test patch. |
+| 2026-07-21 | Rustfmt probe | low | An initial direct `rustfmt --edition 2021 --check` rejected pre-existing Rust 2024 let-chains. | Re-ran the owned files with the repository's Rust 2024 edition; formatting passed without source changes. |

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ This explores your codebase, asks about your aims, writes `AGENTS.md`, scaffolds
 
 | Tool | What it's for |
 |------|--------------|
-| `search` | Code symbols, artifacts, commits, and markdown — flat or graph traversal (`mode`: neighbors, impact, reachable, tests_for, cycles, path). Retrieve bounded current-filesystem source with `file` + `line`/`end_line` (or `file="path:line:column"`; maximum 200 lines). Scope to a subsystem (`subsystem=`), filter cross-subsystem edges (`target_subsystem=`), use `compact: true` for ~25x fewer tokens, `rerank: true` (default for MCP) for cross-encoder precision. Use `include_body: true` (requires `node` or `nodes`) to return function bodies; add `minify_body: true` to strip comments and shorten locals with a legend (tree-sitter AST for TS/JS, Rust, Python, Go; text fallback for others). |
+| `search` | Code symbols, artifacts, commits, and markdown — flat or graph traversal (`mode`: neighbors, impact, reachable, tests_for, cycles, path). The default `agent` projection keeps action context concise; `projection="evidence"` exposes ranking/audit details. Final rendered budgets and explicit body policies prevent duplicate or silently partial source. Opt into role-aware bundles with `context_mode="task"` or the non-mutating `context_mode="graph-delta-beta"`. Existing exact source, subsystem, compact, rerank, and body controls remain available. |
 | `repo_map` | Repository orientation: detected subsystems with their key interfaces, top symbols by importance, hotspot files, active outcomes, entry points. One call replaces an exploratory loop. |
 | `outcome_progress` | Connect business outcomes to code: outcome → tagged commits → changed files → symbols. Optional `include_impact: true` for risk-classified blast radius. |
 | `list_roots` | Show configured workspace roots with live scan stats (symbols, edges, detected frameworks, LSP edge counts per language, scan phase), durable Pass 1 queue snapshots (pending, in-flight, completed, failed, skipped, exhausted, resumed/retried counts, phase counts, oldest work, and bounded actionable exhaustion samples) from `.oh/.cache/lsp_pass1_work_items.json`, and recent OperationReport history from `.oh/.cache/operation_reports.json`. Interrupted queues resume only eligible work: completed output and skipped state are carried forward only when the node input fingerprint is unchanged. OperationReports persist the same queue snapshot for post-run inspection. Includes LSP servers available to install for each root's detected languages. |
@@ -239,6 +239,8 @@ rule supplies valid evidence.
 **Index-updating indicator:** When the background scanner is actively rebuilding the index (triggered by a HEAD change), `search`, `repo_map`, and `outcome_progress` responses append: `_Index updating in background — results reflect last complete scan._` No note appears when the index is current. This is informational — results are still valid, just from the previous complete scan.
 
 **Search degradation:** If semantic scoring fails after a graph is mapped, `search` keeps the graph available, returns bounded lexical/graph results, and appends content-safe component/model/index diagnostics. Rebuild the embeddings capability for that root and retry semantic search; the diagnostic deliberately omits query text, file paths, and panic payloads.
+
+See [Search projections and task context](docs/search-context.md) for projection fields, rendered-cost semantics, body policies, task roles/facets, and the opt-in graph-delta beta contract.
 
 ### CLI ↔ MCP Equivalence
 

--- a/docs/search-context.md
+++ b/docs/search-context.md
@@ -1,0 +1,161 @@
+# Search projections and task context
+
+RNA's unified search has two output projections:
+
+- `agent` (the default) returns source-grounded context needed to act: stable
+  identity and hydration handle, repository-relative location, symbol kind and
+  signature, selection channel/reason, task role when known, body state, and a
+  deterministic rendered-cost summary.
+- `evidence` adds the audit trail: every contributing channel and rank, typed
+  raw retrieval values, normalized contributions, deterministic tie-breaks,
+  omission decisions, hashes, and capability diagnostics. It also lists every
+  member of the bounded candidate set, including candidates omitted from the
+  agent projection and the deterministic reason for each disposition.
+
+The evidence projection changes presentation, not qualification. A caller can
+therefore inspect why a result was selected without paying for that audit data
+in every agent prompt.
+
+## Ranking evidence
+
+Product search combines channels only after deterministic within-channel
+ranking. Every embedding result keeps two distinct values: the backend-native
+value used for audit, and the product ranking score produced after the declared
+normalization and optional test-path adjustment. Values with different meanings
+are never added directly:
+
+| Channel | Native value | Better direction |
+| --- | --- | --- |
+| exact/lexical | exact-match tier or lexical heuristic | higher |
+| full text | BM25 score | higher |
+| vector | cosine distance | lower |
+| hybrid | reciprocal-rank-fusion relevance | higher |
+| rerank | cross-encoder score | higher |
+| structural | PageRank, edge degree, or structural heuristic | higher |
+| graph | hop count or bounded graph heuristic | lower for hops, higher for heuristic |
+
+RNA converts each available channel to a normalized rank contribution under a
+named, versioned policy, then records the contributing channel ranks, final
+ordering reason, and deterministic tie-break in the evidence projection. This
+makes ranking invariant to positive rescaling of a scorer while allowing strong
+exact or graph evidence to promote a candidate without letting weak graph
+evidence dominate a substantially better semantic match. Separate FTS and
+vector lanes are not claimed when the backend supplies only opaque hybrid RRF.
+The sealed strict-semantic qualification path remains isolated: it accepts only
+its frozen hybrid candidate set and reranker permutation and never gains a
+product-search fallback.
+
+### Fusion seam inventory
+
+RNA normalizes evidence at the first shared-service seam where the channels
+meet. A candidate may occur in several lanes; those observations are retained
+independently, unioned before truncation, and fused exactly once.
+
+| Producer/seam | Native meaning | Product treatment |
+| --- | --- | --- |
+| extracted exact/name lookup | match tier and deterministic lexical order | exact/lexical lane; stable identity closes ties |
+| LanceDB keyword search | BM25 `_score` | native value is retained as `bm25`; product score uses non-negative saturation before optional test-path adjustment |
+| LanceDB semantic search | cosine `_distance` | native distance is retained as `cosine_distance`; product score uses `max(1 - distance, 0)` before optional test-path adjustment |
+| LanceDB hybrid search | backend `_relevance_score` | native value is retained as `hybrid_rrf_relevance`; product score uses non-negative saturation in one hybrid-RRF lane |
+| lexical supplementation | deterministic text-match order | independent lexical lane; it cannot evict another lane before fusion |
+| cross-encoder reranker | model relevance order | independent rerank lane in addition to its acquisition lane |
+| structural ranking | PageRank/complexity/edge-degree heuristic | typed structural lane, never added as an unscaled raw bonus |
+| graph traversal | typed relation, directness, and bounded hop count | graph lane ordered by directness/hops, then stable identity |
+| task selector | role/facet coverage and final rendered cost | post-fusion maximum-coverage admission; not a relevance score |
+| artifacts, commits, Markdown | exact/lexical or semantic document order | delivered through the same projection, or explicitly reported unavailable |
+| strict semantic qualification | frozen hybrid candidate order plus reranker permutation | isolated legacy contract; no product lane, supplement, or fallback is introduced |
+
+Evidence output records the actual producer used. For example, a hybrid request
+that executes a vector fallback retains a native cosine distance and is labeled
+vector, not hybrid; reranking adds a second contribution without erasing
+acquisition provenance. If a non-strict backend omits its score column, the
+deterministic substitute is labeled `deterministic_fallback`, never presented as
+a backend-native observation. Test-path demotion is likewise recorded as an
+explicit post-normalization adjustment rather than being mislabeled as a native
+similarity or relevance score.
+
+## Rendered cost
+
+Cost is computed after canonical rendering. RNA reports UTF-8 bytes, Unicode
+scalar values, and an explicitly named deterministic token estimate for the
+complete response and for its headers, bodies, relationships, metadata, and
+accounting footer. The estimate is a budgeting aid; it is never described as
+provider usage or billed tokens.
+
+Use `max_output_bytes` or `max_output_tokens` to set a final-output budget,
+`max_body_bytes` to cap one record, and `max_total_body_bytes` to cap the
+coalesced body section independently. The source planner degrades bodies only
+through explicit states:
+
+- `complete`
+- `focused_span`
+- `signature_only`
+- `minified`
+- `truncated`
+
+`none` is a request policy: the rendered record is labeled `signature_only`
+and carries an explicit `no_body_policy` omission rather than inventing a body
+representation for source that was not emitted.
+
+Every degradation has a stable omission reason and hydration handle. Partial
+source is never labeled complete. Overlapping selected records are projected as
+one source span with all satisfied identities, roles, and reasons attached, so
+the same source byte is not emitted twice.
+
+Source handles bind the exact root/path/line span and are revalidated against
+the current filesystem. Evidence handles are short content-addressed references
+to canonical capsules under `.oh/.cache/search_evidence/v1/`; the capsule binds
+the original selection, query digest, channel evidence, and current-node
+content digest. Missing, tampered, stale, oversized, or non-regular capsules
+fail closed, and hydration performs no retrieval. The cache is derived local
+state and is never part of frozen strict-semantic packets.
+
+## Task context (opt in)
+
+Set `context_mode=task` to compile a coding task into a bounded evidence bundle.
+RNA resolves exact paths, locations, qualified names, backticked identifiers,
+and named tests before running separate behavior, API, test, analogue, helper,
+and graph-impact lanes. Exact hits, ambiguities, and misses remain distinct.
+
+Callers may request bounded `context_roles`, `context_facets`, graph edge types
+and hops, a body policy, and a render budget. Unknown roles/facets and values
+above the service's hard limits fail closed. Selection maximizes newly covered
+roles per marginal rendered cost; one span may satisfy several roles without
+duplicating its source.
+
+Example CLI request:
+
+```bash
+repo-native-alignment search \
+  --repo . \
+  --context-mode task \
+  --context-roles editable_source,definition_or_api_state,test,direct_dependency,caller_or_impact \
+  --body-policy focused_span \
+  --max-output-tokens 4000 \
+  "Fix source_span so an out-of-range end line reports the valid bound"
+```
+
+The MCP `search` tool accepts the same service fields and returns the same
+canonical rendering.
+
+## Graph-delta beta (opt in)
+
+`context_mode=graph-delta-beta` accepts a bounded unified diff or structured
+edit sketch in `proposal`. RNA parses it into an ephemeral overlay, compares
+deterministic before/after routes, and reports changed edges, lost reachability,
+equal-cost alternatives, bypassed behavior, affected contracts/tests, and an
+affected-locus checklist.
+
+The beta analyzer never applies the proposal, changes the worktree, mutates the
+published graph, or writes overlay evidence to LanceDB. Every claim links to an
+existing source span or a proposal line. Unsupported, ambiguous, binary,
+traversal-containing, oversized, or incomplete inputs fail closed. Missing
+optional graph/LSP/semantic evidence is instead reported as a degraded
+capability; it is never presented as proof that no impact exists.
+
+## Strict semantic qualification
+
+The sealed SWE-bench strict path keeps its frozen qualification, ordering,
+rendering, protocol, and packet bytes. Product projections, calibrated fusion,
+task context, and graph-delta are separate opt-in/non-strict paths and do not
+retroactively change frozen benchmark evidence.

--- a/docs/search-context.md
+++ b/docs/search-context.md
@@ -74,6 +74,25 @@ a backend-native observation. Test-path demotion is likewise recorded as an
 explicit post-normalization adjustment rather than being mislabeled as a native
 similarity or relevance score.
 
+### Representative four-query channel diagnostic (#812)
+
+This is a deterministic contract diagnostic, not a latency, quality, or model
+benchmark. The “before” column records the scale/pathology found by the packet
+and seam audit; the “after” column is asserted by the named pure/service
+fixtures. No unexecuted query is presented as measured performance.
+
+| Representative query shape | Before the calibrated contract | After, as asserted by fixtures |
+| --- | --- | --- |
+| Exact name: `projected_search` | Exact and later semantic/graph observations could be assembled at different seams without one comparable contribution record. | Exact/lexical is an explicit ranked lane, additional lanes remain visible, and stable identity closes ties. `giant_semantic_decoy_is_bounded_and_cannot_erase_exact_graph_evidence` proves a large semantic decoy cannot erase the exact/graph candidate solely through score scale. |
+| Natural language: “paginate source hydration without losing bytes” | Native semantic or reranker magnitudes could dominate merely because their numeric scale was larger. | Semantic acquisition and rerank are independent within-channel ranks. `multiplying_each_channel_alone_cannot_change_fusion` proves positive raw-score rescaling cannot change identities or order when channel order is unchanged. |
+| Graph entry: impact from `projected_graph_delta` | The audited formula admitted million-point adjacent semantic gaps while graph bonuses remained below one hundred thousand, so direct graph evidence could not promote by one semantic position. | Graph directness/hops contributes through the same rank fusion. `graph_only_evidence_promotes_while_weak_graph_does_not_overwhelm_semantic` proves both legitimate promotion and weak-graph restraint. |
+| Mixed task: change `projected_graph_delta` and verify its test | A flat top-k could spend the body budget on a giant generic semantic record and omit a named test or state/API obligation. | Fusion establishes comparable candidates first; task selection then admits distinct exact, editable, test, state/API, analogue, dependency, and impact roles by coverage per rendered cost. Exact misses, ambiguities, and role omissions remain explicit. |
+
+The table describes non-strict product search only. The sealed #779 strict
+semantic path still consumes its frozen hybrid candidate order and reranker
+permutation without lexical, graph, vector-only, CPU, or original-order
+fallback.
+
 ## Rendered cost
 
 Cost is computed after canonical rendering. RNA reports UTF-8 bytes, Unicode
@@ -145,6 +164,16 @@ edit sketch in `proposal`. RNA parses it into an ephemeral overlay, compares
 deterministic before/after routes, and reports changed edges, lost reachability,
 equal-cost alternatives, bypassed behavior, affected contracts/tests, and an
 affected-locus checklist.
+
+The pure parser emits proposal-grounded relationship facts for calls, imports,
+registrations, and qualified attribute/state references. These are candidates,
+not graph claims: the live adapter must resolve each target to exactly one
+current source-grounded node before adding or removing an overlay edge.
+Ambiguous or absent endpoints degrade capability evidence rather than being
+guessed. Changed lines also surface grounded behavioral classes for branches,
+reconciliation, representation handling, error paths, and state propagation.
+For route changes, bounded traversal returns only the nearest source-grounded
+test layer; farther tests are not mislabeled as equally direct.
 
 The beta analyzer never applies the proposal, changes the worktree, mutates the
 published graph, or writes overlay evidence to LanceDB. Every claim links to an

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -87,12 +87,101 @@ pub enum SearchMode {
     Semantic,
 }
 
+/// Retrieval channel that actually executed after any allowed fallback.
+#[cfg(not(feature = "embeddings"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutedSearchMode {
+    Keyword,
+    Semantic,
+    HybridRrf,
+}
+
+/// Explicit product policy for test-path results.
+#[cfg(not(feature = "embeddings"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestResultPolicy {
+    Demote,
+    Neutral,
+}
+
+/// Native score emitted by the retrieval backend before product transforms.
+#[cfg(not(feature = "embeddings"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeScoreKind {
+    Bm25,
+    CosineDistance,
+    HybridRrfRelevance,
+}
+
+/// Whether a native value came from the backend or a deterministic fallback.
+#[cfg(not(feature = "embeddings"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeScoreSource {
+    Backend,
+    DeterministicFallback,
+}
+
+/// Deterministic normalization applied before product ranking policy.
+#[cfg(not(feature = "embeddings"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScoreNormalization {
+    NonNegativeSaturation,
+    OneMinusDistanceFloorZero,
+}
+
+/// Product adjustment applied after score normalization.
+#[cfg(not(feature = "embeddings"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScoreAdjustment {
+    None,
+    TestPathDemotion70Percent,
+}
+
+#[cfg(not(feature = "embeddings"))]
+impl ScoreAdjustment {
+    pub const fn factor(self) -> f32 {
+        match self {
+            Self::None => 1.0,
+            Self::TestPathDemotion70Percent => 0.7,
+        }
+    }
+}
+
+/// Score audit record aligned with one returned [`SearchResult`].
+#[cfg(not(feature = "embeddings"))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchScoreProvenance {
+    pub result_id: String,
+    pub native_kind: NativeScoreKind,
+    pub native_value: f32,
+    pub native_source: NativeScoreSource,
+    pub normalization: ScoreNormalization,
+    pub normalized_score: f32,
+    pub adjustment: ScoreAdjustment,
+}
+
+#[cfg(not(feature = "embeddings"))]
+impl SearchScoreProvenance {
+    pub fn product_score(&self) -> f32 {
+        self.normalized_score * self.adjustment.factor()
+    }
+}
+
 #[cfg(not(feature = "embeddings"))]
 pub enum SearchOutcome {
     /// Index is ready; here are the results (may be empty).
     Results(Vec<SearchResult>),
     /// Embedding support is not compiled in or the table is not ready.
     NotReady,
+}
+
+/// Search result plus truthful execution metadata for calibrated product fusion.
+#[cfg(not(feature = "embeddings"))]
+pub struct ObservedSearchOutcome {
+    pub outcome: SearchOutcome,
+    pub executed_mode: Option<ExecutedSearchMode>,
+    /// Same order as `SearchOutcome::Results`; empty for `NotReady`.
+    pub score_provenance: Vec<SearchScoreProvenance>,
 }
 
 #[cfg(not(feature = "embeddings"))]
@@ -259,6 +348,22 @@ impl EmbeddingIndex {
         _filters: &SearchFilters,
     ) -> Result<SearchOutcome> {
         Ok(SearchOutcome::NotReady)
+    }
+
+    pub async fn search_with_filters_observed(
+        &self,
+        _query: &str,
+        _artifact_types: Option<&[String]>,
+        _limit: usize,
+        _mode: SearchMode,
+        _filters: &SearchFilters,
+        _test_policy: TestResultPolicy,
+    ) -> Result<ObservedSearchOutcome> {
+        Ok(ObservedSearchOutcome {
+            outcome: SearchOutcome::NotReady,
+            executed_mode: None,
+            score_provenance: Vec::new(),
+        })
     }
 
     pub async fn search_with_filters_strict(

--- a/src/embed/real.rs
+++ b/src/embed/real.rs
@@ -97,56 +97,167 @@ pub enum SearchMode {
     Semantic,
 }
 
-/// Score representation returned by LanceDB for the query that actually ran.
-///
-/// Hybrid search and its non-strict vector fallback have different schemas, so
-/// this is deliberately tracked alongside the batches instead of inferred from
-/// whichever score-like column happens to be present.
+/// Retrieval channel that actually executed after any allowed fallback.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RetrievalScoreKind {
+pub enum ExecutedSearchMode {
     Keyword,
     Semantic,
     HybridRrf,
 }
 
-impl RetrievalScoreKind {
+/// Explicit product policy for test-path results.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestResultPolicy {
+    Demote,
+    Neutral,
+}
+
+/// Native score representation returned by LanceDB for the query that actually ran.
+///
+/// Hybrid search and its non-strict vector fallback have different schemas, so
+/// this is deliberately tracked alongside the batches instead of inferred from
+/// whichever score-like column happens to be present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeScoreKind {
+    Bm25,
+    CosineDistance,
+    HybridRrfRelevance,
+}
+
+impl From<NativeScoreKind> for ExecutedSearchMode {
+    fn from(value: NativeScoreKind) -> Self {
+        match value {
+            NativeScoreKind::Bm25 => Self::Keyword,
+            NativeScoreKind::CosineDistance => Self::Semantic,
+            NativeScoreKind::HybridRrfRelevance => Self::HybridRrf,
+        }
+    }
+}
+
+/// Whether a score was supplied by LanceDB or substituted by non-strict policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeScoreSource {
+    Backend,
+    DeterministicFallback,
+}
+
+/// Deterministic normalization applied to a backend-native score.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScoreNormalization {
+    /// `max(value, 0) / (1 + max(value, 0))`.
+    NonNegativeSaturation,
+    /// `max(1 - distance, 0)`.
+    OneMinusDistanceFloorZero,
+}
+
+/// Product adjustment applied after score normalization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScoreAdjustment {
+    None,
+    TestPathDemotion70Percent,
+}
+
+impl ScoreAdjustment {
+    pub const fn factor(self) -> f32 {
+        match self {
+            Self::None => 1.0,
+            Self::TestPathDemotion70Percent => 0.7,
+        }
+    }
+}
+
+/// Audit record for the transforms leading to one product ranking score.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchScoreProvenance {
+    pub result_id: String,
+    pub native_kind: NativeScoreKind,
+    pub native_value: f32,
+    pub native_source: NativeScoreSource,
+    pub normalization: ScoreNormalization,
+    pub normalized_score: f32,
+    pub adjustment: ScoreAdjustment,
+}
+
+impl SearchScoreProvenance {
+    pub fn product_score(&self) -> f32 {
+        self.normalized_score * self.adjustment.factor()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct RetrievedScore {
+    native_value: f32,
+    native_source: NativeScoreSource,
+    normalized_score: f32,
+}
+
+/// Resolve the score/backend contract from the operation that actually ran.
+/// `hybrid_vector_fallback` is meaningful only for non-strict hybrid product
+/// search; strict callers reject that fallback before reaching this seam.
+fn product_retrieval_score_kind(
+    requested: SearchMode,
+    hybrid_vector_fallback: bool,
+) -> NativeScoreKind {
+    match (requested, hybrid_vector_fallback) {
+        (SearchMode::Hybrid, true) => NativeScoreKind::CosineDistance,
+        (SearchMode::Hybrid, false) => NativeScoreKind::HybridRrfRelevance,
+        (SearchMode::Keyword, _) => NativeScoreKind::Bm25,
+        (SearchMode::Semantic, _) => NativeScoreKind::CosineDistance,
+    }
+}
+
+fn score_adjustment(stable_id: &str, policy: TestResultPolicy) -> ScoreAdjustment {
+    match (ranking::is_test_path(stable_id), policy) {
+        (true, TestResultPolicy::Demote) => ScoreAdjustment::TestPathDemotion70Percent,
+        _ => ScoreAdjustment::None,
+    }
+}
+
+impl NativeScoreKind {
     fn column(self) -> &'static str {
         match self {
-            Self::Keyword => "_score",
-            Self::Semantic => "_distance",
-            Self::HybridRrf => "_relevance_score",
+            Self::Bm25 => "_score",
+            Self::CosineDistance => "_distance",
+            Self::HybridRrfRelevance => "_relevance_score",
         }
     }
 
     fn label(self) -> &'static str {
         match self {
-            Self::Keyword => "keyword",
-            Self::Semantic => "semantic",
-            Self::HybridRrf => "hybrid RRF",
+            Self::Bm25 => "BM25",
+            Self::CosineDistance => "cosine distance",
+            Self::HybridRrfRelevance => "hybrid RRF relevance",
         }
     }
 
     fn default_raw_score(self) -> f32 {
         match self {
-            Self::Keyword | Self::HybridRrf => 0.5,
-            Self::Semantic => 2.0,
+            Self::Bm25 | Self::HybridRrfRelevance => 0.5,
+            Self::CosineDistance => 2.0,
+        }
+    }
+
+    const fn normalization(self) -> ScoreNormalization {
+        match self {
+            Self::Bm25 | Self::HybridRrfRelevance => ScoreNormalization::NonNegativeSaturation,
+            Self::CosineDistance => ScoreNormalization::OneMinusDistanceFloorZero,
         }
     }
 
     fn normalize(self, raw: f32) -> f32 {
         match self {
-            Self::Keyword | Self::HybridRrf => {
+            Self::Bm25 | Self::HybridRrfRelevance => {
                 let score = raw.max(0.0);
                 score / (1.0 + score)
             }
-            Self::Semantic => (1.0 - raw).max(0.0),
+            Self::CosineDistance => (1.0 - raw).max(0.0),
         }
     }
 }
 
 fn validated_retrieval_score_column(
     batch: &RecordBatch,
-    kind: RetrievalScoreKind,
+    kind: NativeScoreKind,
     strict: bool,
 ) -> Result<Option<&Float32Array>> {
     let column_name = kind.column();
@@ -175,11 +286,16 @@ fn validated_retrieval_score_column(
 fn retrieval_score(
     scores: Option<&Float32Array>,
     row: usize,
-    kind: RetrievalScoreKind,
+    kind: NativeScoreKind,
     strict: bool,
-) -> Result<f32> {
+) -> Result<RetrievedScore> {
     let Some(scores) = scores else {
-        return Ok(kind.normalize(kind.default_raw_score()));
+        let native_value = kind.default_raw_score();
+        return Ok(RetrievedScore {
+            native_value,
+            native_source: NativeScoreSource::DeterministicFallback,
+            normalized_score: kind.normalize(native_value),
+        });
     };
     let column_name = kind.column();
     if scores.is_null(row) {
@@ -191,7 +307,12 @@ fn retrieval_score(
                 row
             );
         }
-        return Ok(kind.normalize(kind.default_raw_score()));
+        let native_value = kind.default_raw_score();
+        return Ok(RetrievedScore {
+            native_value,
+            native_source: NativeScoreSource::DeterministicFallback,
+            normalized_score: kind.normalize(native_value),
+        });
     }
 
     let raw = scores.value(row);
@@ -204,9 +325,18 @@ fn retrieval_score(
                 row
             );
         }
-        return Ok(kind.normalize(kind.default_raw_score()));
+        let native_value = kind.default_raw_score();
+        return Ok(RetrievedScore {
+            native_value,
+            native_source: NativeScoreSource::DeterministicFallback,
+            normalized_score: kind.normalize(native_value),
+        });
     }
-    Ok(kind.normalize(raw))
+    Ok(RetrievedScore {
+        native_value: raw,
+        native_source: NativeScoreSource::Backend,
+        normalized_score: kind.normalize(raw),
+    })
 }
 
 fn rank_search_results(results: &mut [SearchResult]) {
@@ -686,7 +816,11 @@ fn stable_code_embedding_metadata(
     // provenance, path, and job metadata are rebuilt as target row scalars.
     ["doc_comment", "inferred_types"]
         .into_iter()
-        .filter_map(|key| metadata.get(key).map(|value| (key.to_string(), value.clone())))
+        .filter_map(|key| {
+            metadata
+                .get(key)
+                .map(|value| (key.to_string(), value.clone()))
+        })
         .collect()
 }
 
@@ -1111,6 +1245,14 @@ pub enum SearchOutcome {
     NotReady,
 }
 
+/// Search result plus truthful execution metadata for calibrated product fusion.
+pub struct ObservedSearchOutcome {
+    pub outcome: SearchOutcome,
+    pub executed_mode: Option<ExecutedSearchMode>,
+    /// Same order as `SearchOutcome::Results`; empty for `NotReady`.
+    pub score_provenance: Vec<SearchScoreProvenance>,
+}
+
 fn single_query_embedding(mut embeddings: Vec<Vec<f32>>) -> Result<Vec<f32>> {
     if embeddings.len() != 1 {
         anyhow::bail!(
@@ -1237,9 +1379,7 @@ fn retain_reusable_vector(
     vector_sha256: String,
     vector: &[f32],
 ) -> Result<()> {
-    if let Some((existing_sha256, existing_vector)) =
-        vectors_by_input.get(canonical_input_digest)
-    {
+    if let Some((existing_sha256, existing_vector)) = vectors_by_input.get(canonical_input_digest) {
         if existing_sha256 != &vector_sha256 || existing_vector.as_slice() != vector {
             anyhow::bail!(
                 "prior semantic generation maps one canonical encoder input to conflicting vector payloads"
@@ -3307,8 +3447,45 @@ impl EmbeddingIndex {
                 .search_with_filters_strict(query, artifact_types, limit, mode, filters)
                 .await;
         }
-        self.search_with_filters_policy(query, artifact_types, limit, mode, filters, false)
-            .await
+        self.search_with_filters_policy(
+            query,
+            artifact_types,
+            limit,
+            mode,
+            filters,
+            false,
+            TestResultPolicy::Demote,
+        )
+        .await
+    }
+
+    /// Product-search variant that exposes the channel that actually executed.
+    /// This keeps hybrid-to-vector fallback truthful at the fusion boundary and
+    /// makes test-path handling an explicit caller policy.
+    pub async fn search_with_filters_observed(
+        &self,
+        query: &str,
+        artifact_types: Option<&[String]>,
+        limit: usize,
+        mode: SearchMode,
+        filters: &SearchFilters,
+        test_policy: TestResultPolicy,
+    ) -> Result<ObservedSearchOutcome> {
+        if requires_sealed_query_validation(self.require_metal, mode) {
+            return self
+                .search_with_filters_strict_observed(query, artifact_types, limit, mode, filters)
+                .await;
+        }
+        self.search_with_filters_policy_observed(
+            query,
+            artifact_types,
+            limit,
+            mode,
+            filters,
+            false,
+            test_policy,
+        )
+        .await
     }
 
     /// Strict semantic search used by the sealed #786 artifact.
@@ -3322,18 +3499,43 @@ impl EmbeddingIndex {
         mode: SearchMode,
         filters: &SearchFilters,
     ) -> Result<SearchOutcome> {
+        Ok(self
+            .search_with_filters_strict_observed(query, artifact_types, limit, mode, filters)
+            .await?
+            .outcome)
+    }
+
+    async fn search_with_filters_strict_observed(
+        &self,
+        query: &str,
+        artifact_types: Option<&[String]>,
+        limit: usize,
+        mode: SearchMode,
+        filters: &SearchFilters,
+    ) -> Result<ObservedSearchOutcome> {
         if generation::semantic_asset_seeding() {
             anyhow::bail!("strict semantic search is forbidden during asset seeding");
         }
         self.validate_active_generation_graph().await?;
         require_metal_device()?;
         generation::verify_runtime_encoder_assets()?;
-        let outcome = self
-            .search_with_filters_policy(query, artifact_types, limit, mode, filters, true)
+        let mut observed = self
+            .search_with_filters_policy_observed(
+                query,
+                artifact_types,
+                limit,
+                mode,
+                filters,
+                true,
+                TestResultPolicy::Demote,
+            )
             .await?;
+        // Preserve the pre-existing strict observed contract, which reports the
+        // requested backend even when the strict table is not ready.
+        observed.executed_mode = Some(product_retrieval_score_kind(mode, false).into());
         generation::verify_runtime_encoder_assets()?;
         self.validate_active_generation_graph().await?;
-        Ok(outcome)
+        Ok(observed)
     }
 
     async fn search_with_filters_policy(
@@ -3344,7 +3546,32 @@ impl EmbeddingIndex {
         mode: SearchMode,
         filters: &SearchFilters,
         strict: bool,
+        test_policy: TestResultPolicy,
     ) -> Result<SearchOutcome> {
+        Ok(self
+            .search_with_filters_policy_observed(
+                query,
+                artifact_types,
+                limit,
+                mode,
+                filters,
+                strict,
+                test_policy,
+            )
+            .await?
+            .outcome)
+    }
+
+    async fn search_with_filters_policy_observed(
+        &self,
+        query: &str,
+        artifact_types: Option<&[String]>,
+        limit: usize,
+        mode: SearchMode,
+        filters: &SearchFilters,
+        strict: bool,
+        test_policy: TestResultPolicy,
+    ) -> Result<ObservedSearchOutcome> {
         if strict && generation::semantic_asset_seeding() {
             anyhow::bail!("strict semantic search is forbidden during asset seeding");
         }
@@ -3356,7 +3583,11 @@ impl EmbeddingIndex {
                     || msg.contains("does not exist")
                     || msg.contains("not found")
                 {
-                    return Ok(SearchOutcome::NotReady);
+                    return Ok(ObservedSearchOutcome {
+                        outcome: SearchOutcome::NotReady,
+                        executed_mode: None,
+                        score_provenance: Vec::new(),
+                    });
                 }
                 return Err(e).context("Failed to open embedding table");
             }
@@ -3385,7 +3616,7 @@ impl EmbeddingIndex {
 
         use futures::TryStreamExt;
 
-        let (batches, score_kind): (Vec<RecordBatch>, RetrievalScoreKind) = match mode {
+        let (batches, score_kind): (Vec<RecordBatch>, NativeScoreKind) = match mode {
             SearchMode::Keyword => {
                 // Pure BM25 full-text search — no embedding needed.
                 let fts_query = FullTextSearchQuery::new(query.to_string());
@@ -3394,7 +3625,10 @@ impl EmbeddingIndex {
                     q = q.only_if(sql.clone());
                 }
                 let results = q.execute().await.context("FTS keyword search failed")?;
-                (results.try_collect().await?, RetrievalScoreKind::Keyword)
+                (
+                    results.try_collect().await?,
+                    product_retrieval_score_kind(mode, false),
+                )
             }
             SearchMode::Semantic => {
                 // Pure vector search — original behavior.
@@ -3415,7 +3649,10 @@ impl EmbeddingIndex {
                     search = search.only_if(sql.clone());
                 }
                 let results = search.execute().await.context("Vector search failed")?;
-                (results.try_collect().await?, RetrievalScoreKind::Semantic)
+                (
+                    results.try_collect().await?,
+                    product_retrieval_score_kind(mode, false),
+                )
             }
             SearchMode::Hybrid => {
                 // Hybrid: BM25 + vector with RRF fusion.
@@ -3443,7 +3680,10 @@ impl EmbeddingIndex {
                     .await;
 
                 match hybrid_result {
-                    Ok(stream) => (stream.try_collect().await?, RetrievalScoreKind::HybridRrf),
+                    Ok(stream) => (
+                        stream.try_collect().await?,
+                        product_retrieval_score_kind(mode, false),
+                    ),
                     Err(error) if strict => {
                         return Err(error).context(
                             "strict hybrid semantic search failed; vector-only fallback is forbidden",
@@ -3465,20 +3705,23 @@ impl EmbeddingIndex {
                             .execute()
                             .await
                             .context("Fallback vector search failed")?;
-                        (results.try_collect().await?, RetrievalScoreKind::Semantic)
+                        (
+                            results.try_collect().await?,
+                            product_retrieval_score_kind(mode, true),
+                        )
                     }
                 }
             }
         };
 
         let mut search_results = Vec::new();
+        let mut score_provenance_by_id = BTreeMap::new();
 
         for batch in &batches {
             // Validate the mode-specific score schema once per batch before
             // row filtering. Strict retrieval must reject malformed empty or
             // fully filtered batches instead of silently accepting them.
-            let score_column =
-                validated_retrieval_score_column(batch, score_kind, strict)?;
+            let score_column = validated_retrieval_score_column(batch, score_kind, strict)?;
 
             // LanceDB hybrid search with a pre-filter (.only_if()) can return
             // RecordBatches that are missing table columns — only FTS-indexed
@@ -3526,13 +3769,24 @@ impl EmbeddingIndex {
                 // family: BM25 `_score`, vector `_distance`, and hybrid RRF
                 // `_relevance_score`. The non-strict hybrid fallback is a real
                 // vector query and therefore intentionally uses `_distance`.
-                let raw_score = retrieval_score(score_column, i, score_kind, strict)?;
+                let retrieved = retrieval_score(score_column, i, score_kind, strict)?;
 
                 // Demote test files: reduce score so production code ranks above
                 // test code at similar distances.
                 let id_str = ids.value(i).to_string();
-                let is_test = ranking::is_test_path(&id_str);
-                let score = if is_test { raw_score * 0.7 } else { raw_score };
+                let adjustment = score_adjustment(&id_str, test_policy);
+                let provenance = SearchScoreProvenance {
+                    result_id: id_str.clone(),
+                    native_kind: score_kind,
+                    native_value: retrieved.native_value,
+                    native_source: retrieved.native_source,
+                    normalization: score_kind.normalization(),
+                    normalized_score: retrieved.normalized_score,
+                    adjustment,
+                };
+                let score = provenance.product_score();
+
+                score_provenance_by_id.insert(id_str.clone(), provenance);
 
                 search_results.push(SearchResult {
                     id: id_str,
@@ -3547,8 +3801,21 @@ impl EmbeddingIndex {
         // Re-sort by adjusted score (descending) and truncate.
         rank_search_results(&mut search_results);
         search_results.truncate(limit);
+        let score_provenance = search_results
+            .iter()
+            .map(|result| {
+                score_provenance_by_id
+                    .get(&result.id)
+                    .expect("every returned result has score provenance")
+                    .clone()
+            })
+            .collect();
 
-        Ok(SearchOutcome::Results(search_results))
+        Ok(ObservedSearchOutcome {
+            outcome: SearchOutcome::Results(search_results),
+            executed_mode: Some(score_kind.into()),
+            score_provenance,
+        })
     }
 }
 
@@ -3558,16 +3825,17 @@ mod tests {
 
     use super::{
         BACKOFF_THRESHOLD, BATCH_CEILING, BATCH_FLOOR, BATCH_YIELD_MS, CODE_EMBED_CHAR_BUDGET,
-        EMBEDDING_DIMENSION, EmbeddingCandidate, EmbeddingIndex, GenerationOpenPurpose,
-        MaterializedEmbeddingRow, RetrievalScoreKind, SearchFilters, SearchMode, SearchResult,
-        UnpublishedScratchRoot, build_artifact_embedding_text, build_code_embedding_text,
-        fan_out_encoded_vector, group_canonical_encoder_inputs, node_embedding_kind,
-        node_embedding_text, node_embedding_title, node_scalar_filters,
-        publish_generation_after_final_validation, rank_search_results, required_string_column,
-        requires_active_generation_graph_validation, requires_sealed_query_validation,
-        retain_reusable_vector, retrieval_score, single_query_embedding, truncate_chars,
-        validate_canonical_vector_mapping, validated_retrieval_score_column,
-        verify_materialized_rows,
+        EMBEDDING_DIMENSION, EmbeddingCandidate, EmbeddingIndex, ExecutedSearchMode,
+        GenerationOpenPurpose, MaterializedEmbeddingRow, NativeScoreKind, NativeScoreSource,
+        ScoreAdjustment, ScoreNormalization, SearchFilters, SearchMode, SearchResult,
+        TestResultPolicy, UnpublishedScratchRoot, build_artifact_embedding_text,
+        build_code_embedding_text, fan_out_encoded_vector, group_canonical_encoder_inputs,
+        node_embedding_kind, node_embedding_text, node_embedding_title, node_scalar_filters,
+        product_retrieval_score_kind, publish_generation_after_final_validation,
+        rank_search_results, required_string_column, requires_active_generation_graph_validation,
+        requires_sealed_query_validation, retain_reusable_vector, retrieval_score,
+        single_query_embedding, truncate_chars, validate_canonical_vector_mapping,
+        validated_retrieval_score_column, verify_materialized_rows,
     };
 
     #[test]
@@ -3577,6 +3845,50 @@ mod tests {
             false,
             SearchMode::Semantic
         ));
+    }
+
+    #[test]
+    fn product_search_reports_actual_executed_backend_after_hybrid_fallback() {
+        let cases = [
+            (SearchMode::Keyword, false, ExecutedSearchMode::Keyword),
+            (SearchMode::Semantic, false, ExecutedSearchMode::Semantic),
+            (SearchMode::Hybrid, false, ExecutedSearchMode::HybridRrf),
+            (SearchMode::Hybrid, true, ExecutedSearchMode::Semantic),
+        ];
+
+        for (requested, hybrid_vector_fallback, expected) in cases {
+            let actual: ExecutedSearchMode =
+                product_retrieval_score_kind(requested, hybrid_vector_fallback).into();
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn product_search_test_intent_controls_test_path_demotion() {
+        let production = "src/service/search.rs:search:function";
+        let test = "tests/search_projection.rs:task_context_test:function";
+        let raw_score = 0.8;
+
+        let production_adjustment = super::score_adjustment(production, TestResultPolicy::Demote);
+        let test_adjustment = super::score_adjustment(test, TestResultPolicy::Demote);
+        let neutral_adjustment = super::score_adjustment(test, TestResultPolicy::Neutral);
+
+        assert_eq!(production_adjustment, ScoreAdjustment::None);
+        assert_eq!(test_adjustment, ScoreAdjustment::TestPathDemotion70Percent);
+        assert_eq!(neutral_adjustment, ScoreAdjustment::None);
+        assert_eq!(raw_score * production_adjustment.factor(), raw_score);
+        assert_eq!(raw_score * test_adjustment.factor(), raw_score * 0.7);
+
+        let provenance = super::SearchScoreProvenance {
+            result_id: test.to_string(),
+            native_kind: NativeScoreKind::CosineDistance,
+            native_value: 0.2,
+            native_source: NativeScoreSource::Backend,
+            normalization: ScoreNormalization::OneMinusDistanceFloorZero,
+            normalized_score: raw_score,
+            adjustment: test_adjustment,
+        };
+        assert_eq!(provenance.product_score(), raw_score * 0.7);
     }
 
     #[test]
@@ -3654,9 +3966,9 @@ mod tests {
     fn score_at(
         batch: &RecordBatch,
         row: usize,
-        kind: RetrievalScoreKind,
+        kind: NativeScoreKind,
         strict: bool,
-    ) -> anyhow::Result<f32> {
+    ) -> anyhow::Result<super::RetrievedScore> {
         let scores = validated_retrieval_score_column(batch, kind, strict)?;
         retrieval_score(scores, row, kind, strict)
     }
@@ -3679,17 +3991,22 @@ mod tests {
         ])
         .unwrap();
 
+        let keyword_score = score_at(&keyword, 0, NativeScoreKind::Bm25, true).unwrap();
+        assert_eq!(keyword_score.native_value, 3.0);
+        assert_eq!(keyword_score.normalized_score, 0.75);
+        assert_eq!(keyword_score.native_source, NativeScoreSource::Backend);
         assert_eq!(
-            score_at(&keyword, 0, RetrievalScoreKind::Keyword, true).unwrap(),
-            0.75
+            NativeScoreKind::Bm25.normalization(),
+            ScoreNormalization::NonNegativeSaturation
         );
-        assert_eq!(
-            score_at(&semantic, 0, RetrievalScoreKind::Semantic, true).unwrap(),
-            0.75
-        );
-        let hybrid_score =
-            score_at(&hybrid, 0, RetrievalScoreKind::HybridRrf, true).unwrap();
-        assert!((hybrid_score - (0.03 / 1.03)).abs() < f32::EPSILON);
+        let semantic_score = score_at(&semantic, 0, NativeScoreKind::CosineDistance, true).unwrap();
+        assert_eq!(semantic_score.native_value, 0.25);
+        assert_eq!(semantic_score.normalized_score, 0.75);
+        assert_eq!(semantic_score.native_source, NativeScoreSource::Backend);
+        let hybrid_score = score_at(&hybrid, 0, NativeScoreKind::HybridRrfRelevance, true).unwrap();
+        assert!((hybrid_score.native_value - 0.03).abs() < f32::EPSILON);
+        assert!((hybrid_score.normalized_score - (0.03 / 1.03)).abs() < f32::EPSILON);
+        assert_eq!(hybrid_score.native_source, NativeScoreSource::Backend);
     }
 
     #[test]
@@ -3697,20 +4014,20 @@ mod tests {
         use std::sync::Arc;
 
         let legacy_name = score_batch("_score", Arc::new(Float32Array::from(vec![0.03])));
-        let missing = score_at(&legacy_name, 0, RetrievalScoreKind::HybridRrf, true)
+        let missing = score_at(&legacy_name, 0, NativeScoreKind::HybridRrfRelevance, true)
             .unwrap_err()
             .to_string();
         assert!(missing.contains("`_relevance_score`"));
         assert!(missing.contains("missing"));
 
         let wrong_type = score_batch("_relevance_score", Arc::new(Int32Array::from(vec![1])));
-        let wrong_type = score_at(&wrong_type, 0, RetrievalScoreKind::HybridRrf, true)
+        let wrong_type = score_at(&wrong_type, 0, NativeScoreKind::HybridRrfRelevance, true)
             .unwrap_err()
             .to_string();
         assert!(wrong_type.contains("must be Float32"));
 
         let null_score = score_batch("_relevance_score", Arc::new(Float32Array::from(vec![None])));
-        let null_score = score_at(&null_score, 0, RetrievalScoreKind::HybridRrf, true)
+        let null_score = score_at(&null_score, 0, NativeScoreKind::HybridRrfRelevance, true)
             .unwrap_err()
             .to_string();
         assert!(null_score.contains("is null"));
@@ -3719,7 +4036,7 @@ mod tests {
             "_relevance_score",
             Arc::new(Float32Array::from(vec![f32::NAN])),
         );
-        let non_finite = score_at(&non_finite, 0, RetrievalScoreKind::HybridRrf, true)
+        let non_finite = score_at(&non_finite, 0, NativeScoreKind::HybridRrfRelevance, true)
             .unwrap_err()
             .to_string();
         assert!(non_finite.contains("non-finite"));
@@ -3735,13 +4052,10 @@ mod tests {
             Arc::new(StringArray::from(Vec::<String>::new())) as ArrayRef,
         )])
         .unwrap();
-        let missing = validated_retrieval_score_column(
-            &missing,
-            RetrievalScoreKind::HybridRrf,
-            true,
-        )
-        .unwrap_err()
-        .to_string();
+        let missing =
+            validated_retrieval_score_column(&missing, NativeScoreKind::HybridRrfRelevance, true)
+                .unwrap_err()
+                .to_string();
         assert!(missing.contains("`_relevance_score`"));
         assert!(missing.contains("missing"));
 
@@ -3751,7 +4065,7 @@ mod tests {
         );
         let wrong_type = validated_retrieval_score_column(
             &wrong_type,
-            RetrievalScoreKind::HybridRrf,
+            NativeScoreKind::HybridRrfRelevance,
             true,
         )
         .unwrap_err()
@@ -3764,10 +4078,26 @@ mod tests {
         use std::sync::Arc;
 
         let fallback = score_batch("_distance", Arc::new(Float32Array::from(vec![0.125])));
+        let score = score_at(&fallback, 0, NativeScoreKind::CosineDistance, false).unwrap();
+        assert_eq!(score.native_value, 0.125);
+        assert_eq!(score.native_source, NativeScoreSource::Backend);
+        assert_eq!(score.normalized_score, 0.875);
         assert_eq!(
-            score_at(&fallback, 0, RetrievalScoreKind::Semantic, false).unwrap(),
-            0.875
+            NativeScoreKind::CosineDistance.normalization(),
+            ScoreNormalization::OneMinusDistanceFloorZero
         );
+    }
+
+    #[test]
+    fn missing_non_strict_score_is_explicitly_a_deterministic_fallback() {
+        let score = retrieval_score(None, 0, NativeScoreKind::CosineDistance, false).unwrap();
+
+        assert_eq!(score.native_value, 2.0);
+        assert_eq!(
+            score.native_source,
+            NativeScoreSource::DeterministicFallback
+        );
+        assert_eq!(score.normalized_score, 0.0);
     }
 
     #[test]
@@ -3845,14 +4175,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            first.canonical_input_digest,
-            renamed.canonical_input_digest
-        );
-        assert_ne!(
-            first.canonical_input_digest,
-            changed.canonical_input_digest
-        );
+        assert_eq!(first.canonical_input_digest, renamed.canonical_input_digest);
+        assert_ne!(first.canonical_input_digest, changed.canonical_input_digest);
     }
 
     #[test]
@@ -3862,7 +4186,10 @@ mod tests {
             ("inferred_types".to_string(), "Result[str]".to_string()),
             ("importance".to_string(), "0.01".to_string()),
             ("subsystem".to_string(), "first".to_string()),
-            ("lsp_document_symbol_payload_digest".to_string(), "one".to_string()),
+            (
+                "lsp_document_symbol_payload_digest".to_string(),
+                "one".to_string(),
+            ),
         ]);
         let first = make_test_node(
             "value",
@@ -3905,14 +4232,9 @@ mod tests {
         let mut reusable = BTreeMap::new();
         retain_reusable_vector(&mut reusable, "input", "a".repeat(64), &[0.25]).unwrap();
         retain_reusable_vector(&mut reusable, "input", "a".repeat(64), &[0.25]).unwrap();
-        let error = retain_reusable_vector(
-            &mut reusable,
-            "input",
-            "b".repeat(64),
-            &[0.5],
-        )
-        .unwrap_err()
-        .to_string();
+        let error = retain_reusable_vector(&mut reusable, "input", "b".repeat(64), &[0.5])
+            .unwrap_err()
+            .to_string();
         assert!(error.contains("conflicting vector payloads"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,6 +271,39 @@ struct SearchArgs {
     /// Show index stats (default: true for CLI, false for MCP)
     #[arg(long, default_value_t = true)]
     verbose: bool,
+    /// Output projection: agent (default) or evidence.
+    #[arg(long)]
+    projection: Option<String>,
+    /// Body policy: complete, focused_span, signature_only, minified, or none.
+    #[arg(long)]
+    body_policy: Option<String>,
+    /// Maximum final rendered UTF-8 bytes.
+    #[arg(long)]
+    max_output_bytes: Option<usize>,
+    /// Maximum estimated rendered tokens (not provider usage).
+    #[arg(long)]
+    max_output_tokens: Option<usize>,
+    /// Maximum source-body UTF-8 bytes per selected record.
+    #[arg(long)]
+    max_body_bytes: Option<usize>,
+    /// Maximum source-body UTF-8 bytes across all records after coalescing.
+    #[arg(long)]
+    max_total_body_bytes: Option<usize>,
+    /// Opt-in context mode: task or graph-delta-beta.
+    #[arg(long)]
+    context_mode: Option<String>,
+    /// Comma-separated task roles: editable_source, definition_or_api_state,
+    /// test, behavioral_analogue, direct_dependency, caller_or_impact,
+    /// proposal_delta.
+    #[arg(long)]
+    context_roles: Option<String>,
+    /// Comma-separated task facets: behavior, api_or_state, test, analogue,
+    /// proposal.
+    #[arg(long)]
+    context_facets: Option<String>,
+    /// Unified diff or structured edit sketch for graph-delta beta.
+    #[arg(long)]
+    proposal: Option<String>,
 }
 #[derive(clap::Args, Debug)]
 struct GraphArgs {
@@ -1480,6 +1513,26 @@ async fn async_main() -> anyhow::Result<()> {
                 include_body: args.include_body,
                 minify_body: args.minify_body,
                 verbose: args.verbose,
+                projection: args.projection.clone(),
+                body_policy: args.body_policy.clone(),
+                max_output_bytes: args.max_output_bytes,
+                max_output_tokens: args.max_output_tokens,
+                max_body_bytes: args.max_body_bytes,
+                max_total_body_bytes: args.max_total_body_bytes,
+                context_mode: args.context_mode.clone(),
+                context_roles: args.context_roles.as_ref().map(|values| {
+                    values
+                        .split(',')
+                        .map(|value| value.trim().to_string())
+                        .collect()
+                }),
+                context_facets: args.context_facets.as_ref().map(|values| {
+                    values
+                        .split(',')
+                        .map(|value| value.trim().to_string())
+                        .collect()
+                }),
+                proposal: args.proposal.clone(),
             };
             let root_filter = resolve_root_filter(args.root.as_deref(), &repo_root);
             // Include lsp_only subdirectory root slugs in non_code_slugs so they're not

--- a/src/main.rs
+++ b/src/main.rs
@@ -1752,6 +1752,13 @@ async fn async_main() -> anyhow::Result<()> {
     match cli.transport.as_str() {
         "stdio" => {
             init_tracing("warn", log_path.as_deref());
+            if let Some(embed_idx) = load_existing_embedding_index(&repo_root, |msg| {
+                tracing::warn!("{}; MCP semantic search will be unavailable", msg);
+            })
+            .await
+            {
+                handler.embed_index.store(Arc::new(Some(embed_idx)));
+            }
             let transport = rust_mcp_sdk::StdioTransport::new(Default::default())
                 .map_err(|e| anyhow::anyhow!("{:?}", e))?;
             let server = rust_mcp_sdk::mcp_server::server_runtime::create_server(
@@ -1770,6 +1777,13 @@ async fn async_main() -> anyhow::Result<()> {
         }
         "http" => {
             init_tracing("info", log_path.as_deref());
+            if let Some(embed_idx) = load_existing_embedding_index(&repo_root, |msg| {
+                tracing::warn!("{}; MCP semantic search will be unavailable", msg);
+            })
+            .await
+            {
+                handler.embed_index.store(Arc::new(Some(embed_idx)));
+            }
             let server = rust_mcp_sdk::mcp_server::hyper_server::create_server(
                 server_details(),
                 handler.to_mcp_server_handler(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1750,8 +1750,13 @@ async fn async_main() -> anyhow::Result<()> {
         ..Default::default()
     };
     match cli.transport.as_str() {
-        "stdio" => {
-            init_tracing("warn", log_path.as_deref());
+        "stdio" => init_tracing("warn", log_path.as_deref()),
+        "http" => init_tracing("info", log_path.as_deref()),
+        other => anyhow::bail!("Unknown transport: {}. Use 'stdio' or 'http'.", other),
+    }
+    handler.prepare_business_context_cache()?;
+    match try_load_cached_graph(&repo_root).await {
+        Ok(Some(_)) => {
             if let Some(embed_idx) = load_existing_embedding_index(&repo_root, |msg| {
                 tracing::warn!("{}; MCP semantic search will be unavailable", msg);
             })
@@ -1759,6 +1764,14 @@ async fn async_main() -> anyhow::Result<()> {
             {
                 handler.embed_index.store(Arc::new(Some(embed_idx)));
             }
+        }
+        Ok(None) => {}
+        Err(err) => tracing::warn!(
+            "MCP startup could not preload the cached graph: {err:#}; background prewarm will recover it"
+        ),
+    }
+    match cli.transport.as_str() {
+        "stdio" => {
             let transport = rust_mcp_sdk::StdioTransport::new(Default::default())
                 .map_err(|e| anyhow::anyhow!("{:?}", e))?;
             let server = rust_mcp_sdk::mcp_server::server_runtime::create_server(
@@ -1776,14 +1789,6 @@ async fn async_main() -> anyhow::Result<()> {
                 .map_err(|e| anyhow::anyhow!("{:?}", e))?;
         }
         "http" => {
-            init_tracing("info", log_path.as_deref());
-            if let Some(embed_idx) = load_existing_embedding_index(&repo_root, |msg| {
-                tracing::warn!("{}; MCP semantic search will be unavailable", msg);
-            })
-            .await
-            {
-                handler.embed_index.store(Arc::new(Some(embed_idx)));
-            }
             let server = rust_mcp_sdk::mcp_server::hyper_server::create_server(
                 server_details(),
                 handler.to_mcp_server_handler(),
@@ -1801,9 +1806,7 @@ async fn async_main() -> anyhow::Result<()> {
                 .await
                 .map_err(|e| anyhow::anyhow!("{:?}", e))?;
         }
-        other => {
-            anyhow::bail!("Unknown transport: {}. Use 'stdio' or 'http'.", other);
-        }
+        _ => unreachable!("transport was validated before MCP cache loading"),
     }
     Ok(())
 }

--- a/src/open_viewer.rs
+++ b/src/open_viewer.rs
@@ -232,6 +232,7 @@ async fn dispatch_tool(state: &ViewerState, call: &McpCall) -> Result<String, St
                 include_body: false,
                 minify_body: false,
                 verbose: false,
+                ..Default::default()
             };
             let ctx = SearchContext {
                 graph_state: &state.graph,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -962,6 +962,15 @@ mod tests {
         }
     }
 
+    fn call_tool_text(result: &CallToolResult) -> String {
+        serde_json::to_value(result)
+            .expect("CallToolResult serializes")
+            .pointer("/content/0/text")
+            .and_then(serde_json::Value::as_str)
+            .expect("search returns one MCP text content item")
+            .to_owned()
+    }
+
     // ── is_building indicator tests ─────────────────────────────────────
 
     /// Verify the note text and `is_building()` logic in isolation.
@@ -1177,9 +1186,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_search_generated_defaults_current_repo_use_live_graph() {
-        let repo_root = std::env::current_dir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        let repo_root = repo.path().to_path_buf();
         let handler = make_handler(&repo_root);
         let symbol = "rna_generated_default_live_graph_probe";
+        std::fs::write(
+            repo_root.join("src/generated_default_live.rs"),
+            format!("pub fn {symbol}() -> &'static str {{\n    \"live\"\n}}\n"),
+        )
+        .unwrap();
         let root_slug = handler.primary_root_slug();
 
         let node = Node {
@@ -1230,12 +1246,23 @@ mod tests {
         .unwrap();
 
         let result = handler.handle_search(args).await.unwrap();
-        let rendered = serde_json::to_string(&result).unwrap();
+        let rendered = call_tool_text(&result);
 
         assert!(
             rendered.contains(symbol),
             "generated-default current-repo search should return live graph symbol: {rendered}"
         );
+        assert!(rendered.starts_with("# RNA search context\n\n- projection: agent\n"));
+        assert!(rendered.contains("- body_policy: signature_only\n"));
+        assert!(rendered.contains("- selected_records: 1\n"));
+        assert!(rendered.contains(&format!(
+            "[{}] src/generated_default_live.rs:1-3",
+            handler.primary_root_slug()
+        )));
+        assert!(rendered.contains(&format!(
+            "- signature: ` pub fn {}() -> &'static str `",
+            symbol
+        )));
         assert!(
             !rendered.contains("Empty nodes list"),
             "empty generated nodes must not force batch mode: {rendered}"
@@ -1296,7 +1323,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let rendered = serde_json::to_string(&result).unwrap();
+        let rendered = call_tool_text(&result);
 
         let returned_symbols = symbols
             .iter()
@@ -1306,7 +1333,11 @@ mod tests {
             returned_symbols == 1,
             "fallback should return exactly one mapped symbol at limit=1: {rendered}"
         );
-        assert!(rendered.contains("failure=task_panic"), "got: {rendered}");
+        assert!(rendered.starts_with("# RNA search context\n\n- projection: agent\n"));
+        assert!(rendered.contains("- body_policy: signature_only\n"));
+        assert!(rendered.contains("- selected_records: 1\n"));
+        assert!(rendered.contains(&format!("[{}] src/lib.rs:", handler.primary_root_slug())));
+        assert!(rendered.contains("- channel:"), "got: {rendered}");
         assert!(!rendered.contains("customer.rs"), "got: {rendered}");
     }
 

--- a/src/server/tools.rs
+++ b/src/server/tools.rs
@@ -271,8 +271,7 @@ pub struct Search {
     /// Opt-in context mode: `task` or experimental `graph-delta-beta`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_mode: Option<String>,
-    /// Requested task roles: editable_source, definition_or_api_state, test,
-    /// behavioral_analogue, direct_dependency, caller_or_impact, proposal_delta.
+    /// Task roles: editable_source, definition_or_api_state, test, behavioral_analogue, direct_dependency, caller_or_impact, proposal_delta.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_roles: Option<Vec<String>>,
     /// Requested task facets: behavior, api_or_state, test, analogue, proposal.
@@ -822,6 +821,16 @@ mod tests {
             "Search markdown sections (default: true)",
             "Artifact filter: outcome, signal, guardrail, metis, commit",
             "Filter to a specific subsystem (from repo_map)",
+            "Output projection: `agent` (default) or `evidence`.",
+            "Body policy: `complete`, `focused_span`, `signature_only`, `minified`, or `none`.",
+            "Maximum final rendered UTF-8 bytes (bounded by the service hard limit).",
+            "Maximum estimated rendered tokens (an estimate, never provider usage).",
+            "Maximum source-body UTF-8 bytes per selected record.",
+            "Maximum source-body UTF-8 bytes across all selected records after coalescing.",
+            "Opt-in context mode: `task` or experimental `graph-delta-beta`.",
+            "Task roles: editable_source, definition_or_api_state, test, behavioral_analogue, direct_dependency, caller_or_impact, proposal_delta.",
+            "Requested task facets: behavior, api_or_state, test, analogue, proposal.",
+            "Bounded unified diff or structured edit sketch for graph-delta beta.",
             // RepoMap
             "Number of top symbols (default: 15)",
             // Shared

--- a/src/server/tools.rs
+++ b/src/server/tools.rs
@@ -113,9 +113,10 @@ pub struct OutcomeProgress {
 
 #[macros::mcp_tool(
     name = "search",
-    description = "USE THIS INSTEAD OF Grep/Read for code understanding. Searches code symbols, docs, business artifacts, and commits in one call. Add `mode` for graph traversal (neighbors/impact/reachable/tests_for/cycles/path) — equivalent to the `graph` CLI command. Use `compact: true` to save tokens. Use `rerank: true` for natural language queries. Use `subsystem` to scope to a subsystem from repo_map. Use `target_subsystem` with mode to find cross-subsystem edges. Use `depth` with mode='neighbors' to walk N levels deep (e.g., module → members → their members). Use `limit` to control max results (flat default: 10, traversal default: 1). Use `include_body: true` to return function bodies; add `minify_body: true` to strip comments and shorten locals."
+    description = "USE THIS INSTEAD OF Grep/Read for code understanding. Searches code symbols, docs, business artifacts, and commits in one call. Ordinary search defaults to the concise `agent` projection; request `projection: evidence` for channel ranks, normalized contributions, tie-breaks, omissions, and diagnostics. Bound the complete rendered response with `max_output_bytes` or `max_output_tokens`; bound source separately with `max_body_bytes` and `max_total_body_bytes`; choose an explicit `body_policy` (complete/focused_span/signature_only/minified/none). Set `context_mode: task` for bounded role-aware implementation context, or opt into the non-mutating `graph-delta-beta` mode with a proposal. Add `mode` for graph traversal (neighbors/impact/reachable/tests_for/cycles/path). Use `compact: true` to save tokens, `rerank: true` for natural-language queries, and subsystem/depth/limit filters to constrain selection."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct Search {
     /// Search query (name, keyword, or natural language)
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -233,6 +234,53 @@ pub struct Search {
     /// Show index stats footer (default: false for MCP, true for CLI)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verbose: Option<bool>,
+    /// Output projection: `agent` (default) or `evidence`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projection: Option<String>,
+    /// Body policy: `complete`, `focused_span`, `signature_only`, `minified`, or `none`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body_policy: Option<String>,
+    /// Maximum final rendered UTF-8 bytes (bounded by the service hard limit).
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_u32_tolerant",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_output_bytes: Option<u32>,
+    /// Maximum estimated rendered tokens (an estimate, never provider usage).
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_u32_tolerant",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_output_tokens: Option<u32>,
+    /// Maximum source-body UTF-8 bytes per selected record.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_u32_tolerant",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_body_bytes: Option<u32>,
+    /// Maximum source-body UTF-8 bytes across all selected records after coalescing.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_u32_tolerant",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_total_body_bytes: Option<u32>,
+    /// Opt-in context mode: `task` or experimental `graph-delta-beta`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_mode: Option<String>,
+    /// Requested task roles: editable_source, definition_or_api_state, test,
+    /// behavioral_analogue, direct_dependency, caller_or_impact, proposal_delta.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_roles: Option<Vec<String>>,
+    /// Requested task facets: behavior, api_or_state, test, analogue, proposal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_facets: Option<Vec<String>>,
+    /// Bounded unified diff or structured edit sketch for graph-delta beta.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proposal: Option<String>,
 }
 
 fn default_true() -> Option<bool> {
@@ -284,6 +332,22 @@ mod tests {
         assert_eq!(s.query, Some("handle_call_tool_request".to_string()));
         assert!(s.mode.is_none());
         assert!(s.node.is_none());
+    }
+
+    #[test]
+    fn search_rejects_unknown_context_knobs() {
+        let error = parse_search(json!({
+            "query": "render",
+            "context_mode": "task",
+            "unbounded_magic": true
+        }))
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("unknown field `unbounded_magic`")
+        );
     }
 
     #[test]
@@ -438,13 +502,17 @@ mod tests {
     }
 
     #[test]
-    fn test_search_extra_fields_ignored() {
-        let s = parse_search(json!({
+    fn test_search_extra_fields_are_rejected() {
+        let error = parse_search(json!({
             "query": "test",
             "unknown_field": "should be ignored",
             "another_unknown": 42
-        }));
-        assert!(s.is_ok());
+        }))
+        .expect_err("search input must reject fields outside the published schema");
+        assert!(
+            error.to_string().contains("unknown field"),
+            "unexpected serde error: {error}"
+        );
     }
 
     #[test]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -61,6 +61,26 @@ pub struct SearchParams {
     pub include_body: bool,
     pub minify_body: bool,
     pub verbose: bool,
+    /// Agent-facing output (default) or exhaustive evidence projection.
+    pub projection: Option<String>,
+    /// Source body policy for projected/task-context results.
+    pub body_policy: Option<String>,
+    /// Hard cap on the final rendered UTF-8 byte length.
+    pub max_output_bytes: Option<usize>,
+    /// Hard cap on the explicitly estimated rendered token count.
+    pub max_output_tokens: Option<usize>,
+    /// Hard cap on source bytes contributed by any one selected record.
+    pub max_body_bytes: Option<usize>,
+    /// Hard cap on source bytes across all selected records after coalescing.
+    pub max_total_body_bytes: Option<usize>,
+    /// Opt-in context mode: `task` or `graph-delta-beta`.
+    pub context_mode: Option<String>,
+    /// Requested task-context evidence roles.
+    pub context_roles: Option<Vec<String>>,
+    /// Requested task-context query facets.
+    pub context_facets: Option<Vec<String>>,
+    /// Bounded unified diff or structured edit sketch for graph-delta beta.
+    pub proposal: Option<String>,
 }
 
 impl Default for SearchParams {
@@ -98,6 +118,16 @@ impl Default for SearchParams {
             include_body: false,
             minify_body: false,
             verbose: false,
+            projection: None,
+            body_policy: None,
+            max_output_bytes: None,
+            max_output_tokens: None,
+            max_body_bytes: None,
+            max_total_body_bytes: None,
+            context_mode: None,
+            context_roles: None,
+            context_facets: None,
+            proposal: None,
         }
     }
 }
@@ -170,6 +200,16 @@ impl SearchParams {
             include_body: args.include_body.unwrap_or(false),
             minify_body: args.minify_body.unwrap_or(false),
             verbose: args.verbose.unwrap_or(false),
+            projection: non_blank_optional(&args.projection),
+            body_policy: non_blank_optional(&args.body_policy),
+            max_output_bytes: args.max_output_bytes.map(|value| value as usize),
+            max_output_tokens: args.max_output_tokens.map(|value| value as usize),
+            max_body_bytes: args.max_body_bytes.map(|value| value as usize),
+            max_total_body_bytes: args.max_total_body_bytes.map(|value| value as usize),
+            context_mode: non_blank_optional(&args.context_mode),
+            context_roles: non_empty_string_vec(&args.context_roles),
+            context_facets: non_empty_string_vec(&args.context_facets),
+            proposal: args.proposal.clone(),
         }
     }
 }
@@ -340,6 +380,60 @@ mod tests {
 
         assert_eq!(params.edge_types, Some(vec!["calls".to_string()]));
         assert_eq!(params.artifact_types, Some(vec!["outcome".to_string()]));
+    }
+
+    #[test]
+    fn from_mcp_search_preserves_projection_and_task_context_contract() {
+        let proposal = "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+        let search: Search = serde_json::from_value(json!({
+            "query": "Fix `render` and its named test",
+            "projection": " evidence ",
+            "body_policy": " focused_span ",
+            "max_output_bytes": 12000,
+            "max_output_tokens": 3000,
+            "max_body_bytes": 2048,
+            "max_total_body_bytes": 8192,
+            "context_mode": " task ",
+            "context_roles": [" editable_source ", "", "test"],
+            "context_facets": [" behavior ", "api_or_state"],
+            "proposal": proposal
+        }))
+        .unwrap();
+
+        let params = SearchParams::from_mcp_search(&search);
+
+        assert_eq!(params.projection.as_deref(), Some("evidence"));
+        assert_eq!(params.body_policy.as_deref(), Some("focused_span"));
+        assert_eq!(params.max_output_bytes, Some(12000));
+        assert_eq!(params.max_output_tokens, Some(3000));
+        assert_eq!(params.max_body_bytes, Some(2048));
+        assert_eq!(params.max_total_body_bytes, Some(8192));
+        assert_eq!(params.context_mode.as_deref(), Some("task"));
+        assert_eq!(
+            params.context_roles,
+            Some(vec!["editable_source".to_string(), "test".to_string()])
+        );
+        assert_eq!(
+            params.context_facets,
+            Some(vec!["behavior".to_string(), "api_or_state".to_string()])
+        );
+        assert_eq!(params.proposal.as_deref(), Some(proposal));
+    }
+
+    #[test]
+    fn search_context_controls_default_to_ordinary_agent_search() {
+        let params = SearchParams::default();
+
+        assert!(params.projection.is_none());
+        assert!(params.body_policy.is_none());
+        assert!(params.max_output_bytes.is_none());
+        assert!(params.max_output_tokens.is_none());
+        assert!(params.max_body_bytes.is_none());
+        assert!(params.max_total_body_bytes.is_none());
+        assert!(params.context_mode.is_none());
+        assert!(params.context_roles.is_none());
+        assert!(params.context_facets.is_none());
+        assert!(params.proposal.is_none());
     }
 }
 

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -298,8 +298,12 @@ fn sealed_semantic_bundle() -> bool {
         && option_env!("RNA_SEMANTIC_BUNDLE_BUILD") == Some("1")
 }
 
-const fn use_verified_reranker_loader(strict_semantic: bool, sealed_bundle: bool) -> bool {
-    strict_semantic || sealed_bundle
+const fn use_verified_reranker_loader(
+    strict_semantic: bool,
+    sealed_bundle: bool,
+    asset_seeding: bool,
+) -> bool {
+    strict_semantic || (sealed_bundle && !asset_seeding)
 }
 
 fn semantic_asset_seeding() -> bool {
@@ -7436,8 +7440,11 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
         // executor during ONNX model inference (and possible first-time
         // model download/initialization).
         let query_owned = query_str.to_string();
-        let verified_reranker =
-            use_verified_reranker_loader(strict_semantic, sealed_semantic_bundle());
+        let verified_reranker = use_verified_reranker_loader(
+            strict_semantic,
+            sealed_semantic_bundle(),
+            semantic_asset_seeding(),
+        );
         let rerank_result = tokio::task::spawn_blocking(move || {
             if verified_reranker {
                 rerank_results_strict(&query_owned, &candidates)
@@ -13636,10 +13643,11 @@ mod tests {
 
     #[test]
     fn acceptance_delivery_sealed_product_queries_use_verified_reranker_loader() {
-        assert!(!use_verified_reranker_loader(false, false));
-        assert!(use_verified_reranker_loader(true, false));
-        assert!(use_verified_reranker_loader(false, true));
-        assert!(use_verified_reranker_loader(true, true));
+        assert!(!use_verified_reranker_loader(false, false, false));
+        assert!(use_verified_reranker_loader(true, false, false));
+        assert!(use_verified_reranker_loader(false, true, false));
+        assert!(use_verified_reranker_loader(true, true, false));
+        assert!(!use_verified_reranker_loader(false, true, true));
     }
 
     #[test]

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -1045,6 +1045,13 @@ pub async fn search(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
     if let Some(node) = params.node.as_deref()
         && node.starts_with("rna-hydrate-v1:")
     {
+        if params.normalized_mode().is_some()
+            || params.nodes.as_ref().is_some_and(|nodes| !nodes.is_empty())
+            || params.target_subsystem.is_some()
+        {
+            return "Invalid search context: hydration cannot be combined with legacy nodes/traversal/target_subsystem dispatch."
+                .to_string();
+        }
         return hydrate_from_handle(node, params, ctx).await;
     }
 
@@ -1059,22 +1066,59 @@ pub async fn search(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
             .unwrap_or_else(|error| format!("Source span lookup task failed: {error}."));
     }
 
-    // Traversal and batch rendering retain their established contracts until
-    // typed projection adapters exist. In particular, never reinterpret a
-    // node/mode request as a flat product search.
-    if params.context_mode.is_none()
+    let legacy_dispatch = params.context_mode.is_none()
         && (params.normalized_mode().is_some()
             || params
                 .node
                 .as_deref()
                 .is_some_and(|node| !node.trim().is_empty())
             || params.nodes.as_ref().is_some_and(|nodes| !nodes.is_empty())
-            || params.target_subsystem.is_some())
-    {
+            || params.target_subsystem.is_some());
+    if legacy_dispatch && let Some(controls) = legacy_product_controls(params) {
+        return format!(
+            "Invalid search context: product controls ({controls}) cannot be combined with legacy node/nodes/traversal/target_subsystem dispatch. Remove those controls or use flat/task context search."
+        );
+    }
+
+    // Traversal and batch rendering retain their established contracts until
+    // typed projection adapters exist. In particular, never reinterpret a
+    // node/mode request as a flat product search.
+    if legacy_dispatch {
         return legacy_search_dispatch(params, ctx).await;
     }
 
     projected_search(params, ctx).await
+}
+
+/// Return the stable names of product-only controls that legacy dispatch
+/// cannot honor. Legacy requests with none of these controls retain their
+/// established renderer and ordering; silently ignoring an explicit control
+/// would otherwise make the response claim a contract it did not execute.
+fn legacy_product_controls(params: &SearchParams) -> Option<String> {
+    let controls = [
+        params.projection.is_some().then_some("projection"),
+        params.body_policy.is_some().then_some("body_policy"),
+        params
+            .max_output_bytes
+            .is_some()
+            .then_some("max_output_bytes"),
+        params
+            .max_output_tokens
+            .is_some()
+            .then_some("max_output_tokens"),
+        params.max_body_bytes.is_some().then_some("max_body_bytes"),
+        params
+            .max_total_body_bytes
+            .is_some()
+            .then_some("max_total_body_bytes"),
+        params.context_roles.is_some().then_some("context_roles"),
+        params.context_facets.is_some().then_some("context_facets"),
+        params.proposal.is_some().then_some("proposal"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
+    (!controls.is_empty()).then(|| controls.join(", "))
 }
 
 fn normalize_product_context_controls(params: &SearchParams) -> SearchParams {
@@ -2745,10 +2789,11 @@ async fn task_records(
     }
 
     let mut policy = TaskSelectionPolicy::default();
-    policy.rendered_budget = params
-        .max_output_bytes
-        .unwrap_or(policy.rendered_budget)
-        .min(task_context::MAX_RENDERED_BUDGET);
+    // Admission uses one deterministic byte currency. A token-only request is
+    // conservatively projected at four bytes per estimated token; when callers
+    // supply both bounds, the tighter one wins. The final renderer still
+    // validates the exact independently measured byte and token totals.
+    policy.rendered_budget = task_admission_budget(params, policy.rendered_budget);
     policy.per_record_limit = policy.rendered_budget;
     policy.candidate_limit = typed.len().clamp(1, task_context::MAX_SELECTION_CANDIDATES);
     policy.per_file_limit = policy.per_file_limit.min(policy.candidate_limit).max(1);
@@ -2844,6 +2889,19 @@ async fn task_records(
         ),
     });
     Ok(output)
+}
+
+fn task_admission_budget(params: &SearchParams, default_budget: usize) -> usize {
+    let token_budget_bytes = params
+        .max_output_tokens
+        .map(|tokens| tokens.saturating_mul(4));
+    match (params.max_output_bytes, token_budget_bytes) {
+        (Some(bytes), Some(token_bytes)) => bytes.min(token_bytes),
+        (Some(bytes), None) => bytes,
+        (None, Some(token_bytes)) => token_bytes,
+        (None, None) => default_budget,
+    }
+    .min(task_context::MAX_RENDERED_BUDGET)
 }
 
 fn task_lane_candidate_evidence(
@@ -3447,42 +3505,37 @@ fn enrich_live_graph_delta(overlay: &mut graph_delta::EphemeralOverlay, ctx: &Se
         }
     }
 
-    let mut relationship_lines = 0usize;
-    let mut inferred_lines = 0usize;
-    for file in &overlay.changed_files {
-        for hunk in &file.hunks {
-            for line in &hunk.changed_lines {
-                if !relationship_shaped_line(&line.text) {
-                    continue;
-                }
-                relationship_lines += 1;
-                let Some(source_id) =
-                    grounded.get(&(file.path.clone(), line.grounding.proposal_line))
-                else {
-                    continue;
-                };
-                match infer_changed_line_edge(line, source_id, ctx) {
-                    Ok(Some(edge)) => {
-                        inferred_lines += 1;
-                        match line.kind {
-                            graph_delta::ChangedLineKind::Added => {
-                                if !ctx.graph_state.edges.iter().any(|current| {
-                                    current.from.to_stable_id() == edge.key.from
-                                        && current.to.to_stable_id() == edge.key.to
-                                        && current.kind.to_string() == edge.key.kind
-                                }) {
-                                    overlay.edge_additions.push(edge);
-                                }
-                            }
-                            graph_delta::ChangedLineKind::Removed => {
-                                overlay.edge_removals.push(edge.key);
-                            }
+    let relationship_facts = overlay.relationships.len();
+    let mut inferred_relationships = 0usize;
+    for fact in &overlay.relationships {
+        let Some(source_id) =
+            grounded.get(&(fact.grounding.path.clone(), fact.grounding.proposal_line))
+        else {
+            misses.push((
+                fact.grounding.clone(),
+                "relationship fact has no uniquely grounded changed source line",
+            ));
+            continue;
+        };
+        match corroborate_changed_relationship(fact, source_id, ctx) {
+            Ok(edge) => {
+                inferred_relationships += 1;
+                match fact.change {
+                    graph_delta::ChangedLineKind::Added => {
+                        if !ctx.graph_state.edges.iter().any(|current| {
+                            current.from.to_stable_id() == edge.key.from
+                                && current.to.to_stable_id() == edge.key.to
+                                && current.kind.to_string() == edge.key.kind
+                        }) {
+                            overlay.edge_additions.push(edge);
                         }
                     }
-                    Ok(None) => {}
-                    Err(reason) => misses.push((line.grounding.clone(), reason)),
+                    graph_delta::ChangedLineKind::Removed => {
+                        overlay.edge_removals.push(edge.key);
+                    }
                 }
             }
+            Err(reason) => misses.push((fact.grounding.clone(), reason)),
         }
     }
 
@@ -3605,13 +3658,13 @@ fn enrich_live_graph_delta(overlay: &mut graph_delta::EphemeralOverlay, ctx: &Se
     set_graph_delta_capability(
         &mut overlay.capabilities,
         graph_delta::GraphDeltaCapability::LiveGraphInference,
-        if grounded.is_empty() || inferred_lines < relationship_lines {
+        if grounded.is_empty() || inferred_relationships < relationship_facts {
             graph_delta::CapabilityState::Degraded
         } else {
             graph_delta::CapabilityState::Ready
         },
         format!(
-            "uniquely grounded {}/{} changed lines and inferred {inferred_lines}/{relationship_lines} corroborated relationship lines",
+            "uniquely grounded {}/{} changed lines and inferred {inferred_relationships}/{relationship_facts} canonical corroborated relationship facts",
             grounded.len(),
             overlay
                 .changed_files
@@ -3695,58 +3748,44 @@ fn unique_node_at_line<'a>(
     Ok(best)
 }
 
-fn relationship_shaped_line(text: &str) -> bool {
-    let trimmed = text.trim_start();
-    trimmed.starts_with("use ")
-        || trimmed.starts_with("import ")
-        || trimmed.starts_with("from ")
-        || (text.contains('(') && text.contains(')'))
-}
-
-fn infer_changed_line_edge(
-    line: &graph_delta::ChangedLineFact,
+fn corroborate_changed_relationship(
+    fact: &graph_delta::ChangedRelationshipFact,
     source_id: &str,
     ctx: &SearchContext<'_>,
-) -> Result<Option<graph_delta::WeightedEdge>, &'static str> {
-    let identifiers = line
-        .text
-        .split(|character: char| !(character == '_' || character.is_ascii_alphanumeric()))
-        .filter(|token| !token.is_empty())
-        .collect::<BTreeSet<_>>();
-    let compact = line
-        .text
-        .chars()
-        .filter(|character| !character.is_whitespace())
-        .collect::<String>();
-    let import_like = {
-        let trimmed = line.text.trim_start();
-        trimmed.starts_with("use ")
-            || trimmed.starts_with("import ")
-            || trimmed.starts_with("from ")
-    };
+) -> Result<graph_delta::WeightedEdge, &'static str> {
     let mut matches = ctx
         .graph_state
         .nodes
         .iter()
-        .filter(|node| node.stable_id() != source_id && identifiers.contains(node.id.name.as_str()))
-        .filter(|node| import_like || compact.contains(&format!("{}(", node.id.name)))
+        .filter(|node| node.stable_id() != source_id && node.id.name == fact.target)
         .collect::<Vec<_>>();
     matches.sort_by_key(|node| node.stable_id());
     matches.dedup_by_key(|node| node.stable_id());
+    if matches.len() > 1
+        && let Some(qualifier) = fact.qualifier.as_deref()
+    {
+        let qualified = matches
+            .iter()
+            .copied()
+            .filter(|node| changed_relationship_qualifier_matches(node, qualifier))
+            .collect::<Vec<_>>();
+        if !qualified.is_empty() {
+            matches = qualified;
+        }
+    }
     let [target] = matches.as_slice() else {
         return if matches.is_empty() {
-            Err("relationship-shaped line has no uniquely corroborated current endpoint")
+            Err("canonical relationship fact has no corroborated current endpoint")
         } else {
-            Err("relationship-shaped line has multiple corroborated current endpoints")
+            Err("canonical relationship fact has multiple corroborated current endpoints")
         };
     };
-    let kind = if import_like { "references" } else { "calls" };
     let key = graph_delta::EdgeKey {
         from: source_id.to_string(),
         to: target.stable_id(),
-        kind: kind.to_string(),
+        kind: fact.kind.edge_kind().to_string(),
     };
-    if line.kind == graph_delta::ChangedLineKind::Removed
+    if fact.change == graph_delta::ChangedLineKind::Removed
         && !ctx.graph_state.edges.iter().any(|edge| {
             edge.from.to_stable_id() == key.from
                 && edge.to.to_stable_id() == key.to
@@ -3755,13 +3794,19 @@ fn infer_changed_line_edge(
     {
         return Err("removed relationship is not corroborated by a persisted current edge");
     }
-    Ok(Some(graph_delta::WeightedEdge {
+    Ok(graph_delta::WeightedEdge {
         key,
         cost: 1,
         priority: 0,
-        registration_order: line.grounding.proposal_line,
-        grounding: graph_delta::EvidenceGrounding::Proposal(line.grounding.clone()),
-    }))
+        registration_order: fact.grounding.proposal_line,
+        grounding: graph_delta::EvidenceGrounding::Proposal(fact.grounding.clone()),
+    })
+}
+
+fn changed_relationship_qualifier_matches(node: &Node, qualifier: &str) -> bool {
+    node.stable_id().contains(qualifier)
+        || node.id.file.to_string_lossy().contains(qualifier)
+        || node.signature.contains(qualifier)
 }
 
 fn graph_delta_node_grounding(node: &Node) -> Option<graph_delta::EvidenceGrounding> {
@@ -4351,6 +4396,7 @@ fn graph_delta_snapshot(graph: &GraphState) -> graph_delta::GraphSnapshot {
             let span = node_source_span(node)?;
             safe_graph_delta_path(&span.path).then_some(graph_delta::GraphNode {
                 id: node.stable_id(),
+                kind: graph_delta_impact_kind(node, false),
                 grounding: graph_delta::EvidenceGrounding::CurrentSource(graph_delta::SourceSpan {
                     root: span.root,
                     path: span.path,
@@ -8340,6 +8386,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn default_compact_evidence_projection_matrix_is_byte_stable() {
+        let repository = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repository.path().join("src")).unwrap();
+        std::fs::write(
+            repository.path().join("src/matrix.rs"),
+            "fn matrix_target() {}\n",
+        )
+        .unwrap();
+        let mut node = make_node("matrix_target", NodeKind::Function, "src/matrix.rs");
+        node.line_start = 1;
+        node.line_end = 1;
+        let graph = make_graph_state(vec![node]);
+        let ctx = make_search_context(&graph, repository.path());
+        let base = SearchParams {
+            query: Some("matrix_target".into()),
+            include_artifacts: false,
+            include_markdown: false,
+            ..Default::default()
+        };
+        let action = search(&base, &ctx).await;
+        let compact = search(
+            &SearchParams {
+                compact: true,
+                ..base.clone()
+            },
+            &ctx,
+        )
+        .await;
+        let evidence = search(
+            &SearchParams {
+                projection: Some("evidence".into()),
+                ..base.clone()
+            },
+            &ctx,
+        )
+        .await;
+
+        assert_eq!(action, compact, "compact is the concise agent projection");
+        assert_eq!(action, search(&base, &ctx).await);
+        assert!(action.contains("- projection: agent"));
+        assert!(!action.contains("## Candidate audit"));
+        assert!(!action.contains("evidence.content_hash"));
+        assert!(evidence.contains("- projection: evidence"));
+        assert!(evidence.contains("## Candidate audit"));
+        assert!(evidence.contains("evidence.content_hash"));
+        for rendered in [&action, &compact, &evidence] {
+            assert!(rendered.contains("## Render accounting"));
+            assert!(rendered.contains("deterministic estimate; not provider usage"));
+        }
+    }
+
+    #[tokio::test]
     async fn test_search_trims_traversal_mode_at_service_boundary() {
         let caller = make_node("caller", NodeKind::Function, "src/caller.rs");
         let callee = make_node("callee", NodeKind::Function, "src/callee.rs");
@@ -11653,6 +11751,116 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn legacy_dispatch_rejects_product_controls_but_preserves_default_bytes() {
+        let caller = make_node("legacy_caller", NodeKind::Function, "src/caller.rs");
+        let callee = make_node("legacy_callee", NodeKind::Function, "src/callee.rs");
+        let graph = make_graph_state_with_edges(
+            vec![caller.clone(), callee.clone()],
+            vec![make_edge(&caller, &callee, EdgeKind::Calls)],
+        );
+        let repository = PathBuf::from("/tmp/legacy-product-control-fixture");
+        let ctx = make_search_context(&graph, &repository);
+        let legacy = SearchParams {
+            node: Some(caller.stable_id()),
+            mode: Some("neighbors".into()),
+            compact: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            search(&legacy, &ctx).await,
+            legacy_search_dispatch(&legacy, &ctx).await,
+            "default legacy dispatch must remain byte/order compatible"
+        );
+
+        let controlled = [
+            SearchParams {
+                projection: Some("evidence".into()),
+                ..legacy.clone()
+            },
+            SearchParams {
+                body_policy: Some("focused_span".into()),
+                ..legacy.clone()
+            },
+            SearchParams {
+                max_output_bytes: Some(4096),
+                ..legacy.clone()
+            },
+            SearchParams {
+                max_output_tokens: Some(1024),
+                ..legacy.clone()
+            },
+            SearchParams {
+                max_body_bytes: Some(512),
+                ..legacy.clone()
+            },
+            SearchParams {
+                max_total_body_bytes: Some(2048),
+                ..legacy.clone()
+            },
+        ];
+        for params in controlled {
+            let response = search(&params, &ctx).await;
+            assert!(
+                response.contains("product controls")
+                    && response.contains("legacy node/nodes/traversal/target_subsystem dispatch"),
+                "explicit product control must fail closed: {response}"
+            );
+        }
+
+        for params in [
+            SearchParams {
+                nodes: Some(vec![caller.stable_id()]),
+                projection: Some("agent".into()),
+                ..Default::default()
+            },
+            SearchParams {
+                query: Some("legacy".into()),
+                target_subsystem: Some("service".into()),
+                projection: Some("agent".into()),
+                ..Default::default()
+            },
+        ] {
+            assert!(search(&params, &ctx).await.contains("product controls"));
+        }
+    }
+
+    #[test]
+    fn task_admission_uses_token_only_and_tighter_combined_budget() {
+        assert_eq!(
+            task_admission_budget(
+                &SearchParams {
+                    max_output_tokens: Some(250),
+                    ..Default::default()
+                },
+                9_999,
+            ),
+            1_000
+        );
+        assert_eq!(
+            task_admission_budget(
+                &SearchParams {
+                    max_output_bytes: Some(700),
+                    max_output_tokens: Some(250),
+                    ..Default::default()
+                },
+                9_999,
+            ),
+            700
+        );
+        assert_eq!(
+            task_admission_budget(
+                &SearchParams {
+                    max_output_bytes: Some(2_000),
+                    max_output_tokens: Some(250),
+                    ..Default::default()
+                },
+                9_999,
+            ),
+            1_000
+        );
+    }
+
     #[test]
     fn graph_delta_beta_requires_bounded_non_binary_proposal() {
         let missing = SearchParams {
@@ -11997,50 +12205,167 @@ mod tests {
             "fn live_graph_delta_infers_corroborated_edges_without_mutating_graph(",
         );
         delta_test.metadata.insert("is_test".into(), "true".into());
+        let mut nodes = vec![
+            projected.clone(),
+            delta.clone(),
+            task_test.clone(),
+            delta_test.clone(),
+        ];
+        for (name, needle) in [
+            ("projection_request", "fn projection_request("),
+            ("projection_source_reader", "fn projection_source_reader("),
+            (
+                "projected_non_code_records",
+                "async fn projected_non_code_records(",
+            ),
+            (
+                "projected_live_markdown_records",
+                "fn projected_live_markdown_records(",
+            ),
+            (
+                "evidence_capsule_capability",
+                "fn evidence_capsule_capability(",
+            ),
+            ("graph_delta_projection", "fn graph_delta_projection("),
+            (
+                "graph_delta_projection_span",
+                "fn graph_delta_projection_span(",
+            ),
+            ("render_projected_input", "fn render_projected_input("),
+            (
+                "projected_fused_candidates",
+                "async fn projected_fused_candidates(",
+            ),
+            (
+                "resolve_projected_entry_nodes",
+                "fn resolve_projected_entry_nodes<'a>(",
+            ),
+            ("projected_traversal_ids", "fn projected_traversal_ids("),
+            ("projected_node_passes", "fn projected_node_passes("),
+            ("node_projection_digest", "fn node_projection_digest("),
+        ] {
+            nodes.push(node_at(name, needle));
+        }
+        // Put each real test two typed hops behind its editable source. Task
+        // mode is allowed to satisfy its explicit test obligation through the
+        // bounded graph expansion; ordinary flat fusion sees only the direct
+        // helper and must spend top-k slots without receiving that obligation
+        // for free.
+        let projection_bridge = nodes
+            .iter()
+            .find(|node| node.id.name == "projection_request")
+            .unwrap()
+            .clone();
+        let delta_bridge = nodes
+            .iter()
+            .find(|node| node.id.name == "graph_delta_projection")
+            .unwrap()
+            .clone();
         let graph = make_graph_state_with_edges(
+            nodes,
             vec![
-                projected.clone(),
-                delta.clone(),
-                task_test.clone(),
-                delta_test.clone(),
-            ],
-            vec![
-                make_edge(&task_test, &projected, EdgeKind::TestedBy),
-                make_edge(&delta_test, &delta, EdgeKind::TestedBy),
+                make_edge(&task_test, &projection_bridge, EdgeKind::TestedBy),
+                make_edge(&projection_bridge, &projected, EdgeKind::Calls),
+                make_edge(&delta_test, &delta_bridge, EdgeKind::TestedBy),
+                make_edge(&delta_bridge, &delta, EdgeKind::Calls),
             ],
         );
         let ctx = make_search_context(&graph, repository.path());
-        for (query, expected) in [
+        for (query, expected, expected_test) in [
             (
-                "Change `projected_search` behavior and verify the regression test",
+                "Change `projected_search` search projection source evidence behavior and verify `task_agent_projection_carries_stable_action_fields`",
                 projected.stable_id(),
+                task_test.stable_id(),
             ),
             (
-                "Review `projected_graph_delta` API state and its existing analogue test",
+                "Review `projected_graph_delta` search projection source evidence behavior and verify `live_graph_delta_infers_corroborated_edges_without_mutating_graph`",
                 delta.stable_id(),
+                delta_test.stable_id(),
             ),
         ] {
-            let output = task_records(
-                &SearchParams {
-                    query: Some(query.into()),
-                    context_mode: Some("task".into()),
-                    include_artifacts: false,
-                    include_markdown: false,
-                    ..Default::default()
-                },
-                &ctx,
-            )
-            .await
-            .unwrap();
+            let task_params = SearchParams {
+                query: Some(query.into()),
+                context_mode: Some("task".into()),
+                context_roles: Some(vec![
+                    "editable_source".into(),
+                    "test".into(),
+                    "direct_dependency".into(),
+                    "caller_or_impact".into(),
+                ]),
+                context_facets: Some(vec!["behavior".into(), "test".into()]),
+                hops: Some(2),
+                limit: Some(16),
+                include_artifacts: false,
+                include_markdown: false,
+                ..Default::default()
+            };
+            let output = task_records(&task_params, &ctx).await.unwrap();
             assert!(output.records.iter().any(|record| {
                 record.identity.node_id == expected
                     && record.selection.role == Some(ProjectionRole::EditableSource)
             }));
+            assert!(output.records.iter().any(|record| {
+                record.identity.node_id == expected_test
+                    && record.selection.role == Some(ProjectionRole::Test)
+            }));
+
+            let flat_params = SearchParams {
+                query: task_params.query.clone(),
+                // Give flat retrieval twice as many records as the role-aware
+                // bundle. It still cannot express the required dependency and
+                // impact obligations, while its extra records make the cost
+                // comparison conservative rather than k-starved.
+                limit: Some(32),
+                include_artifacts: false,
+                include_markdown: false,
+                ..Default::default()
+            };
+            let (flat, _, _) = projected_fused_candidates(&flat_params, &ctx)
+                .await
+                .unwrap();
+            let flat_roles = flat
+                .iter()
+                .take(flat_params.limit.unwrap())
+                .filter_map(|candidate| find_node(&graph, &candidate.stable_id))
+                .map(default_role)
+                .collect::<BTreeSet<_>>();
+            let flat_ids = flat
+                .iter()
+                .take(flat_params.limit.unwrap())
+                .map(|candidate| candidate.stable_id.as_str())
+                .collect::<BTreeSet<_>>();
+            let task_roles = output
+                .records
+                .iter()
+                .filter_map(|record| record.selection.role)
+                .collect::<BTreeSet<_>>();
+            let required = [
+                ProjectionRole::EditableSource,
+                ProjectionRole::Test,
+                ProjectionRole::DirectDependency,
+                ProjectionRole::CallerOrImpact,
+            ];
+            let task_coverage = required
+                .iter()
+                .filter(|role| task_roles.contains(role))
+                .count();
+            let flat_coverage = required
+                .iter()
+                .filter(|role| flat_roles.contains(role))
+                .count();
+            assert_eq!(task_coverage, required.len());
             assert!(
-                output
-                    .records
-                    .iter()
-                    .any(|record| record.selection.role == Some(ProjectionRole::Test))
+                task_coverage > flat_coverage,
+                "task lanes must improve required-role coverage: task={task_roles:?} flat={flat_roles:?} flat_ids={flat_ids:?}"
+            );
+
+            let task_rendered = projected_search(&task_params, &ctx).await;
+            let flat_rendered = projected_search(&flat_params, &ctx).await;
+            assert!(
+                task_rendered.len() < flat_rendered.len(),
+                "task context must render below flat top-k bytes: task={} flat={}",
+                task_rendered.len(),
+                flat_rendered.len()
             );
         }
     }
@@ -12159,5 +12484,199 @@ mod tests {
                 ))
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[tokio::test]
+    async fn rna_graph_delta_card_is_smaller_and_more_role_specific_than_raw_traversal() {
+        let repository = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repository.path().join("src/service")).unwrap();
+        let source = std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("src/service/search.rs"),
+        )
+        .unwrap();
+        std::fs::write(repository.path().join("src/service/search.rs"), &source).unwrap();
+        let line_of = |needle: &str| {
+            u32::try_from(
+                source
+                    .lines()
+                    .position(|line| line.contains(needle))
+                    .unwrap_or_else(|| panic!("real RNA source fixture is missing {needle:?}"))
+                    + 1,
+            )
+            .unwrap()
+        };
+        let node_at = |name: &str, needle: &str| {
+            let mut node = make_node(name, NodeKind::Function, "src/service/search.rs");
+            let line = line_of(needle);
+            node.line_start = line as usize;
+            node.line_end = (line as usize + 39).min(source.lines().count());
+            node.body = source
+                .lines()
+                .skip(line as usize - 1)
+                .take(node.line_end - node.line_start + 1)
+                .collect::<Vec<_>>()
+                .join("\n");
+            node
+        };
+
+        let mut search_node = make_node("search", NodeKind::Function, "src/service/search.rs");
+        search_node.line_start = line_of("pub async fn search(") as usize;
+        search_node.line_end = line_of("fn legacy_product_controls(") as usize - 1;
+        search_node.body = "pub async fn search(/* current product dispatch */)".into();
+        let legacy = node_at("legacy_search_dispatch", "async fn legacy_search_dispatch(");
+        let projected = node_at("projected_search", "async fn projected_search(");
+        let mut nodes = vec![search_node.clone(), legacy.clone(), projected.clone()];
+        for (name, needle) in [
+            ("validate_named_values", "fn validate_named_values("),
+            (
+                "validate_search_experience",
+                "fn validate_search_experience(",
+            ),
+            ("strict_semantic_requested", "fn strict_semantic_requested("),
+            ("projection_request", "fn projection_request("),
+            ("projection_source_reader", "fn projection_source_reader("),
+            ("hydrate_from_handle", "async fn hydrate_from_handle("),
+            (
+                "projected_non_code_records",
+                "async fn projected_non_code_records(",
+            ),
+            (
+                "projected_live_markdown_records",
+                "fn projected_live_markdown_records(",
+            ),
+            (
+                "evidence_capsule_capability",
+                "fn evidence_capsule_capability(",
+            ),
+            ("task_records", "async fn task_records("),
+            (
+                "task_lane_candidate_evidence",
+                "fn task_lane_candidate_evidence(",
+            ),
+            ("requested_task_facets", "fn requested_task_facets("),
+            ("expand_task_graph", "fn expand_task_graph("),
+            ("rendered_task_bundle_cost", "fn rendered_task_bundle_cost("),
+            ("live_graph_delta_card", "fn live_graph_delta_card("),
+            ("enrich_live_graph_delta", "fn enrich_live_graph_delta("),
+            ("graph_delta_projection", "fn graph_delta_projection("),
+            ("render_projected_input", "fn render_projected_input("),
+            (
+                "projected_fused_candidates",
+                "async fn projected_fused_candidates(",
+            ),
+            ("projected_node_passes", "fn projected_node_passes("),
+            ("node_projection_digest", "fn node_projection_digest("),
+            ("default_role", "fn default_role("),
+            ("projected_relationships", "fn projected_relationships("),
+            ("compiler_location", "fn compiler_location("),
+            ("source_roots", "fn source_roots("),
+            ("collect_suffix_matches", "fn collect_suffix_matches("),
+            ("source_span", "fn source_span("),
+            ("format_lsp_completeness", "fn format_lsp_completeness("),
+            ("legacy_search_dispatch", "async fn legacy_search_dispatch("),
+            ("selected_for_hydration", "fn selected_for_hydration("),
+            ("task_role_from_str", "fn task_role_from_str("),
+            ("lexical_score", "fn lexical_score("),
+            ("node_source_span", "fn node_source_span("),
+            ("symbol_summary", "fn symbol_summary("),
+            ("selected_from_exact_node", "fn selected_from_exact_node("),
+            ("default_capabilities", "fn default_capabilities("),
+            ("channel_for_evidence", "fn channel_for_evidence("),
+            (
+                "resolve_projected_entry_nodes",
+                "fn resolve_projected_entry_nodes<'a>(",
+            ),
+        ] {
+            nodes.push(node_at(name, needle));
+        }
+        let mut nearest_route_test = node_at(
+            "live_graph_delta_infers_corroborated_edges_without_mutating_graph",
+            "fn live_graph_delta_infers_corroborated_edges_without_mutating_graph(",
+        );
+        nearest_route_test
+            .metadata
+            .insert("is_test".into(), "true".into());
+        nodes.push(nearest_route_test.clone());
+
+        let mut edges = vec![make_edge(&search_node, &legacy, EdgeKind::Calls)];
+        for node in nodes.iter().skip(3) {
+            edges.push(make_edge(node, &search_node, EdgeKind::Calls));
+        }
+        edges.push(make_edge(
+            &nearest_route_test,
+            &search_node,
+            EdgeKind::TestedBy,
+        ));
+        let graph = make_graph_state_with_edges(nodes, edges);
+        let ctx = make_search_context(&graph, repository.path());
+        let changed_line = line_of("return legacy_search_dispatch(params, ctx).await;");
+        let proposal = format!(
+            "diff --git a/src/service/search.rs b/src/service/search.rs\n--- a/src/service/search.rs\n+++ b/src/service/search.rs\n@@ -{changed_line},1 +{changed_line},1 @@\n-        return legacy_search_dispatch(params, ctx).await;\n+        return projected_search(params, ctx).await;\n"
+        );
+        let card = projected_graph_delta(
+            &SearchParams {
+                context_mode: Some("graph-delta-beta".into()),
+                root: Some("local".into()),
+                proposal: Some(proposal),
+                limit: Some(4),
+                include_artifacts: false,
+                include_markdown: false,
+                ..Default::default()
+            },
+            &ctx,
+        )
+        .await;
+        // The card covers all affected loci in one bounded response. The
+        // context-equivalent legacy baseline therefore needs the neighbors and
+        // impact view for every locus, not only the edited seed.
+        let mut raw_bytes = 0usize;
+        let mut seed_neighbors = String::new();
+        let mut seed_impact = String::new();
+        for node_id in graph.nodes.iter().map(Node::stable_id) {
+            let neighbors = search(
+                &SearchParams {
+                    node: Some(node_id.clone()),
+                    mode: Some("neighbors".into()),
+                    limit: Some(50),
+                    include_body: true,
+                    ..Default::default()
+                },
+                &ctx,
+            )
+            .await;
+            let impact = search(
+                &SearchParams {
+                    node: Some(node_id.clone()),
+                    mode: Some("impact".into()),
+                    hops: Some(1),
+                    limit: Some(50),
+                    include_body: true,
+                    ..Default::default()
+                },
+                &ctx,
+            )
+            .await;
+            if node_id == search_node.stable_id() {
+                seed_neighbors = neighbors.clone();
+                seed_impact = impact.clone();
+            }
+            raw_bytes = raw_bytes
+                .saturating_add(neighbors.len())
+                .saturating_add(impact.len());
+        }
+
+        assert!(
+            card.len() < raw_bytes,
+            "graph-delta card must be smaller than raw neighbors+impact: card={} raw={raw_bytes}",
+            card.len()
+        );
+        assert!(card.contains("role: caller_or_impact"));
+        assert!(
+            card.contains("role: test"),
+            "nearest route test missing: {card}"
+        );
+        assert!(card.contains("graph_delta_route"));
+        assert!(!seed_neighbors.contains("role:"));
+        assert!(!seed_impact.contains("role:"));
     }
 }

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -198,6 +198,13 @@ fn validate_search_experience(params: &SearchParams) -> Result<(), String> {
         return Err("context_roles/context_facets require context_mode=task".to_string());
     }
     if context_mode.is_some() {
+        if let Some(direction) = params.direction.as_deref().map(str::trim)
+            && !matches!(direction, "incoming" | "outgoing" | "both")
+        {
+            return Err(format!(
+                "unknown task-context direction `{direction}`; allowed values: incoming, outgoing, both"
+            ));
+        }
         if params.hops.unwrap_or(1) > MAX_CONTEXT_HOPS {
             return Err(format!(
                 "task-context hops cannot exceed {MAX_CONTEXT_HOPS}"
@@ -2379,7 +2386,7 @@ fn evidence_capsule_capability(records: &[SelectedRecord]) -> CapabilityStatus {
 const TASK_LANE_CANDIDATE_LIMIT: usize = 12;
 const TASK_GRAPH_CANDIDATE_LIMIT: usize = 64;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct TaskAdapterOutput {
     records: Vec<SelectedRecord>,
     relationships: Vec<ProjectedRelationship>,
@@ -2437,24 +2444,39 @@ async fn task_records(
         match resolution.resolution {
             ExactResolution::Hit(candidate) => {
                 exact_hits += 1;
+                let Some(node) = candidate_nodes.get(&candidate.evidence_id).copied() else {
+                    output.omissions.push(ProjectionOmission {
+                        record_id: Some(candidate.evidence_id),
+                        source: None,
+                        code: OmissionCode::MissingSource,
+                        detail: format!(
+                            "exact reference {:?} resolved outside the filtered task graph",
+                            resolution.reference.raw
+                        ),
+                    });
+                    continue;
+                };
+                let roles = exact_task_roles(node);
                 let fused = single_channel_fused(
                     &candidate.evidence_id,
                     EvidenceChannel::ExactLexical,
                     ScoreKind::ExactMatchTier,
                 );
-                merge_task_assembly(
-                    &mut assemblies,
-                    fused,
-                    TaskRole::EditableSource,
-                    TaskLane::ExactReference,
-                    task_facet_for_role(TaskRole::EditableSource),
-                    Some(resolution.reference.raw.clone()),
-                    0,
-                    format!(
-                        "exact reference {:?} resolved across the full filtered graph",
-                        resolution.reference.raw
-                    ),
-                );
+                for role in roles {
+                    merge_task_assembly(
+                        &mut assemblies,
+                        fused.clone(),
+                        role,
+                        TaskLane::ExactReference,
+                        task_facet_for_role(role),
+                        Some(resolution.reference.raw.clone()),
+                        0,
+                        format!(
+                            "exact reference {:?} resolved as eligible role {role:?} across the full filtered graph",
+                            resolution.reference.raw
+                        ),
+                    );
+                }
             }
             ExactResolution::Ambiguous(candidates) => output.omissions.push(ProjectionOmission {
                 record_id: None,
@@ -2793,7 +2815,6 @@ async fn task_records(
             );
             records.push(selected);
         }
-        let rendered_cost = rendered_task_bundle_cost(params, &reader, &records)?;
         typed.insert(
             id.clone(),
             TaskEvidenceCandidate {
@@ -2801,7 +2822,9 @@ async fn task_records(
                 roles: assembly.roles.clone(),
                 lanes: assembly.lanes.clone(),
                 facets: assembly.facets.clone(),
-                rendered_cost,
+                // Replaced below with the exact canonical singleton bundle
+                // cost once fixed task-only sections are available.
+                rendered_cost: 1,
                 exact_reference: assembly.exact_reference.clone(),
                 source: SourceAnchor {
                     path: source.path,
@@ -2829,91 +2852,75 @@ async fn task_records(
             .filter_map(|role| task_role_from_str(role))
             .collect();
     }
-    let selection = task_context::select_context(typed.values().cloned().collect(), &policy)
-        .map_err(|error| error.to_string())?;
+    let request = projection_request(params, SearchIntent::Implement);
+    let default_task_capabilities = default_capabilities(ctx, request.projection).await;
+    let base_output = output;
+
+    // A record-level cap is evaluated in the same currency as selection: the
+    // canonical final task response with that identity selected and every
+    // fixed task-only section present.
+    let candidate_ids = typed.keys().cloned().collect::<Vec<_>>();
+    for id in candidate_ids {
+        let singleton = [id.clone()];
+        let cost = rendered_task_bundle_cost(
+            params,
+            &reader,
+            &singleton,
+            &bundles,
+            &typed,
+            &assemblies,
+            &candidate_nodes,
+            &product_score_audit,
+            &base_output,
+            &policy.required_roles,
+            &default_task_capabilities,
+            edge_index,
+        )?;
+        if let Some(candidate) = typed.get_mut(&id) {
+            candidate.rendered_cost = cost.max(1);
+        }
+    }
+
+    let selection = task_context::select_context_with_cost_and_interactions(
+        typed.values().cloned().collect(),
+        &policy,
+        |selected_ids| {
+            rendered_task_bundle_cost(
+                params,
+                &reader,
+                selected_ids,
+                &bundles,
+                &typed,
+                &assemblies,
+                &candidate_nodes,
+                &product_score_audit,
+                &base_output,
+                &policy.required_roles,
+                &default_task_capabilities,
+                edge_index,
+            )
+            .map_err(|reason| task_context::TaskContextError::BundleCost { reason })
+        },
+        |selected_ids, remaining_ids| {
+            task_future_interaction_signature(selected_ids, remaining_ids, edge_index)
+        },
+    )
+    .map_err(|error| error.to_string())?;
     let selected_ids = selection
         .selected
         .iter()
-        .map(|selected| selected.evidence_id.as_str())
-        .collect::<BTreeSet<_>>();
-    for (rank, selected) in selection.selected.iter().enumerate() {
-        let reason = task_selection_reason(&selected.reason);
-        if let Some(records) = bundles.get_mut(&selected.evidence_id) {
-            for record in records {
-                record.selection_rank = rank;
-                record.selection.reason = format!("{}; {reason}", record.selection.reason);
-                output.records.push(record.clone());
-            }
-        }
-    }
-    let omission_reasons = selection
-        .omitted
-        .iter()
-        .map(|omitted| {
-            (
-                omitted.evidence_id.as_str(),
-                format!("{:?}", omitted.reason),
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
-    for (rank, (id, assembly)) in assemblies.iter().enumerate() {
-        let Some(node) = candidate_nodes.get(id).copied() else {
-            continue;
-        };
-        let selected = selected_ids.contains(id.as_str());
-        let mut audit = candidate_audit_from_fused(
-            node,
-            &assembly.fused,
-            rank,
-            selected,
-            if selected {
-                "selected by exact-first maximum-coverage projection cost"
-            } else {
-                omission_reasons
-                    .get(id.as_str())
-                    .map(String::as_str)
-                    .unwrap_or("omitted without marginal role/lane/facet coverage")
-            },
-        );
-        append_product_score_audit(
-            &mut audit.evidence,
-            product_score_audit.get(id).map(Vec::as_slice),
-        );
-        output.candidate_audit.push(audit);
-    }
-    for omitted in &selection.omitted {
-        output.omissions.push(ProjectionOmission {
-            record_id: Some(omitted.evidence_id.clone()),
-            source: candidate_nodes
-                .get(&omitted.evidence_id)
-                .and_then(|node| node_source_span(node)),
-            code: OmissionCode::RenderBudget,
-            detail: format!("task selector omission: {:?}", omitted.reason),
-        });
-    }
-    for role in &selection.missing_roles {
-        output.omissions.push(ProjectionOmission {
-            record_id: None,
-            source: None,
-            code: OmissionCode::MissingSource,
-            detail: format!("required task context role {role:?} is not covered"),
-        });
-    }
-    output.capabilities.push(CapabilityStatus {
-        capability: "task_context_selection".into(),
-        state: if selection.missing_roles.is_empty() {
-            CapabilityState::Ready
-        } else {
-            CapabilityState::Degraded
-        },
-        detail: format!(
-            "selected {} of {} candidates at {} rendered bytes; missing_roles={:?}",
-            selection.selected.len(),
-            typed.len(),
-            selection.rendered_cost,
-            selection.missing_roles
-        ),
-    });
+        .map(|selected| selected.evidence_id.clone())
+        .collect::<Vec<_>>();
+    let output = materialize_task_output(
+        &selected_ids,
+        &bundles,
+        &typed,
+        &assemblies,
+        &candidate_nodes,
+        &product_score_audit,
+        &base_output,
+        &policy.required_roles,
+    );
     Ok(output)
 }
 
@@ -3288,20 +3295,192 @@ fn expand_task_graph(
     });
 }
 
+#[allow(clippy::too_many_arguments)]
+fn materialize_task_output(
+    selected_ids: &[String],
+    bundles: &BTreeMap<String, Vec<SelectedRecord>>,
+    typed: &BTreeMap<String, TaskEvidenceCandidate>,
+    assemblies: &BTreeMap<String, TaskAssembly>,
+    candidate_nodes: &BTreeMap<String, &Node>,
+    product_score_audit: &BTreeMap<String, Vec<ProductScoreAudit>>,
+    base_output: &TaskAdapterOutput,
+    required_roles: &BTreeSet<TaskRole>,
+) -> TaskAdapterOutput {
+    let mut output = base_output.clone();
+    let selected_set = selected_ids.iter().cloned().collect::<BTreeSet<_>>();
+    let mut covered_roles = BTreeSet::new();
+    let mut covered_lanes = BTreeSet::new();
+    let mut covered_facets = BTreeSet::new();
+
+    for (rank, id) in selected_ids.iter().enumerate() {
+        let Some(candidate) = typed.get(id) else {
+            continue;
+        };
+        let reason = if let Some(reference) = candidate.exact_reference.clone() {
+            TaskSelectionReason::ExactReference { reference }
+        } else {
+            TaskSelectionReason::CoveragePerCost {
+                newly_covered_roles: candidate
+                    .roles
+                    .intersection(required_roles)
+                    .filter(|role| !covered_roles.contains(*role))
+                    .copied()
+                    .collect(),
+                newly_covered_lanes: candidate
+                    .lanes
+                    .difference(&covered_lanes)
+                    .copied()
+                    .collect(),
+                newly_covered_facets: candidate
+                    .facets
+                    .difference(&covered_facets)
+                    .copied()
+                    .collect(),
+            }
+        };
+        covered_roles.extend(candidate.roles.iter().copied());
+        covered_lanes.extend(candidate.lanes.iter().copied());
+        covered_facets.extend(candidate.facets.iter().copied());
+        let reason = task_selection_reason(&reason);
+        if let Some(records) = bundles.get(id) {
+            for mut record in records.clone() {
+                record.selection_rank = rank;
+                record.selection.reason = format!("{}; {reason}", record.selection.reason);
+                output.records.push(record);
+            }
+        }
+    }
+
+    for (rank, (id, assembly)) in assemblies.iter().enumerate() {
+        let Some(node) = candidate_nodes.get(id).copied() else {
+            continue;
+        };
+        let selected = selected_set.contains(id);
+        let mut audit = candidate_audit_from_fused(
+            node,
+            &assembly.fused,
+            rank,
+            selected,
+            if selected {
+                "selected by exact-first maximum coverage under canonical final task-bundle cost"
+            } else {
+                "omitted by canonical final task-bundle coverage, diversity, or budget selection"
+            },
+        );
+        append_product_score_audit(
+            &mut audit.evidence,
+            product_score_audit.get(id).map(Vec::as_slice),
+        );
+        output.candidate_audit.push(audit);
+    }
+    for id in typed.keys() {
+        if selected_set.contains(id) {
+            continue;
+        }
+        output.omissions.push(ProjectionOmission {
+            record_id: Some(id.clone()),
+            source: candidate_nodes
+                .get(id)
+                .copied()
+                .and_then(node_source_span),
+            code: OmissionCode::RenderBudget,
+            detail: "task candidate was not selected by canonical final-bundle coverage, diversity, or budget optimization".into(),
+        });
+    }
+    let missing_roles = required_roles
+        .difference(&covered_roles)
+        .copied()
+        .collect::<BTreeSet<_>>();
+    for role in &missing_roles {
+        output.omissions.push(ProjectionOmission {
+            record_id: None,
+            source: None,
+            code: OmissionCode::MissingSource,
+            detail: format!("required task context role {role:?} is not covered"),
+        });
+    }
+    output.capabilities.push(CapabilityStatus {
+        capability: "task_context_selection".into(),
+        state: if missing_roles.is_empty() {
+            CapabilityState::Ready
+        } else {
+            CapabilityState::Degraded
+        },
+        // Do not put the measured cost in the response being measured: that
+        // would make task admission self-referential.
+        detail: format!(
+            "selected {} of {} candidates using canonical final-bundle cost; missing_roles={missing_roles:?}",
+            selected_ids.len(),
+            typed.len()
+        ),
+    });
+    output
+}
+
+#[allow(clippy::too_many_arguments)]
 fn rendered_task_bundle_cost(
     params: &SearchParams,
     reader: &source::SourceReader,
-    records: &[SelectedRecord],
+    selected_ids: &[String],
+    bundles: &BTreeMap<String, Vec<SelectedRecord>>,
+    typed: &BTreeMap<String, TaskEvidenceCandidate>,
+    assemblies: &BTreeMap<String, TaskAssembly>,
+    candidate_nodes: &BTreeMap<String, &Node>,
+    product_score_audit: &BTreeMap<String, Vec<ProductScoreAudit>>,
+    base_output: &TaskAdapterOutput,
+    required_roles: &BTreeSet<TaskRole>,
+    default_task_capabilities: &[CapabilityStatus],
+    edge_index: &ProjectedEdgeIndex<'_>,
 ) -> Result<usize, String> {
+    let mut output = materialize_task_output(
+        selected_ids,
+        bundles,
+        typed,
+        assemblies,
+        candidate_nodes,
+        product_score_audit,
+        base_output,
+        required_roles,
+    );
+    let mut seen_records = BTreeSet::new();
+    output.records.retain(|record| {
+        seen_records.insert((record.identity.node_id.clone(), record.selection.role))
+    });
+    output.records.sort_by(|left, right| {
+        left.selection_rank
+            .cmp(&right.selection_rank)
+            .then_with(|| left.identity.node_id.cmp(&right.identity.node_id))
+            .then_with(|| left.selection.role.cmp(&right.selection.role))
+    });
+    output
+        .capabilities
+        .push(evidence_capsule_capability(&output.records));
+    output
+        .capabilities
+        .extend_from_slice(default_task_capabilities);
+    output.capabilities = merge_capabilities(output.capabilities);
+    output
+        .relationships
+        .extend(projected_relationships(edge_index, &output.records));
+    output.relationships.sort();
+    output.relationships.dedup();
+    output.candidate_audit.sort_by(|left, right| {
+        left.candidate_rank
+            .cmp(&right.candidate_rank)
+            .then_with(|| left.identity.node_id.cmp(&right.identity.node_id))
+    });
+
     let mut request = projection_request(params, SearchIntent::Implement);
-    request.projection = SearchProjection::Evidence;
     request.budget.max_rendered_bytes = None;
     request.budget.max_estimated_tokens = None;
     let plan = projection::plan_projection(
         request,
         ProjectionInput {
-            records: records.to_vec(),
-            ..Default::default()
+            records: output.records,
+            candidate_audit: output.candidate_audit,
+            relationships: output.relationships,
+            omissions: output.omissions,
+            capabilities: output.capabilities,
         },
         reader,
     );
@@ -3367,6 +3546,42 @@ fn projection_role_for_task(role: TaskRole) -> ProjectionRole {
         TaskRole::CallerOrImpact => ProjectionRole::CallerOrImpact,
         TaskRole::ProposalDelta => ProjectionRole::ProposalDelta,
     }
+}
+
+/// Derive the roles an exact graph record can truthfully satisfy. Exact-first
+/// pinning controls priority only; it must not relabel tests or API/state
+/// declarations as editable implementation source.
+fn exact_task_roles(node: &Node) -> BTreeSet<TaskRole> {
+    if default_role(node) == ProjectionRole::Test {
+        return BTreeSet::from([TaskRole::Test]);
+    }
+
+    let mut roles = BTreeSet::new();
+    if matches!(
+        &node.id.kind,
+        NodeKind::Function | NodeKind::Impl | NodeKind::Macro | NodeKind::ApiEndpoint
+    ) {
+        roles.insert(TaskRole::EditableSource);
+    }
+    if matches!(
+        &node.id.kind,
+        NodeKind::Struct
+            | NodeKind::Trait
+            | NodeKind::Enum
+            | NodeKind::TypeAlias
+            | NodeKind::Const
+            | NodeKind::Field
+            | NodeKind::EnumVariant
+            | NodeKind::ProtoMessage
+            | NodeKind::SqlTable
+            | NodeKind::ApiEndpoint
+    ) {
+        roles.insert(TaskRole::DefinitionOrApiState);
+    }
+    if roles.is_empty() {
+        roles.insert(TaskRole::DirectDependency);
+    }
+    roles
 }
 
 fn task_lane_for_role(role: TaskRole) -> TaskLane {
@@ -3468,7 +3683,8 @@ fn live_graph_delta_card(
         &limits,
     )
     .map_err(|error| format!("proposal rejected: {error}"))?;
-    enrich_live_graph_delta(&mut overlay, ctx, edge_index);
+    let source_reader = projection_source_reader(params, ctx.repo_root)?;
+    enrich_live_graph_delta(&mut overlay, ctx, edge_index, &source_reader);
     let mut endpoint_pairs = overlay
         .edge_additions
         .iter()
@@ -3498,10 +3714,275 @@ fn live_graph_delta_card(
     .map_err(|error| error.to_string())
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct SourceBehaviorProfile {
+    features: BTreeMap<graph_delta::BehavioralDeltaKind, BTreeMap<String, u32>>,
+}
+
+impl SourceBehaviorProfile {
+    fn record(&mut self, kind: graph_delta::BehavioralDeltaKind, feature: impl Into<String>) {
+        *self
+            .features
+            .entry(kind)
+            .or_default()
+            .entry(feature.into())
+            .or_default() += 1;
+    }
+
+    fn remove(&mut self, kind: graph_delta::BehavioralDeltaKind, feature: &str) {
+        let Some(features) = self.features.get_mut(&kind) else {
+            return;
+        };
+        let Some(count) = features.get_mut(feature) else {
+            return;
+        };
+        *count = count.saturating_sub(1);
+        if *count == 0 {
+            features.remove(feature);
+        }
+    }
+
+    fn values(&self, kind: graph_delta::BehavioralDeltaKind) -> BTreeSet<String> {
+        self.features
+            .get(&kind)
+            .into_iter()
+            .flat_map(|features| features.iter())
+            .map(|(feature, count)| format!("{feature}:{count}"))
+            .collect()
+    }
+
+    fn shared(&self, other: &Self) -> BTreeSet<String> {
+        behavior_profile_kinds()
+            .into_iter()
+            .flat_map(|kind| {
+                let left = self.features.get(&kind).cloned().unwrap_or_default();
+                let right = other.features.get(&kind).cloned().unwrap_or_default();
+                left.keys()
+                    .filter(|feature| right.contains_key(*feature))
+                    .map(|feature| format!("{}={feature}", behavior_kind_name(kind)))
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+}
+
+fn behavior_profile_kinds() -> [graph_delta::BehavioralDeltaKind; 6] {
+    [
+        graph_delta::BehavioralDeltaKind::BypassedCall,
+        graph_delta::BehavioralDeltaKind::BranchBehavior,
+        graph_delta::BehavioralDeltaKind::Reconciliation,
+        graph_delta::BehavioralDeltaKind::Representation,
+        graph_delta::BehavioralDeltaKind::ErrorPath,
+        graph_delta::BehavioralDeltaKind::StatePropagation,
+    ]
+}
+
+fn behavior_kind_name(kind: graph_delta::BehavioralDeltaKind) -> &'static str {
+    match kind {
+        graph_delta::BehavioralDeltaKind::BypassedCall => "helper_calls",
+        graph_delta::BehavioralDeltaKind::BranchBehavior => "branches",
+        graph_delta::BehavioralDeltaKind::Reconciliation => "reconciliation",
+        graph_delta::BehavioralDeltaKind::Representation => "representation",
+        graph_delta::BehavioralDeltaKind::ErrorPath => "error_paths",
+        graph_delta::BehavioralDeltaKind::StatePropagation => "state_propagation",
+        graph_delta::BehavioralDeltaKind::Other => "other",
+    }
+}
+
+fn source_behavior_profile(
+    node: &Node,
+    reader: &source::SourceReader,
+    edge_index: &ProjectedEdgeIndex<'_>,
+) -> Result<SourceBehaviorProfile, String> {
+    let span =
+        node_source_span(node).ok_or_else(|| "node has no current source span".to_string())?;
+    let text = reader.read(&span).map_err(|error| error.to_string())?.text;
+    let mut profile = SourceBehaviorProfile::default();
+    for edge in edge_index.outgoing(&node.stable_id()) {
+        match &edge.kind {
+            EdgeKind::Calls => profile.record(
+                graph_delta::BehavioralDeltaKind::BypassedCall,
+                edge.to.to_stable_id(),
+            ),
+            EdgeKind::HasField | EdgeKind::References | EdgeKind::ReferencedBy => profile.record(
+                graph_delta::BehavioralDeltaKind::StatePropagation,
+                edge.to.name.clone(),
+            ),
+            _ => {}
+        }
+    }
+    for line in text.lines() {
+        record_text_behavior_features(&mut profile, line, graph_delta::ChangedLineKind::Added);
+    }
+    Ok(profile)
+}
+
+fn behavior_words(text: &str) -> BTreeSet<String> {
+    text.split(|character: char| !(character == '_' || character.is_ascii_alphanumeric()))
+        .filter(|word| !word.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect()
+}
+
+fn record_text_behavior_features(
+    profile: &mut SourceBehaviorProfile,
+    text: &str,
+    change: graph_delta::ChangedLineKind,
+) {
+    let words = behavior_words(text);
+    for (kind, markers) in [
+        (
+            graph_delta::BehavioralDeltaKind::BranchBehavior,
+            &["if", "else", "elif", "match", "switch", "case", "guard"][..],
+        ),
+        (
+            graph_delta::BehavioralDeltaKind::Reconciliation,
+            &[
+                "dedupe",
+                "deduplicate",
+                "merge",
+                "reconcile",
+                "sync",
+                "synchronize",
+            ][..],
+        ),
+        (
+            graph_delta::BehavioralDeltaKind::Representation,
+            &[
+                "encode",
+                "decode",
+                "serialize",
+                "deserialize",
+                "format",
+                "render",
+            ][..],
+        ),
+        (
+            graph_delta::BehavioralDeltaKind::ErrorPath,
+            &[
+                "error", "err", "raise", "throw", "catch", "except", "panic", "bail",
+            ][..],
+        ),
+        (
+            graph_delta::BehavioralDeltaKind::StatePropagation,
+            &["state", "status", "cache", "context", "metadata"][..],
+        ),
+    ] {
+        for marker in markers {
+            if words.contains(*marker) {
+                match change {
+                    graph_delta::ChangedLineKind::Added => profile.record(kind, *marker),
+                    graph_delta::ChangedLineKind::Removed => profile.remove(kind, marker),
+                }
+            }
+        }
+    }
+}
+
+fn apply_proposal_behavior(
+    profile: &mut SourceBehaviorProfile,
+    lines: &[graph_delta::ChangedLineFact],
+    relationships: &[graph_delta::ChangedRelationshipFact],
+) {
+    for line in lines {
+        record_text_behavior_features(profile, &line.text, line.kind);
+        for fact in relationships.iter().filter(|fact| {
+            fact.grounding.path == line.grounding.path
+                && fact.grounding.proposal_line == line.grounding.proposal_line
+        }) {
+            let Some(kind) = (match fact.kind {
+                // Helper calls use only uniquely corroborated overlay edges so
+                // their feature identity is the exact stable target ID.
+                graph_delta::InferredRelationshipKind::Call => None,
+                graph_delta::InferredRelationshipKind::Reference
+                | graph_delta::InferredRelationshipKind::Registration
+                | graph_delta::InferredRelationshipKind::AttributeOrStateReference => {
+                    Some(graph_delta::BehavioralDeltaKind::StatePropagation)
+                }
+            }) else {
+                continue;
+            };
+            match fact.change {
+                graph_delta::ChangedLineKind::Added => profile.record(kind, fact.target.clone()),
+                graph_delta::ChangedLineKind::Removed => profile.remove(kind, &fact.target),
+            }
+        }
+    }
+}
+
+fn source_backed_behavioral_contrasts(
+    proposed: &SourceBehaviorProfile,
+    analogue: &SourceBehaviorProfile,
+    proposal_loci: &BTreeMap<graph_delta::BehavioralDeltaKind, graph_delta::EvidenceGrounding>,
+    current_locus: &graph_delta::EvidenceGrounding,
+    analogue_locus: &graph_delta::EvidenceGrounding,
+) -> Vec<graph_delta::BehavioralDelta> {
+    behavior_profile_kinds()
+        .into_iter()
+        .filter_map(|kind| {
+            let proposed = proposed.values(kind);
+            let existing = analogue.values(kind);
+            if proposed == existing {
+                return None;
+            }
+            let proposal_only = proposed.difference(&existing).cloned().collect::<Vec<_>>();
+            let analogue_only = existing.difference(&proposed).cloned().collect::<Vec<_>>();
+            Some(graph_delta::BehavioralDelta {
+                kind,
+                label: format!(
+                    "{} source-backed contrast: proposal_only=[{}]; analogue_only=[{}]",
+                    behavior_kind_name(kind),
+                    proposal_only.join(","),
+                    analogue_only.join(",")
+                ),
+                changed_locus: proposal_loci.get(&kind).unwrap_or(current_locus).clone(),
+                analogue_locus: Some(analogue_locus.clone()),
+            })
+        })
+        .collect()
+}
+
+fn proposal_behavior_loci(
+    lines: &[graph_delta::ChangedLineFact],
+    relationships: &[graph_delta::ChangedRelationshipFact],
+) -> BTreeMap<graph_delta::BehavioralDeltaKind, graph_delta::EvidenceGrounding> {
+    let mut loci = BTreeMap::new();
+    for line in lines {
+        let grounding = graph_delta::EvidenceGrounding::Proposal(line.grounding.clone());
+        let mut line_profile = SourceBehaviorProfile::default();
+        record_text_behavior_features(
+            &mut line_profile,
+            &line.text,
+            graph_delta::ChangedLineKind::Added,
+        );
+        for kind in line_profile.features.keys() {
+            loci.entry(*kind).or_insert_with(|| grounding.clone());
+        }
+        for fact in relationships.iter().filter(|fact| {
+            fact.grounding.path == line.grounding.path
+                && fact.grounding.proposal_line == line.grounding.proposal_line
+        }) {
+            let kind = match fact.kind {
+                graph_delta::InferredRelationshipKind::Call => {
+                    graph_delta::BehavioralDeltaKind::BypassedCall
+                }
+                graph_delta::InferredRelationshipKind::Reference
+                | graph_delta::InferredRelationshipKind::Registration
+                | graph_delta::InferredRelationshipKind::AttributeOrStateReference => {
+                    graph_delta::BehavioralDeltaKind::StatePropagation
+                }
+            };
+            loci.entry(kind).or_insert_with(|| grounding.clone());
+        }
+    }
+    loci
+}
+
 fn enrich_live_graph_delta(
     overlay: &mut graph_delta::EphemeralOverlay,
     ctx: &SearchContext<'_>,
     edge_index: &ProjectedEdgeIndex<'_>,
+    source_reader: &source::SourceReader,
 ) {
     let mut grounded = BTreeMap::<(String, u32), String>::new();
     let mut changed_nodes = BTreeSet::new();
@@ -3509,18 +3990,7 @@ fn enrich_live_graph_delta(
     for file in &overlay.changed_files {
         for hunk in &file.hunks {
             for line in &hunk.changed_lines {
-                let current_line = match line.kind {
-                    graph_delta::ChangedLineKind::Added => line.grounding.new_line,
-                    graph_delta::ChangedLineKind::Removed => line.grounding.old_line,
-                };
-                let Some(current_line) = current_line else {
-                    misses.push((
-                        line.grounding.clone(),
-                        "changed line has no current coordinate",
-                    ));
-                    continue;
-                };
-                match unique_node_at_line(ctx, &file.path, current_line) {
+                match pre_edit_node_for_changed_line(ctx, file, hunk, line) {
                     Ok(node) => {
                         let id = node.stable_id();
                         grounded.insert(
@@ -3617,15 +4087,68 @@ fn enrich_live_graph_delta(
         }
     }
 
+    let mut changed_lines_by_node = BTreeMap::<String, Vec<graph_delta::ChangedLineFact>>::new();
+    for file in &overlay.changed_files {
+        for hunk in &file.hunks {
+            for line in &hunk.changed_lines {
+                if let Some(id) =
+                    grounded.get(&(line.grounding.path.clone(), line.grounding.proposal_line))
+                {
+                    changed_lines_by_node
+                        .entry(id.clone())
+                        .or_default()
+                        .push(line.clone());
+                }
+            }
+        }
+    }
+    for lines in changed_lines_by_node.values_mut() {
+        lines.sort_by_key(|line| line.grounding.proposal_line);
+        lines.dedup();
+    }
+
     let mut analogue_count = 0usize;
     for changed_id in &changed_nodes {
         let Some(changed) = find_node(ctx.graph_state, changed_id) else {
             continue;
         };
-        let changed_edges = outgoing_edge_kinds(edge_index, changed_id);
         let Some(changed_grounding) = graph_delta_node_grounding(changed) else {
             continue;
         };
+        let Ok(mut proposed_profile) = source_behavior_profile(changed, source_reader, edge_index)
+        else {
+            continue;
+        };
+        let changed_lines = changed_lines_by_node
+            .get(changed_id)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        apply_proposal_behavior(&mut proposed_profile, changed_lines, &overlay.relationships);
+        for removed in overlay
+            .edge_removals
+            .iter()
+            .filter(|edge| edge.from == *changed_id)
+        {
+            let kind = if removed.kind == EdgeKind::Calls.to_string() {
+                graph_delta::BehavioralDeltaKind::BypassedCall
+            } else {
+                graph_delta::BehavioralDeltaKind::StatePropagation
+            };
+            proposed_profile.remove(kind, &removed.to);
+        }
+        for added in overlay
+            .edge_additions
+            .iter()
+            .filter(|edge| edge.key.from == *changed_id)
+        {
+            let kind = if added.key.kind == EdgeKind::Calls.to_string() {
+                graph_delta::BehavioralDeltaKind::BypassedCall
+            } else {
+                graph_delta::BehavioralDeltaKind::StatePropagation
+            };
+            proposed_profile.record(kind, added.key.to.clone());
+        }
+        let proposal_loci = proposal_behavior_loci(changed_lines, &overlay.relationships);
         let mut candidates = ctx
             .graph_state
             .nodes
@@ -3634,17 +4157,21 @@ fn enrich_live_graph_delta(
                 candidate.stable_id() != *changed_id && candidate.id.kind == changed.id.kind
             })
             .filter_map(|candidate| {
-                let candidate_edges = outgoing_edge_kinds(edge_index, &candidate.stable_id());
-                let overlap = candidate_edges.intersection(&changed_edges).count();
-                (overlap > 0).then_some((
-                    std::cmp::Reverse(overlap),
+                let profile = source_behavior_profile(candidate, source_reader, edge_index).ok()?;
+                let shared = proposed_profile.shared(&profile);
+                (!shared.is_empty()).then_some((
+                    std::cmp::Reverse(shared.len()),
                     candidate.stable_id(),
                     candidate,
+                    profile,
+                    shared,
                 ))
             })
             .collect::<Vec<_>>();
         candidates.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
-        for (std::cmp::Reverse(overlap), _, analogue) in candidates.into_iter().take(2) {
+        for (std::cmp::Reverse(_), _, analogue, analogue_profile, shared) in
+            candidates.into_iter().take(2)
+        {
             if analogue_count >= 8 {
                 break;
             }
@@ -3665,20 +4192,19 @@ fn enrich_live_graph_delta(
                     grounding: analogue_grounding.clone(),
                 },
                 similarity_basis: format!(
-                    "same symbol kind and {overlap} shared outgoing typed edge kinds"
+                    "source-backed proposal/analogue behavior shared: {}",
+                    shared.into_iter().collect::<Vec<_>>().join(",")
                 ),
             });
             overlay
                 .behavioral_deltas
-                .push(graph_delta::BehavioralDelta {
-                    kind: graph_delta::BehavioralDeltaKind::Other,
-                    label: format!(
-                        "compare proposed behavior at {} with {}",
-                        changed.id.name, analogue.id.name
-                    ),
-                    changed_locus: changed_grounding.clone(),
-                    analogue_locus: Some(analogue_grounding),
-                });
+                .extend(source_backed_behavioral_contrasts(
+                    &proposed_profile,
+                    &analogue_profile,
+                    &proposal_loci,
+                    &changed_grounding,
+                    &analogue_grounding,
+                ));
         }
     }
 
@@ -3735,7 +4261,9 @@ fn enrich_live_graph_delta(
         } else {
             graph_delta::CapabilityState::Ready
         },
-        format!("retained {analogue_count} source-grounded structural analogues"),
+        format!(
+            "retained {analogue_count} source-backed behavioral analogues with explicit shared/missing feature contrasts"
+        ),
     );
     set_graph_delta_capability(
         &mut overlay.capabilities,
@@ -3751,6 +4279,70 @@ fn enrich_live_graph_delta(
             overlay.edge_removals.len()
         ),
     );
+}
+
+/// Resolve a changed proposal line only against coordinates that exist in the
+/// immutable pre-edit graph. Removed lines have an exact old coordinate.
+/// Added lines instead use the narrowest current node enclosing the hunk's
+/// old range; hunks without pre-edit context remain proposal-only.
+fn pre_edit_node_for_changed_line<'a>(
+    ctx: &'a SearchContext<'_>,
+    file: &graph_delta::ChangedFileFact,
+    hunk: &graph_delta::ChangedHunkFact,
+    line: &graph_delta::ChangedLineFact,
+) -> Result<&'a Node, &'static str> {
+    if let Some(old_line) = line.grounding.old_line {
+        return unique_node_at_line(ctx, &file.path, old_line);
+    }
+    if line.kind != graph_delta::ChangedLineKind::Added || hunk.old_count == 0 {
+        return Err("changed line has no pre-edit coordinate and remains proposal-only");
+    }
+    let new_line = line
+        .grounding
+        .new_line
+        .ok_or("added line has no new hunk coordinate")?;
+    let new_offset = new_line
+        .checked_sub(hunk.new_start)
+        .ok_or("added line precedes its hunk")?;
+    let prior_added = hunk
+        .changed_lines
+        .iter()
+        .filter(|changed| {
+            changed.kind == graph_delta::ChangedLineKind::Added
+                && changed.grounding.proposal_line < line.grounding.proposal_line
+        })
+        .count() as u32;
+    let prior_removed = hunk
+        .changed_lines
+        .iter()
+        .filter(|changed| {
+            changed.kind == graph_delta::ChangedLineKind::Removed
+                && changed.grounding.proposal_line < line.grounding.proposal_line
+        })
+        .count() as u32;
+    let old_gap = hunk
+        .old_start
+        .checked_add(new_offset)
+        .and_then(|value| value.checked_sub(prior_added))
+        .and_then(|value| value.checked_add(prior_removed))
+        .ok_or("added line cannot map to a bounded old-side insertion gap")?;
+    let old_end_exclusive = hunk
+        .old_start
+        .checked_add(hunk.old_count)
+        .ok_or("hunk old range overflows")?;
+    let before = old_gap
+        .checked_sub(1)
+        .filter(|value| *value >= hunk.old_start);
+    let after = (old_gap < old_end_exclusive).then_some(old_gap);
+    let (Some(before), Some(after)) = (before, after) else {
+        return Err("added line lacks old-side context on both sides and remains proposal-only");
+    };
+    let before_node = unique_node_at_line(ctx, &file.path, before)?;
+    let after_node = unique_node_at_line(ctx, &file.path, after)?;
+    if before_node.stable_id() != after_node.stable_id() {
+        return Err("added line crosses pre-edit symbol boundaries and remains proposal-only");
+    }
+    Ok(before_node)
 }
 
 fn unique_node_at_line<'a>(
@@ -3876,14 +4468,6 @@ fn graph_delta_impact_kind(node: &Node, caller: bool) -> graph_delta::ImpactKind
     } else {
         graph_delta::ImpactKind::EditableLocus
     }
-}
-
-fn outgoing_edge_kinds(edge_index: &ProjectedEdgeIndex<'_>, id: &str) -> BTreeSet<String> {
-    edge_index
-        .outgoing(id)
-        .iter()
-        .map(|edge| edge.kind.to_string())
-        .collect()
 }
 
 fn set_graph_delta_capability(
@@ -4309,10 +4893,9 @@ fn graph_delta_grounding_node<'a>(
             unique_node_at_line(ctx, &span.path, span.start_line)
         }
         graph_delta::EvidenceGrounding::Proposal(line) => {
-            let current_line = line
-                .new_line
-                .or(line.old_line)
-                .ok_or("proposal line has no current coordinate")?;
+            let current_line = line.old_line.ok_or(
+                "added proposal line has no exact pre-edit coordinate; it remains proposal-only",
+            )?;
             unique_node_at_line(ctx, &line.path, current_line)
         }
     }
@@ -5704,6 +6287,48 @@ fn projected_relationships(
     relationships.sort();
     relationships.dedup();
     relationships
+}
+
+fn task_future_interaction_signature(
+    selected_ids: &[String],
+    remaining_ids: &[String],
+    edge_index: &ProjectedEdgeIndex<'_>,
+) -> task_context::FutureInteractionSignature {
+    let selected = selected_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    remaining_ids
+        .iter()
+        .map(|remaining_id| {
+            let mut relationships = BTreeSet::new();
+            for selected_id in &selected {
+                for edge in edge_index.outgoing(selected_id) {
+                    let to = edge.to.to_stable_id();
+                    if to == *remaining_id {
+                        relationships.insert((
+                            edge.from.to_stable_id(),
+                            edge.kind.to_string(),
+                            to,
+                            format!("{} {:?}", edge.source, edge.confidence),
+                        ));
+                    }
+                }
+            }
+            for edge in edge_index.outgoing(remaining_id) {
+                let to = edge.to.to_stable_id();
+                if selected.contains(to.as_str()) {
+                    relationships.insert((
+                        edge.from.to_stable_id(),
+                        edge.kind.to_string(),
+                        to,
+                        format!("{} {:?}", edge.source, edge.confidence),
+                    ));
+                }
+            }
+            (remaining_id.clone(), relationships.into_iter().collect())
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12880,5 +13505,219 @@ mod tests {
         assert!(card.contains("graph_delta_route"));
         assert!(!seed_neighbors.contains("role:"));
         assert!(!seed_impact.contains("role:"));
+    }
+
+    #[test]
+    fn acceptance_remediation_task_direction_validation_fails_closed_and_accepts_both() {
+        let mut params = SearchParams {
+            query: Some("change behavior".into()),
+            context_mode: Some("task".into()),
+            direction: Some("sideways".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            validate_search_experience(&params),
+            Err("unknown task-context direction `sideways`; allowed values: incoming, outgoing, both".into())
+        );
+        params.direction = Some("both".into());
+        assert!(validate_search_experience(&params).is_ok());
+    }
+
+    #[test]
+    fn acceptance_remediation_exact_task_roles_preserve_test_and_definition_truth() {
+        let mut test = make_node("test_task_roles", NodeKind::Function, "tests/task.rs");
+        test.metadata.insert("is_test".into(), "true".into());
+        let definition = make_node("TaskState", NodeKind::Struct, "src/task.rs");
+
+        assert_eq!(exact_task_roles(&test), BTreeSet::from([TaskRole::Test]));
+        assert_eq!(
+            task_facet_for_role(*exact_task_roles(&test).first().unwrap()),
+            TaskFacet::Test
+        );
+        assert_eq!(
+            exact_task_roles(&definition),
+            BTreeSet::from([TaskRole::DefinitionOrApiState])
+        );
+        assert_eq!(
+            task_facet_for_role(*exact_task_roles(&definition).first().unwrap()),
+            TaskFacet::ApiOrState
+        );
+    }
+
+    #[test]
+    fn acceptance_remediation_added_line_uses_only_same_symbol_old_side_context() {
+        let mut before = make_node("before", NodeKind::Function, "src/lib.rs");
+        before.line_start = 1;
+        before.line_end = 9;
+        let mut after = make_node("after", NodeKind::Function, "src/lib.rs");
+        after.line_start = 10;
+        after.line_end = 20;
+        let boundary_graph = make_graph_state(vec![before, after]);
+        let repository = tempfile::tempdir().unwrap();
+        let boundary_ctx = make_search_context(&boundary_graph, repository.path());
+        let added = graph_delta::ChangedLineFact {
+            kind: graph_delta::ChangedLineKind::Added,
+            grounding: graph_delta::ProposalLine {
+                root: "local".into(),
+                path: "src/lib.rs".into(),
+                proposal_line: 5,
+                old_line: None,
+                new_line: Some(10),
+            },
+            text: "inserted();".into(),
+        };
+        let hunk = graph_delta::ChangedHunkFact {
+            proposal_header_line: 4,
+            old_start: 9,
+            old_count: 2,
+            new_start: 9,
+            new_count: 3,
+            changed_lines: vec![added.clone()],
+        };
+        let file = graph_delta::ChangedFileFact {
+            root: "local".into(),
+            path: "src/lib.rs".into(),
+            hunks: vec![hunk.clone()],
+        };
+        assert!(pre_edit_node_for_changed_line(&boundary_ctx, &file, &hunk, &added).is_err());
+
+        let mut enclosing = make_node("enclosing", NodeKind::Function, "src/lib.rs");
+        enclosing.line_start = 1;
+        enclosing.line_end = 20;
+        let enclosing_graph = make_graph_state(vec![enclosing]);
+        let enclosing_ctx = make_search_context(&enclosing_graph, repository.path());
+        assert_eq!(
+            pre_edit_node_for_changed_line(&enclosing_ctx, &file, &hunk, &added)
+                .unwrap()
+                .id
+                .name,
+            "enclosing"
+        );
+        let proposal_grounding = graph_delta::EvidenceGrounding::Proposal(added.grounding);
+        assert!(graph_delta_grounding_node(&proposal_grounding, &enclosing_ctx).is_err());
+    }
+
+    #[test]
+    fn acceptance_remediation_source_backed_behavior_contrasts_cover_all_typed_classes_and_loci() {
+        let mut proposed = SourceBehaviorProfile::default();
+        let mut analogue = SourceBehaviorProfile::default();
+        for kind in behavior_profile_kinds() {
+            proposed.record(kind, "shared");
+            analogue.record(kind, "shared");
+            proposed.record(kind, "proposal-only");
+            analogue.record(kind, "analogue-only");
+        }
+        // Whole bodies are classified line-by-line: removing one occurrence
+        // must not erase the same branch behavior retained on another line.
+        record_text_behavior_features(
+            &mut proposed,
+            "if first",
+            graph_delta::ChangedLineKind::Added,
+        );
+        record_text_behavior_features(
+            &mut proposed,
+            "if second",
+            graph_delta::ChangedLineKind::Added,
+        );
+        record_text_behavior_features(
+            &mut proposed,
+            "if first",
+            graph_delta::ChangedLineKind::Removed,
+        );
+        assert!(
+            proposed
+                .values(graph_delta::BehavioralDeltaKind::BranchBehavior)
+                .contains("if:1")
+        );
+
+        let changed = graph_delta::EvidenceGrounding::Proposal(graph_delta::ProposalLine {
+            root: "local".into(),
+            path: "src/lib.rs".into(),
+            proposal_line: 7,
+            old_line: None,
+            new_line: Some(12),
+        });
+        let source = graph_delta::EvidenceGrounding::CurrentSource(graph_delta::SourceSpan {
+            root: "local".into(),
+            path: "src/analogue.rs".into(),
+            start_line: 3,
+            end_line: 9,
+        });
+        let current = graph_delta::EvidenceGrounding::CurrentSource(graph_delta::SourceSpan {
+            root: "local".into(),
+            path: "src/lib.rs".into(),
+            start_line: 10,
+            end_line: 20,
+        });
+        let helper_changed = graph_delta::EvidenceGrounding::Proposal(graph_delta::ProposalLine {
+            root: "local".into(),
+            path: "src/lib.rs".into(),
+            proposal_line: 8,
+            old_line: Some(13),
+            new_line: None,
+        });
+        let loci = BTreeMap::from([
+            (graph_delta::BehavioralDeltaKind::BranchBehavior, changed),
+            (
+                graph_delta::BehavioralDeltaKind::BypassedCall,
+                helper_changed,
+            ),
+        ]);
+        let deltas =
+            source_backed_behavioral_contrasts(&proposed, &analogue, &loci, &current, &source);
+        assert_eq!(deltas.len(), 6);
+        assert_eq!(
+            deltas
+                .iter()
+                .map(|delta| delta.kind)
+                .collect::<BTreeSet<_>>(),
+            behavior_profile_kinds().into_iter().collect()
+        );
+        assert!(deltas.iter().all(|delta| {
+            delta.kind != graph_delta::BehavioralDeltaKind::Other
+                && matches!(
+                    delta.analogue_locus,
+                    Some(graph_delta::EvidenceGrounding::CurrentSource(_))
+                )
+                && delta.label.contains("proposal_only")
+                && delta.label.contains("analogue_only")
+        }));
+        assert!(deltas.iter().any(|delta| {
+            delta.kind == graph_delta::BehavioralDeltaKind::BranchBehavior
+                && matches!(
+                    delta.changed_locus,
+                    graph_delta::EvidenceGrounding::Proposal(graph_delta::ProposalLine {
+                        proposal_line: 7,
+                        ..
+                    })
+                )
+        }));
+        assert!(deltas.iter().any(|delta| {
+            delta.kind == graph_delta::BehavioralDeltaKind::BypassedCall
+                && matches!(
+                    delta.changed_locus,
+                    graph_delta::EvidenceGrounding::Proposal(graph_delta::ProposalLine {
+                        proposal_line: 8,
+                        ..
+                    })
+                )
+        }));
+        assert!(
+            deltas
+                .iter()
+                .filter(|delta| !matches!(
+                    delta.kind,
+                    graph_delta::BehavioralDeltaKind::BranchBehavior
+                        | graph_delta::BehavioralDeltaKind::BypassedCall
+                ))
+                .all(|delta| matches!(
+                    delta.changed_locus,
+                    graph_delta::EvidenceGrounding::CurrentSource(_)
+                ))
+        );
+        assert_eq!(
+            deltas,
+            source_backed_behavioral_contrasts(&proposed, &analogue, &loci, &current, &source)
+        );
     }
 }

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -298,6 +298,10 @@ fn sealed_semantic_bundle() -> bool {
         && option_env!("RNA_SEMANTIC_BUNDLE_BUILD") == Some("1")
 }
 
+const fn use_verified_reranker_loader(strict_semantic: bool, sealed_bundle: bool) -> bool {
+    strict_semantic || sealed_bundle
+}
+
 fn semantic_asset_seeding() -> bool {
     std::env::var("RNA_SEMANTIC_ASSET_SEEDING").as_deref() == Ok("1")
 }
@@ -4355,6 +4359,15 @@ fn unique_node_at_line<'a>(
         .nodes
         .iter()
         .filter(|node| node.id.file.to_string_lossy().replace('\\', "/") == path)
+        // Persisted document-symbol nodes prove the LSP response survived
+        // reopen; they intentionally duplicate the source symbol and must not
+        // compete with that symbol as proposal grounding.
+        .filter(|node| {
+            !matches!(
+                &node.id.kind,
+                NodeKind::Other(kind) if kind == "lsp_document_symbol"
+            )
+        })
         .filter(|node| {
             u32::try_from(node.line_start).is_ok_and(|start| start <= line)
                 && u32::try_from(node.line_end).is_ok_and(|end| end >= line)
@@ -7423,8 +7436,10 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
         // executor during ONNX model inference (and possible first-time
         // model download/initialization).
         let query_owned = query_str.to_string();
+        let verified_reranker =
+            use_verified_reranker_loader(strict_semantic, sealed_semantic_bundle());
         let rerank_result = tokio::task::spawn_blocking(move || {
-            if strict_semantic {
+            if verified_reranker {
                 rerank_results_strict(&query_owned, &candidates)
             } else {
                 rerank_results(&query_owned, &candidates)
@@ -13595,6 +13610,36 @@ mod tests {
         );
         let proposal_grounding = graph_delta::EvidenceGrounding::Proposal(added.grounding);
         assert!(graph_delta_grounding_node(&proposal_grounding, &enclosing_ctx).is_err());
+    }
+
+    #[test]
+    fn acceptance_delivery_changed_line_prefers_source_over_lsp_document_symbol_proof() {
+        let mut source = make_node("hello", NodeKind::Function, "lib.rs");
+        source.line_start = 2;
+        source.line_end = 2;
+        let mut proof = make_node(
+            "hello@proof",
+            NodeKind::Other("lsp_document_symbol".into()),
+            "lib.rs",
+        );
+        proof.line_start = 2;
+        proof.line_end = 2;
+        let graph = make_graph_state(vec![source.clone(), proof]);
+        let repository = tempfile::tempdir().unwrap();
+        let ctx = make_search_context(&graph, repository.path());
+
+        assert_eq!(
+            unique_node_at_line(&ctx, "lib.rs", 2).unwrap().stable_id(),
+            source.stable_id()
+        );
+    }
+
+    #[test]
+    fn acceptance_delivery_sealed_product_queries_use_verified_reranker_loader() {
+        assert!(!use_verified_reranker_loader(false, false));
+        assert!(use_verified_reranker_loader(true, false));
+        assert!(use_verified_reranker_loader(false, true));
+        assert!(use_verified_reranker_loader(true, true));
     }
 
     #[test]

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -306,25 +306,16 @@ fn strict_semantic_requested(params: &SearchParams) -> bool {
         .search_mode
         .as_deref()
         .is_some_and(|mode| mode.trim().eq_ignore_ascii_case(STRICT_SEMANTIC_MODE));
-    // The frozen #779 packet generator predates `search_mode=strict`, so the
-    // sealed artifact must still recognize its exact CLI request shape. Do not
-    // broaden that compatibility hook to ordinary product searches merely
-    // because they happen to run from the same artifact.
-    let sealed_bundle_default = sealed_semantic_bundle() && frozen_implicit_strict_request(params);
+    // The frozen #779 packet generator and the artifact's offline qualification
+    // probe predate `search_mode=strict`, so eligible bare queries from a sealed
+    // bundle must retain implicit strict behavior. Explicit product-context
+    // controls opt into the separate non-strict projection pipeline.
+    let sealed_bundle_default = sealed_semantic_bundle() && implicit_strict_request(params);
     explicit || sealed_bundle_default
 }
 
-fn frozen_implicit_strict_request(params: &SearchParams) -> bool {
-    params
-        .search_mode
-        .as_deref()
-        .is_some_and(|mode| mode.trim().eq_ignore_ascii_case("hybrid"))
-        && params.rerank
-        && params.limit == Some(20)
-        && !params.include_artifacts
-        && params.include_markdown
-        && params.compact
-        && legacy_product_controls(params).is_none()
+fn implicit_strict_request(params: &SearchParams) -> bool {
+    legacy_product_controls(params).is_none()
         && params.context_mode.is_none()
         && params.normalized_mode().is_none()
         && params
@@ -9890,7 +9881,7 @@ mod tests {
     }
 
     #[test]
-    fn sealed_implicit_strict_is_limited_to_frozen_packet_shape() {
+    fn sealed_implicit_strict_preserves_qualification_and_excludes_product_controls() {
         let frozen = SearchParams {
             query: Some("registered frozen query".into()),
             search_mode: Some("hybrid".into()),
@@ -9901,13 +9892,15 @@ mod tests {
             compact: true,
             ..Default::default()
         };
-        assert!(frozen_implicit_strict_request(&frozen));
+        assert!(implicit_strict_request(&frozen));
 
-        let ordinary = SearchParams {
-            query: frozen.query.clone(),
+        let offline_probe = SearchParams {
+            query: Some("function returns value".into()),
+            limit: Some(10),
+            compact: true,
             ..Default::default()
         };
-        assert!(!frozen_implicit_strict_request(&ordinary));
+        assert!(implicit_strict_request(&offline_probe));
 
         for product in [
             SearchParams {
@@ -9924,7 +9917,7 @@ mod tests {
             },
         ] {
             assert!(
-                !frozen_implicit_strict_request(&product),
+                !implicit_strict_request(&product),
                 "product controls must never enter the frozen implicit strict path"
             );
         }

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -17,7 +17,7 @@ use crate::embed::{
     SearchOutcome, SearchResult, SearchScoreProvenance, TestResultPolicy,
 };
 use crate::graph::index::GraphIndex;
-use crate::graph::{EdgeKind, ExtractionSource, Node, NodeKind};
+use crate::graph::{Edge, EdgeKind, ExtractionSource, Node, NodeKind};
 use crate::ranking;
 use crate::server::handlers::parse_search_mode;
 use crate::server::helpers::{
@@ -306,7 +306,25 @@ fn strict_semantic_requested(params: &SearchParams) -> bool {
         .search_mode
         .as_deref()
         .is_some_and(|mode| mode.trim().eq_ignore_ascii_case(STRICT_SEMANTIC_MODE));
-    let sealed_bundle_default = sealed_semantic_bundle()
+    // The frozen #779 packet generator predates `search_mode=strict`, so the
+    // sealed artifact must still recognize its exact CLI request shape. Do not
+    // broaden that compatibility hook to ordinary product searches merely
+    // because they happen to run from the same artifact.
+    let sealed_bundle_default = sealed_semantic_bundle() && frozen_implicit_strict_request(params);
+    explicit || sealed_bundle_default
+}
+
+fn frozen_implicit_strict_request(params: &SearchParams) -> bool {
+    params
+        .search_mode
+        .as_deref()
+        .is_some_and(|mode| mode.trim().eq_ignore_ascii_case("hybrid"))
+        && params.rerank
+        && params.limit == Some(20)
+        && !params.include_artifacts
+        && params.include_markdown
+        && params.compact
+        && legacy_product_controls(params).is_none()
         && params.context_mode.is_none()
         && params.normalized_mode().is_none()
         && params
@@ -317,8 +335,7 @@ fn strict_semantic_requested(params: &SearchParams) -> bool {
             .node
             .as_deref()
             .is_none_or(|node| node.trim().is_empty())
-        && params.nodes.as_ref().is_none_or(|nodes| nodes.is_empty());
-    explicit || sealed_bundle_default
+        && params.nodes.as_ref().is_none_or(|nodes| nodes.is_empty())
 }
 
 fn strict_semantic_failure(reason: &str) -> String {
@@ -1565,8 +1582,9 @@ fn selected_for_hydration(
 }
 
 async fn projected_search(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
+    let edge_index = ProjectedEdgeIndex::new(ctx.graph_state);
     if params.context_mode.as_deref() == Some("graph-delta-beta") {
-        return projected_graph_delta(params, ctx).await;
+        return projected_graph_delta(params, ctx, &edge_index).await;
     }
     let intent = if params.context_mode.as_deref() == Some("task") {
         SearchIntent::Implement
@@ -1576,7 +1594,7 @@ async fn projected_search(params: &SearchParams, ctx: &SearchContext<'_>) -> Str
     let request = projection_request(params, intent);
     let (mut records, mut relationships, mut capabilities, mut omissions, mut candidate_audit) =
         if params.context_mode.as_deref() == Some("task") {
-            match task_records(params, ctx).await {
+            match task_records(params, ctx, &edge_index).await {
                 Ok(output) => (
                     output.records,
                     output.relationships,
@@ -1588,7 +1606,7 @@ async fn projected_search(params: &SearchParams, ctx: &SearchContext<'_>) -> Str
             }
         } else {
             let (fused, capabilities, product_score_audit) =
-                match projected_fused_candidates(params, ctx).await {
+                match projected_fused_candidates(params, ctx, &edge_index).await {
                     Ok(result) => result,
                     Err(error) => return format!("Search projection failed: {error}."),
                 };
@@ -1685,7 +1703,7 @@ async fn projected_search(params: &SearchParams, ctx: &SearchContext<'_>) -> Str
     });
     capabilities.extend(default_capabilities(ctx, request.projection).await);
     capabilities = merge_capabilities(capabilities);
-    relationships.extend(projected_relationships(ctx.graph_state, &records));
+    relationships.extend(projected_relationships(&edge_index, &records));
     relationships.sort();
     relationships.dedup();
     candidate_audit.sort_by(|left, right| {
@@ -2392,6 +2410,7 @@ struct TaskAssembly {
 async fn task_records(
     params: &SearchParams,
     ctx: &SearchContext<'_>,
+    edge_index: &ProjectedEdgeIndex<'_>,
 ) -> Result<TaskAdapterOutput, String> {
     let task = task_context::parse_task(params.query.as_deref().unwrap_or_default())
         .map_err(|error| error.to_string())?;
@@ -2525,7 +2544,7 @@ async fn task_records(
         lane_params.nodes = None;
         lane_params.mode = None;
         let (fused, capabilities, lane_score_audit) =
-            projected_fused_candidates(&lane_params, ctx).await?;
+            projected_fused_candidates(&lane_params, ctx, edge_index).await?;
         merge_product_score_audit(&mut product_score_audit, lane_score_audit);
         let observed = fused.len().min(TASK_LANE_CANDIDATE_LIMIT);
         let mut eligible = 0usize;
@@ -2539,7 +2558,8 @@ async fn task_records(
                 rejected += 1;
                 continue;
             };
-            match task_lane_candidate_evidence(node, role, &assemblies, ctx.graph_state) {
+            match task_lane_candidate_evidence(node, role, &assemblies, ctx.graph_state, edge_index)
+            {
                 Ok(role_evidence) => {
                     eligible += 1;
                     merge_task_assembly(
@@ -2612,7 +2632,7 @@ async fn task_records(
         proposal_params.nodes = None;
         proposal_params.mode = None;
         let (fused, capabilities, proposal_score_audit) =
-            projected_fused_candidates(&proposal_params, ctx).await?;
+            projected_fused_candidates(&proposal_params, ctx, edge_index).await?;
         merge_product_score_audit(&mut product_score_audit, proposal_score_audit);
         let observed = fused.len().min(TASK_LANE_CANDIDATE_LIMIT);
         for (rank, candidate) in fused
@@ -2643,7 +2663,7 @@ async fn task_records(
                 "independently queried proposal evidence and retained {observed} bounded candidates"
             ),
         });
-        match live_graph_delta_card(params, ctx) {
+        match live_graph_delta_card(params, ctx, edge_index) {
             Ok(card) => {
                 for (rank, impact) in card.impacted_loci.iter().enumerate() {
                     let Ok(node) = graph_delta_grounding_node(&impact.grounding, ctx) else {
@@ -2727,7 +2747,13 @@ async fn task_records(
         }
     }
 
-    expand_task_graph(params, ctx, &mut assemblies, &mut output.relationships);
+    expand_task_graph(
+        params,
+        ctx,
+        edge_index,
+        &mut assemblies,
+        &mut output.relationships,
+    );
 
     if assemblies.len() > task_context::MAX_SELECTION_CANDIDATES {
         return Err(format!(
@@ -2741,6 +2767,16 @@ async fn task_records(
     let mut typed = BTreeMap::<String, TaskEvidenceCandidate>::new();
     for (id, assembly) in &assemblies {
         let Some(node) = candidate_nodes.get(id).copied() else {
+            continue;
+        };
+        let Some(source) = node_source_span(node) else {
+            output.omissions.push(ProjectionOmission {
+                record_id: Some(id.clone()),
+                source: None,
+                code: OmissionCode::MissingSource,
+                detail: "task candidate has no valid current source anchor and was omitted before selection"
+                    .into(),
+            });
             continue;
         };
         let mut records = Vec::new();
@@ -2767,7 +2803,6 @@ async fn task_records(
             records.push(selected);
         }
         let rendered_cost = rendered_task_bundle_cost(params, &reader, &records)?;
-        let source = node_source_span(node);
         typed.insert(
             id.clone(),
             TaskEvidenceCandidate {
@@ -2778,9 +2813,9 @@ async fn task_records(
                 rendered_cost,
                 exact_reference: assembly.exact_reference.clone(),
                 source: SourceAnchor {
-                    path: node.id.file.to_string_lossy().replace('\\', "/"),
-                    start_line: source.as_ref().map_or(1, |span| span.start_line),
-                    end_line: source.as_ref().map_or(1, |span| span.end_line),
+                    path: source.path,
+                    start_line: source.start_line,
+                    end_line: source.end_line,
                 },
                 channel_rank: assembly.channel_rank,
             },
@@ -2909,6 +2944,7 @@ fn task_lane_candidate_evidence(
     role: TaskRole,
     assemblies: &BTreeMap<String, TaskAssembly>,
     graph: &GraphState,
+    edge_index: &ProjectedEdgeIndex<'_>,
 ) -> Result<String, String> {
     let span = node_source_span(node)
         .ok_or_else(|| "candidate has no valid current source span".to_string())?;
@@ -2988,10 +3024,9 @@ fn task_lane_candidate_evidence(
             {
                 anchors.retain(|(_, assembly)| assembly.exact_reference.is_some());
             }
-            let candidate_edges = graph
-                .edges
+            let candidate_edges = edge_index
+                .outgoing(&candidate_id)
                 .iter()
-                .filter(|edge| edge.from.to_stable_id() == candidate_id)
                 .map(|edge| (edge.kind.to_string(), edge.to.to_stable_id()))
                 .collect::<BTreeSet<_>>();
             let mut corroborated = anchors
@@ -3001,10 +3036,9 @@ fn task_lane_candidate_evidence(
                     if anchor.id.kind != node.id.kind {
                         return None;
                     }
-                    let anchor_edges = graph
-                        .edges
+                    let anchor_edges = edge_index
+                        .outgoing(anchor_id)
                         .iter()
-                        .filter(|edge| edge.from.to_stable_id() == anchor_id.as_str())
                         .map(|edge| (edge.kind.to_string(), edge.to.to_stable_id()))
                         .collect::<BTreeSet<_>>();
                     let shared = candidate_edges
@@ -3139,6 +3173,7 @@ fn merge_task_assembly(
 fn expand_task_graph(
     params: &SearchParams,
     ctx: &SearchContext<'_>,
+    edge_index: &ProjectedEdgeIndex<'_>,
     assemblies: &mut BTreeMap<String, TaskAssembly>,
     relationships: &mut Vec<ProjectedRelationship>,
 ) {
@@ -3167,20 +3202,27 @@ fn expand_task_graph(
             continue;
         }
         let mut adjacent = Vec::new();
-        for edge in &ctx.graph_state.edges {
+        for edge in edge_index.outgoing(&current) {
             if allowed
                 .as_ref()
                 .is_some_and(|allowed| !allowed.contains(&edge.kind))
             {
                 continue;
             }
-            let from = edge.from.to_stable_id();
             let to = edge.to.to_stable_id();
-            if outgoing && from == current {
+            if outgoing {
                 adjacent.push((to.clone(), true, edge));
             }
-            if incoming && to == current {
-                adjacent.push((from, false, edge));
+        }
+        for edge in edge_index.incoming(&current) {
+            if allowed
+                .as_ref()
+                .is_some_and(|allowed| !allowed.contains(&edge.kind))
+            {
+                continue;
+            }
+            if incoming {
+                adjacent.push((edge.from.to_stable_id(), false, edge));
             }
         }
         adjacent.sort_by(|left, right| {
@@ -3388,8 +3430,12 @@ fn task_selection_reason(reason: &TaskSelectionReason) -> String {
     }
 }
 
-async fn projected_graph_delta(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
-    let card = match live_graph_delta_card(params, ctx) {
+async fn projected_graph_delta(
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+    edge_index: &ProjectedEdgeIndex<'_>,
+) -> String {
+    let card = match live_graph_delta_card(params, ctx, edge_index) {
         Ok(card) => card,
         Err(error) => return format!("Graph-delta analysis failed: {error}."),
     };
@@ -3412,6 +3458,7 @@ async fn projected_graph_delta(params: &SearchParams, ctx: &SearchContext<'_>) -
 fn live_graph_delta_card(
     params: &SearchParams,
     ctx: &SearchContext<'_>,
+    edge_index: &ProjectedEdgeIndex<'_>,
 ) -> Result<graph_delta::GraphDeltaCard, String> {
     let proposal = params.proposal.clone().unwrap_or_default();
     let root = graph_delta_request_root(params, ctx)?;
@@ -3430,7 +3477,7 @@ fn live_graph_delta_card(
         &limits,
     )
     .map_err(|error| format!("proposal rejected: {error}"))?;
-    enrich_live_graph_delta(&mut overlay, ctx);
+    enrich_live_graph_delta(&mut overlay, ctx, edge_index);
     let mut endpoint_pairs = overlay
         .edge_additions
         .iter()
@@ -3460,7 +3507,11 @@ fn live_graph_delta_card(
     .map_err(|error| error.to_string())
 }
 
-fn enrich_live_graph_delta(overlay: &mut graph_delta::EphemeralOverlay, ctx: &SearchContext<'_>) {
+fn enrich_live_graph_delta(
+    overlay: &mut graph_delta::EphemeralOverlay,
+    ctx: &SearchContext<'_>,
+    edge_index: &ProjectedEdgeIndex<'_>,
+) {
     let mut grounded = BTreeMap::<(String, u32), String>::new();
     let mut changed_nodes = BTreeSet::new();
     let mut misses = Vec::new();
@@ -3517,16 +3568,12 @@ fn enrich_live_graph_delta(overlay: &mut graph_delta::EphemeralOverlay, ctx: &Se
             ));
             continue;
         };
-        match corroborate_changed_relationship(fact, source_id, ctx) {
+        match corroborate_changed_relationship(fact, source_id, ctx, edge_index) {
             Ok(edge) => {
                 inferred_relationships += 1;
                 match fact.change {
                     graph_delta::ChangedLineKind::Added => {
-                        if !ctx.graph_state.edges.iter().any(|current| {
-                            current.from.to_stable_id() == edge.key.from
-                                && current.to.to_stable_id() == edge.key.to
-                                && current.kind.to_string() == edge.key.kind
-                        }) {
+                        if !edge_index.contains(&edge.key.from, &edge.key.to, &edge.key.kind) {
                             overlay.edge_additions.push(edge);
                         }
                     }
@@ -3549,16 +3596,18 @@ fn enrich_live_graph_delta(overlay: &mut graph_delta::EphemeralOverlay, ctx: &Se
         if depth >= 2 || visited.len() >= TASK_GRAPH_CANDIDATE_LIMIT {
             continue;
         }
-        for edge in &ctx.graph_state.edges {
-            let from = edge.from.to_stable_id();
-            let to = edge.to.to_stable_id();
-            let (neighbor, caller) = if from == current {
-                (to, false)
-            } else if to == current {
-                (from, true)
-            } else {
-                continue;
-            };
+        let adjacent = edge_index
+            .outgoing(&current)
+            .iter()
+            .map(|edge| (edge.to.to_stable_id(), false))
+            .chain(
+                edge_index
+                    .incoming(&current)
+                    .iter()
+                    .map(|edge| (edge.from.to_stable_id(), true)),
+            )
+            .collect::<Vec<_>>();
+        for (neighbor, caller) in adjacent {
             if !visited.insert(neighbor.clone()) {
                 continue;
             }
@@ -3582,7 +3631,7 @@ fn enrich_live_graph_delta(overlay: &mut graph_delta::EphemeralOverlay, ctx: &Se
         let Some(changed) = find_node(ctx.graph_state, changed_id) else {
             continue;
         };
-        let changed_edges = outgoing_edge_kinds(ctx.graph_state, changed_id);
+        let changed_edges = outgoing_edge_kinds(edge_index, changed_id);
         let Some(changed_grounding) = graph_delta_node_grounding(changed) else {
             continue;
         };
@@ -3594,7 +3643,7 @@ fn enrich_live_graph_delta(overlay: &mut graph_delta::EphemeralOverlay, ctx: &Se
                 candidate.stable_id() != *changed_id && candidate.id.kind == changed.id.kind
             })
             .filter_map(|candidate| {
-                let candidate_edges = outgoing_edge_kinds(ctx.graph_state, &candidate.stable_id());
+                let candidate_edges = outgoing_edge_kinds(edge_index, &candidate.stable_id());
                 let overlap = candidate_edges.intersection(&changed_edges).count();
                 (overlap > 0).then_some((
                     std::cmp::Reverse(overlap),
@@ -3752,6 +3801,7 @@ fn corroborate_changed_relationship(
     fact: &graph_delta::ChangedRelationshipFact,
     source_id: &str,
     ctx: &SearchContext<'_>,
+    edge_index: &ProjectedEdgeIndex<'_>,
 ) -> Result<graph_delta::WeightedEdge, &'static str> {
     let mut matches = ctx
         .graph_state
@@ -3786,11 +3836,7 @@ fn corroborate_changed_relationship(
         kind: fact.kind.edge_kind().to_string(),
     };
     if fact.change == graph_delta::ChangedLineKind::Removed
-        && !ctx.graph_state.edges.iter().any(|edge| {
-            edge.from.to_stable_id() == key.from
-                && edge.to.to_stable_id() == key.to
-                && edge.kind.to_string() == key.kind
-        })
+        && !edge_index.contains(&key.from, &key.to, &key.kind)
     {
         return Err("removed relationship is not corroborated by a persisted current edge");
     }
@@ -3841,11 +3887,10 @@ fn graph_delta_impact_kind(node: &Node, caller: bool) -> graph_delta::ImpactKind
     }
 }
 
-fn outgoing_edge_kinds(graph: &GraphState, id: &str) -> BTreeSet<String> {
-    graph
-        .edges
+fn outgoing_edge_kinds(edge_index: &ProjectedEdgeIndex<'_>, id: &str) -> BTreeSet<String> {
+    edge_index
+        .outgoing(id)
         .iter()
-        .filter(|edge| edge.from.to_stable_id() == id)
         .map(|edge| edge.kind.to_string())
         .collect()
 }
@@ -4466,6 +4511,7 @@ fn render_projected_input(
 async fn projected_fused_candidates(
     params: &SearchParams,
     ctx: &SearchContext<'_>,
+    edge_index: &ProjectedEdgeIndex<'_>,
 ) -> Result<
     (
         Vec<FusedCandidate>,
@@ -4621,7 +4667,7 @@ async fn projected_fused_candidates(
                 .map(|node| {
                     RawCandidateScore::new(
                         node.stable_id(),
-                        edge_degree(ctx.graph_state, node) as f64,
+                        edge_index.degree(&node.stable_id()) as f64,
                     )
                 })
                 .collect(),
@@ -4634,8 +4680,8 @@ async fn projected_fused_candidates(
             graph_ids
                 .into_iter()
                 .filter_map(|id| {
-                    find_node(ctx.graph_state, &id).map(|node| {
-                        RawCandidateScore::new(id, edge_degree(ctx.graph_state, node) as f64)
+                    find_node(ctx.graph_state, &id).map(|_node| {
+                        RawCandidateScore::new(id.clone(), edge_index.degree(&id) as f64)
                     })
                 })
                 .collect(),
@@ -4802,16 +4848,55 @@ fn lexical_score(node: &Node, query: &str) -> f64 {
     }
 }
 
-fn edge_degree(graph: &GraphState, node: &Node) -> usize {
-    graph
-        .edges
-        .iter()
-        .filter(|edge| edge.from == node.id || edge.to == node.id)
-        .count()
+struct ProjectedEdgeIndex<'a> {
+    outgoing: HashMap<String, Vec<&'a Edge>>,
+    incoming: HashMap<String, Vec<&'a Edge>>,
+    degrees: HashMap<String, usize>,
+}
+
+impl<'a> ProjectedEdgeIndex<'a> {
+    fn new(graph: &'a GraphState) -> Self {
+        let mut outgoing = HashMap::<String, Vec<&Edge>>::new();
+        let mut incoming = HashMap::<String, Vec<&Edge>>::new();
+        let mut degrees = HashMap::<String, usize>::new();
+        for edge in &graph.edges {
+            let from = edge.from.to_stable_id();
+            let to = edge.to.to_stable_id();
+            outgoing.entry(from.clone()).or_default().push(edge);
+            incoming.entry(to.clone()).or_default().push(edge);
+            *degrees.entry(from.clone()).or_default() += 1;
+            if to != from {
+                *degrees.entry(to).or_default() += 1;
+            }
+        }
+        Self {
+            outgoing,
+            incoming,
+            degrees,
+        }
+    }
+
+    fn outgoing(&self, id: &str) -> &[&'a Edge] {
+        self.outgoing.get(id).map(Vec::as_slice).unwrap_or_default()
+    }
+
+    fn incoming(&self, id: &str) -> &[&'a Edge] {
+        self.incoming.get(id).map(Vec::as_slice).unwrap_or_default()
+    }
+
+    fn degree(&self, id: &str) -> usize {
+        self.degrees.get(id).copied().unwrap_or_default()
+    }
+
+    fn contains(&self, from: &str, to: &str, kind: &str) -> bool {
+        self.outgoing(from)
+            .iter()
+            .any(|edge| edge.to.to_stable_id() == to && edge.kind.to_string() == kind)
+    }
 }
 
 fn find_node<'a>(graph: &'a GraphState, id: &str) -> Option<&'a Node> {
-    graph.nodes.iter().find(|node| node.stable_id() == id)
+    graph.node_by_stable_id(id, graph.node_index_map())
 }
 
 fn symbol_summary(node: &Node) -> SymbolSummary {
@@ -5606,29 +5691,25 @@ fn merge_capabilities(capabilities: Vec<CapabilityStatus>) -> Vec<CapabilityStat
 }
 
 fn projected_relationships(
-    graph: &GraphState,
+    edge_index: &ProjectedEdgeIndex<'_>,
     records: &[SelectedRecord],
 ) -> Vec<ProjectedRelationship> {
     let ids: BTreeSet<_> = records
         .iter()
         .map(|record| record.identity.node_id.as_str())
         .collect();
-    let mut relationships: Vec<_> = graph
-        .edges
-        .iter()
-        .filter_map(|edge| {
-            let from = edge.from.to_stable_id();
+    let mut relationships = Vec::new();
+    for id in &ids {
+        relationships.extend(edge_index.outgoing(id).iter().filter_map(|edge| {
             let to = edge.to.to_stable_id();
-            (ids.contains(from.as_str()) && ids.contains(to.as_str())).then(|| {
-                ProjectedRelationship {
-                    from,
-                    kind: edge.kind.to_string(),
-                    to,
-                    reason: format!("{} {:?}", edge.source, edge.confidence),
-                }
+            ids.contains(to.as_str()).then(|| ProjectedRelationship {
+                from: edge.from.to_stable_id(),
+                kind: edge.kind.to_string(),
+                to,
+                reason: format!("{} {:?}", edge.source, edge.confidence),
             })
-        })
-        .collect();
+        }));
+    }
     relationships.sort();
     relationships.dedup();
     relationships
@@ -9808,6 +9889,47 @@ mod tests {
         assert!(strict_semantic_requested(&strict));
     }
 
+    #[test]
+    fn sealed_implicit_strict_is_limited_to_frozen_packet_shape() {
+        let frozen = SearchParams {
+            query: Some("registered frozen query".into()),
+            search_mode: Some("hybrid".into()),
+            rerank: true,
+            limit: Some(20),
+            include_artifacts: false,
+            include_markdown: true,
+            compact: true,
+            ..Default::default()
+        };
+        assert!(frozen_implicit_strict_request(&frozen));
+
+        let ordinary = SearchParams {
+            query: frozen.query.clone(),
+            ..Default::default()
+        };
+        assert!(!frozen_implicit_strict_request(&ordinary));
+
+        for product in [
+            SearchParams {
+                projection: Some("agent".into()),
+                ..frozen.clone()
+            },
+            SearchParams {
+                context_mode: Some("task".into()),
+                ..frozen.clone()
+            },
+            SearchParams {
+                body_policy: Some("signature_only".into()),
+                ..frozen.clone()
+            },
+        ] {
+            assert!(
+                !frozen_implicit_strict_request(&product),
+                "product controls must never enter the frozen implicit strict path"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn strict_semantic_search_rejects_an_unsealed_binary_without_fallback() {
         let gs = make_graph_state(vec![make_node(
@@ -12019,6 +12141,7 @@ mod tests {
         nodes.push(target);
         let graph = make_graph_state(nodes);
         let ctx = make_search_context(&graph, repository.path());
+        let edge_index = ProjectedEdgeIndex::new(&graph);
         let output = task_records(
             &SearchParams {
                 query: Some("Fix `target_symbol` behavior and add a regression test".into()),
@@ -12028,6 +12151,7 @@ mod tests {
                 ..Default::default()
             },
             &ctx,
+            &edge_index,
         )
         .await
         .unwrap();
@@ -12040,6 +12164,68 @@ mod tests {
         assert!(output.capabilities.iter().any(|capability| {
             capability.capability == "task_exact_reference_resolution"
                 && capability.state == CapabilityState::Ready
+        }));
+    }
+
+    #[tokio::test]
+    async fn task_evidence_omits_source_less_graph_candidate_without_failing_valid_records() {
+        let repository = tempfile::tempdir().unwrap();
+        std::fs::write(
+            repository.path().join("lib.rs"),
+            "fn hello() {}\nfn test_hello() {}\n",
+        )
+        .unwrap();
+        let mut hello = make_node("hello", NodeKind::Function, "lib.rs");
+        hello.line_start = 1;
+        hello.line_end = 1;
+        let mut test = make_node("test_hello", NodeKind::Function, "lib.rs");
+        test.line_start = 2;
+        test.line_end = 2;
+        test.metadata.insert("is_test".into(), "true".into());
+        let source_less_module = make_node("lib", NodeKind::Module, "lib.rs");
+        let source_less_id = source_less_module.stable_id();
+        let graph = make_graph_state_with_edges(
+            vec![hello.clone(), test.clone(), source_less_module],
+            vec![make_edge(
+                &hello,
+                &make_node("lib", NodeKind::Module, "lib.rs"),
+                EdgeKind::DependsOn,
+            )],
+        );
+        let ctx = make_search_context(&graph, repository.path());
+        let edge_index = ProjectedEdgeIndex::new(&graph);
+        let output = task_records(
+            &SearchParams {
+                query: Some("Fix `hello` and update `test_hello`".into()),
+                context_mode: Some("task".into()),
+                context_roles: Some(vec!["editable_source".into()]),
+                context_facets: Some(Vec::new()),
+                hops: Some(1),
+                include_artifacts: false,
+                include_markdown: false,
+                ..Default::default()
+            },
+            &ctx,
+            &edge_index,
+        )
+        .await
+        .expect("a source-less graph neighbor must not fail the valid task response");
+
+        assert!(
+            output
+                .records
+                .iter()
+                .any(|record| record.identity.node_id == hello.stable_id())
+        );
+        assert!(
+            output
+                .records
+                .iter()
+                .any(|record| record.identity.node_id == test.stable_id())
+        );
+        assert!(output.omissions.iter().any(|omission| {
+            omission.record_id.as_deref() == Some(source_less_id.as_str())
+                && omission.detail.contains("no valid current source anchor")
         }));
     }
 
@@ -12056,16 +12242,28 @@ mod tests {
         regression.line_start = 1;
         regression.line_end = 1;
         let graph = make_graph_state(vec![production.clone(), regression.clone()]);
+        let edge_index = ProjectedEdgeIndex::new(&graph);
         let assemblies = BTreeMap::new();
 
-        let rejection =
-            task_lane_candidate_evidence(&production, TaskRole::Test, &assemblies, &graph)
-                .unwrap_err();
+        let rejection = task_lane_candidate_evidence(
+            &production,
+            TaskRole::Test,
+            &assemblies,
+            &graph,
+            &edge_index,
+        )
+        .unwrap_err();
         assert!(rejection.contains("production source cannot satisfy the test lane"));
         assert!(
-            task_lane_candidate_evidence(&regression, TaskRole::Test, &assemblies, &graph,)
-                .unwrap()
-                .contains("test path/metadata")
+            task_lane_candidate_evidence(
+                &regression,
+                TaskRole::Test,
+                &assemblies,
+                &graph,
+                &edge_index,
+            )
+            .unwrap()
+            .contains("test path/metadata")
         );
     }
 
@@ -12138,11 +12336,13 @@ mod tests {
         );
         let unrelated_graph =
             make_graph_state(vec![anchor.clone(), candidate.clone(), helper.clone()]);
+        let unrelated_edge_index = ProjectedEdgeIndex::new(&unrelated_graph);
         let rejection = task_lane_candidate_evidence(
             &candidate,
             TaskRole::BehavioralAnalogue,
             &assemblies,
             &unrelated_graph,
+            &unrelated_edge_index,
         )
         .unwrap_err();
         assert!(rejection.contains("lacks a shared typed graph target"));
@@ -12154,12 +12354,14 @@ mod tests {
                 make_edge(&candidate, &helper, EdgeKind::Calls),
             ],
         );
+        let corroborated_edge_index = ProjectedEdgeIndex::new(&corroborated_graph);
         assert!(
             task_lane_candidate_evidence(
                 &candidate,
                 TaskRole::BehavioralAnalogue,
                 &assemblies,
                 &corroborated_graph,
+                &corroborated_edge_index,
             )
             .unwrap()
             .contains("shared_typed_targets=calls:")
@@ -12270,6 +12472,7 @@ mod tests {
                 make_edge(&delta_bridge, &delta, EdgeKind::Calls),
             ],
         );
+        let edge_index = ProjectedEdgeIndex::new(&graph);
         let ctx = make_search_context(&graph, repository.path());
         for (query, expected, expected_test) in [
             (
@@ -12299,7 +12502,7 @@ mod tests {
                 include_markdown: false,
                 ..Default::default()
             };
-            let output = task_records(&task_params, &ctx).await.unwrap();
+            let output = task_records(&task_params, &ctx, &edge_index).await.unwrap();
             assert!(output.records.iter().any(|record| {
                 record.identity.node_id == expected
                     && record.selection.role == Some(ProjectionRole::EditableSource)
@@ -12320,7 +12523,7 @@ mod tests {
                 include_markdown: false,
                 ..Default::default()
             };
-            let (flat, _, _) = projected_fused_candidates(&flat_params, &ctx)
+            let (flat, _, _) = projected_fused_candidates(&flat_params, &ctx, &edge_index)
                 .await
                 .unwrap();
             let flat_roles = flat
@@ -12388,6 +12591,7 @@ mod tests {
         );
         let repository = PathBuf::from("/tmp/task-graph-fixture");
         let ctx = make_search_context(&graph, &repository);
+        let edge_index = ProjectedEdgeIndex::new(&graph);
         let mut assemblies = BTreeMap::new();
         merge_task_assembly(
             &mut assemblies,
@@ -12411,6 +12615,7 @@ mod tests {
                 ..Default::default()
             },
             &ctx,
+            &edge_index,
             &mut assemblies,
             &mut relationships,
         );
@@ -12448,6 +12653,7 @@ mod tests {
             .collect::<Vec<_>>();
         let repository = PathBuf::from("/tmp/graph-delta-fixture");
         let ctx = make_search_context(&graph, &repository);
+        let edge_index = ProjectedEdgeIndex::new(&graph);
         let card = live_graph_delta_card(
             &SearchParams {
                 context_mode: Some("graph-delta-beta".into()),
@@ -12459,6 +12665,7 @@ mod tests {
                 ..Default::default()
             },
             &ctx,
+            &edge_index,
         )
         .unwrap();
         assert_eq!(card.changed_edges.len(), 2);
@@ -12608,6 +12815,7 @@ mod tests {
             EdgeKind::TestedBy,
         ));
         let graph = make_graph_state_with_edges(nodes, edges);
+        let edge_index = ProjectedEdgeIndex::new(&graph);
         let ctx = make_search_context(&graph, repository.path());
         let changed_line = line_of("return legacy_search_dispatch(params, ctx).await;");
         let proposal = format!(
@@ -12624,6 +12832,7 @@ mod tests {
                 ..Default::default()
             },
             &ctx,
+            &edge_index,
         )
         .await;
         // The card covers all affected loci in one bounded response. The

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -1548,6 +1548,8 @@ fn selected_for_source_span_hydration(
             kind: "source_span".into(),
             language: "text".into(),
             signature: display,
+            extraction_source: None,
+            declared_metadata: BTreeMap::new(),
         },
         selection: SelectionSummary {
             channel: SelectionChannel::Exact,
@@ -2153,6 +2155,8 @@ fn projected_live_markdown_records(
                     kind: "markdown_section".into(),
                     language: language.into(),
                     signature,
+                    extraction_source: None,
+                    declared_metadata: BTreeMap::new(),
                 },
                 selection: SelectionSummary {
                     channel: SelectionChannel::Markdown,
@@ -2325,6 +2329,8 @@ fn selected_from_embedding_result(
             kind: result.kind,
             language: "text".into(),
             signature,
+            extraction_source: None,
+            declared_metadata: BTreeMap::new(),
         },
         selection: SelectionSummary {
             channel: SelectionChannel::Artifact,
@@ -4305,6 +4311,9 @@ fn pre_edit_node_for_changed_line<'a>(
     if line.kind != graph_delta::ChangedLineKind::Added || hunk.old_count == 0 {
         return Err("changed line has no pre-edit coordinate and remains proposal-only");
     }
+    if let Some(old_line) = paired_replacement_old_line(hunk, line) {
+        return unique_node_at_line(ctx, &file.path, old_line);
+    }
     let new_line = line
         .grounding
         .new_line
@@ -4353,6 +4362,54 @@ fn pre_edit_node_for_changed_line<'a>(
     Ok(before_node)
 }
 
+fn paired_replacement_old_line(
+    hunk: &graph_delta::ChangedHunkFact,
+    line: &graph_delta::ChangedLineFact,
+) -> Option<u32> {
+    let line_index = hunk.changed_lines.iter().position(|candidate| {
+        candidate.kind == line.kind
+            && candidate.grounding.proposal_line == line.grounding.proposal_line
+    })?;
+    let mut added_start = line_index;
+    while added_start > 0 {
+        let previous = &hunk.changed_lines[added_start - 1];
+        let current = &hunk.changed_lines[added_start];
+        if previous.kind != graph_delta::ChangedLineKind::Added
+            || previous.grounding.proposal_line + 1 != current.grounding.proposal_line
+        {
+            break;
+        }
+        added_start -= 1;
+    }
+    if added_start == 0 {
+        return None;
+    }
+    let removed_end = added_start;
+    let last_removed = &hunk.changed_lines[removed_end - 1];
+    if last_removed.kind != graph_delta::ChangedLineKind::Removed
+        || last_removed.grounding.proposal_line + 1
+            != hunk.changed_lines[added_start].grounding.proposal_line
+    {
+        return None;
+    }
+    let mut removed_start = removed_end - 1;
+    while removed_start > 0 {
+        let previous = &hunk.changed_lines[removed_start - 1];
+        let current = &hunk.changed_lines[removed_start];
+        if previous.kind != graph_delta::ChangedLineKind::Removed
+            || previous.grounding.proposal_line + 1 != current.grounding.proposal_line
+        {
+            break;
+        }
+        removed_start -= 1;
+    }
+    let added_offset = line_index.checked_sub(added_start)?;
+    hunk.changed_lines
+        .get(removed_start + added_offset)
+        .filter(|_| removed_start + added_offset < removed_end)
+        .and_then(|removed| removed.grounding.old_line)
+}
+
 fn unique_node_at_line<'a>(
     ctx: &'a SearchContext<'_>,
     path: &str,
@@ -4381,17 +4438,35 @@ fn unique_node_at_line<'a>(
         left.line_end
             .saturating_sub(left.line_start)
             .cmp(&right.line_end.saturating_sub(right.line_start))
+            .then_with(|| {
+                let left_synthetic = left
+                    .metadata
+                    .get("synthetic")
+                    .is_some_and(|value| value == "true");
+                let right_synthetic = right
+                    .metadata
+                    .get("synthetic")
+                    .is_some_and(|value| value == "true");
+                left_synthetic.cmp(&right_synthetic)
+            })
             .then_with(|| left.stable_id().cmp(&right.stable_id()))
     });
     let Some(best) = candidates.first().copied() else {
         return Err("no current graph node contains the changed line");
     };
     let best_width = best.line_end.saturating_sub(best.line_start);
-    if candidates
-        .iter()
-        .skip(1)
-        .any(|candidate| candidate.line_end.saturating_sub(candidate.line_start) == best_width)
-    {
+    let best_synthetic = best
+        .metadata
+        .get("synthetic")
+        .is_some_and(|value| value == "true");
+    if candidates.iter().skip(1).any(|candidate| {
+        candidate.line_end.saturating_sub(candidate.line_start) == best_width
+            && candidate
+                .metadata
+                .get("synthetic")
+                .is_some_and(|value| value == "true")
+                == best_synthetic
+    }) {
         return Err("multiple equally specific current graph nodes contain the changed line");
     }
     Ok(best)
@@ -4528,6 +4603,58 @@ fn graph_delta_projection(
             detail: format!("graph-delta {:?}: {}", omission.code, omission.detail),
         })
         .collect::<Vec<_>>();
+
+    // Proposal lines are first-class, source-grounded evidence even when an
+    // added line has no pre-edit coordinate or current graph node. Keep the
+    // conservative live-graph inference degradation, but do not erase the
+    // proposal itself from the graph-delta card.
+    for file in &card.changed_files {
+        for hunk in &file.hunks {
+            for line in &hunk.changed_lines {
+                let grounding = graph_delta::EvidenceGrounding::Proposal(line.grounding.clone());
+                let id = grounding.stable_hydration_key();
+                let change = format!("{:?}", line.kind).to_ascii_lowercase();
+                by_role
+                    .entry((id.clone(), ProjectionRole::ProposalDelta))
+                    .or_insert_with(|| SelectedRecord {
+                        selection_rank: 0,
+                        identity: RecordIdentity {
+                            node_id: id.clone(),
+                            source: None,
+                        },
+                        symbol: SymbolSummary {
+                            name: format!("{}:{}", file.path, line.grounding.proposal_line),
+                            kind: format!("proposal_{change}_line"),
+                            language: "diff".into(),
+                            signature: line.text.clone(),
+                            extraction_source: None,
+                            declared_metadata: BTreeMap::new(),
+                        },
+                        selection: SelectionSummary {
+                            channel: SelectionChannel::Graph,
+                            reason: format!("explicit {change} proposal line grounded by {id}"),
+                            role: Some(ProjectionRole::ProposalDelta),
+                            lane: Some(ProjectionLane::ProposalDelta),
+                        },
+                        evidence: SelectionEvidence {
+                            content_hash: Some(
+                                blake3::hash(line.text.as_bytes()).to_hex().to_string(),
+                            ),
+                            provenance: vec![EvidenceProvenance {
+                                source: "proposal".into(),
+                                detail: format!(
+                                    "{} line {} from validated bounded unified diff",
+                                    file.path, line.grounding.proposal_line
+                                ),
+                            }],
+                            ..Default::default()
+                        },
+                        evidence_hydration: None,
+                        focused_span: None,
+                    });
+            }
+        }
+    }
 
     for impact in &card.impacted_loci {
         insert_graph_delta_impact(
@@ -5392,6 +5519,15 @@ enum NodeDeliveryClass {
 fn node_delivery_class(node: &Node) -> NodeDeliveryClass {
     if node.metadata.contains_key("oh_kind") || node.id.kind == NodeKind::PrMerge {
         NodeDeliveryClass::Artifact
+    } else if node
+        .metadata
+        .get("local_knowledge")
+        .is_some_and(|value| value == "true")
+    {
+        // A frontmatter-declared domain entity is a persisted graph record,
+        // not a generic Markdown search chunk. Preserve exact graph lookup
+        // even when callers disable live Markdown expansion.
+        NodeDeliveryClass::Code
     } else if node.id.kind == NodeKind::MarkdownSection
         || matches!(
             node.language.to_ascii_lowercase().as_str(),
@@ -5491,11 +5627,27 @@ fn find_node<'a>(graph: &'a GraphState, id: &str) -> Option<&'a Node> {
 }
 
 fn symbol_summary(node: &Node) -> SymbolSummary {
+    let local_knowledge = node
+        .metadata
+        .get("local_knowledge")
+        .is_some_and(|value| value == "true");
     SymbolSummary {
         name: node.id.name.clone(),
         kind: node.id.kind.to_string(),
         language: node.language.clone(),
         signature: node.signature.clone(),
+        extraction_source: local_knowledge.then(|| node.source.to_string()),
+        declared_metadata: if local_knowledge {
+            node.metadata
+                .iter()
+                .filter_map(|(key, value)| {
+                    key.strip_prefix("rna.metadata.")
+                        .map(|name| (name.to_string(), value.clone()))
+                })
+                .collect()
+        } else {
+            BTreeMap::new()
+        },
     }
 }
 
@@ -12723,6 +12875,8 @@ mod tests {
                 kind: "metis".into(),
                 language: "text".into(),
                 signature: "truncated".into(),
+                extraction_source: None,
+                declared_metadata: BTreeMap::new(),
             },
             selection: SelectionSummary {
                 channel: SelectionChannel::Artifact,
@@ -13624,6 +13778,10 @@ mod tests {
         let mut source = make_node("hello", NodeKind::Function, "lib.rs");
         source.line_start = 2;
         source.line_end = 2;
+        let mut literal = make_node("world", NodeKind::Const, "lib.rs");
+        literal.line_start = 2;
+        literal.line_end = 2;
+        literal.metadata.insert("synthetic".into(), "true".into());
         let mut proof = make_node(
             "hello@proof",
             NodeKind::Other("lsp_document_symbol".into()),
@@ -13631,13 +13789,199 @@ mod tests {
         );
         proof.line_start = 2;
         proof.line_end = 2;
-        let graph = make_graph_state(vec![source.clone(), proof]);
+        let graph = make_graph_state(vec![source.clone(), literal, proof]);
         let repository = tempfile::tempdir().unwrap();
         let ctx = make_search_context(&graph, repository.path());
 
         assert_eq!(
             unique_node_at_line(&ctx, "lib.rs", 2).unwrap().stable_id(),
             source.stable_id()
+        );
+
+        let mut ambiguous = make_node("also_hello", NodeKind::Function, "lib.rs");
+        ambiguous.line_start = 2;
+        ambiguous.line_end = 2;
+        let ambiguous_graph = make_graph_state(vec![source, ambiguous]);
+        let ambiguous_ctx = make_search_context(&ambiguous_graph, repository.path());
+        assert_eq!(
+            unique_node_at_line(&ambiguous_ctx, "lib.rs", 2).unwrap_err(),
+            "multiple equally specific current graph nodes contain the changed line"
+        );
+    }
+
+    #[test]
+    fn acceptance_delivery_replacement_addition_uses_paired_removed_coordinate() {
+        let mut source = make_node("hello", NodeKind::Function, "lib.rs");
+        source.line_start = 2;
+        source.line_end = 2;
+        let graph = make_graph_state(vec![source.clone()]);
+        let repository = tempfile::tempdir().unwrap();
+        let ctx = make_search_context(&graph, repository.path());
+        let removed = graph_delta::ChangedLineFact {
+            kind: graph_delta::ChangedLineKind::Removed,
+            grounding: graph_delta::ProposalLine {
+                root: "local".into(),
+                path: "lib.rs".into(),
+                proposal_line: 5,
+                old_line: Some(2),
+                new_line: None,
+            },
+            text: "pub fn hello() { old(); }".into(),
+        };
+        let added = graph_delta::ChangedLineFact {
+            kind: graph_delta::ChangedLineKind::Added,
+            grounding: graph_delta::ProposalLine {
+                root: "local".into(),
+                path: "lib.rs".into(),
+                proposal_line: 6,
+                old_line: None,
+                new_line: Some(2),
+            },
+            text: "pub fn hello() { new(); }".into(),
+        };
+        let hunk = graph_delta::ChangedHunkFact {
+            proposal_header_line: 4,
+            old_start: 2,
+            old_count: 1,
+            new_start: 2,
+            new_count: 1,
+            changed_lines: vec![removed, added.clone()],
+        };
+        let file = graph_delta::ChangedFileFact {
+            root: "local".into(),
+            path: "lib.rs".into(),
+            hunks: vec![hunk.clone()],
+        };
+
+        assert_eq!(
+            pre_edit_node_for_changed_line(&ctx, &file, &hunk, &added)
+                .unwrap()
+                .stable_id(),
+            source.stable_id()
+        );
+    }
+
+    #[tokio::test]
+    async fn acceptance_delivery_local_knowledge_remains_exactly_searchable_without_markdown_expansion()
+     {
+        let mut quote = make_node(
+            "quote.mcp-provenance",
+            NodeKind::Other("quote".into()),
+            "provenance.md",
+        );
+        quote.language = "markdown".into();
+        quote.source = ExtractionSource::Markdown;
+        quote
+            .metadata
+            .insert("local_knowledge".into(), "true".into());
+        quote.metadata.insert("rna.kind".into(), "quote".into());
+        quote
+            .metadata
+            .insert("rna.id".into(), "quote.mcp-provenance".into());
+        quote
+            .metadata
+            .insert("rna.name".into(), "MCP provenance smoke fixture".into());
+        quote
+            .metadata
+            .insert("rna.metadata.public_use".into(), "mcp_verified".into());
+        let mut section = make_node("section", NodeKind::MarkdownSection, "provenance.md");
+        section.language = "markdown".into();
+
+        assert_eq!(node_delivery_class(&quote), NodeDeliveryClass::Code);
+        assert_eq!(node_delivery_class(&section), NodeDeliveryClass::Markdown);
+
+        let graph = make_graph_state(vec![quote]);
+        let repository = tempfile::tempdir().unwrap();
+        let ctx = make_search_context(&graph, repository.path());
+        let output = search(
+            &SearchParams {
+                query: Some("quote.mcp-provenance".into()),
+                compact: true,
+                limit: Some(3),
+                include_artifacts: false,
+                include_markdown: false,
+                ..Default::default()
+            },
+            &ctx,
+        )
+        .await;
+
+        assert!(output.contains("quote.mcp-provenance"), "{output}");
+        assert!(output.contains("src:markdown"), "{output}");
+        assert!(output.contains("mcp_verified"), "{output}");
+    }
+
+    #[test]
+    fn acceptance_delivery_graph_delta_keeps_proposal_only_lines_as_typed_records() {
+        let card = graph_delta::GraphDeltaCard {
+            beta: true,
+            capabilities: Vec::new(),
+            changed_files: vec![graph_delta::ChangedFileFact {
+                root: "local".into(),
+                path: "lib.rs".into(),
+                hunks: vec![graph_delta::ChangedHunkFact {
+                    proposal_header_line: 4,
+                    old_start: 2,
+                    old_count: 1,
+                    new_start: 2,
+                    new_count: 1,
+                    changed_lines: vec![graph_delta::ChangedLineFact {
+                        kind: graph_delta::ChangedLineKind::Added,
+                        grounding: graph_delta::ProposalLine {
+                            root: "local".into(),
+                            path: "lib.rs".into(),
+                            proposal_line: 6,
+                            old_line: None,
+                            new_line: Some(2),
+                        },
+                        text: "pub fn hello() { proposed(); }".into(),
+                    }],
+                }],
+            }],
+            routes: Vec::new(),
+            changed_edges: Vec::new(),
+            impacted_loci: Vec::new(),
+            impacted_tests: Vec::new(),
+            impacted_state_or_api: Vec::new(),
+            bypassed_loci: Vec::new(),
+            behavioral_deltas: Vec::new(),
+            behavioral_analogues: Vec::new(),
+            affected_locus_checklist: Vec::new(),
+            omissions: Vec::new(),
+        };
+        let graph = make_graph_state(Vec::new());
+        let repository = tempfile::tempdir().unwrap();
+        let ctx = make_search_context(&graph, repository.path());
+
+        let (records, _, _, _, _) = graph_delta_projection(
+            &card,
+            &SearchParams {
+                limit: Some(4),
+                ..Default::default()
+            },
+            &ctx,
+        );
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].selection.role,
+            Some(ProjectionRole::ProposalDelta)
+        );
+        assert_eq!(
+            records[0].selection.lane,
+            Some(ProjectionLane::ProposalDelta)
+        );
+        assert_eq!(records[0].symbol.kind, "proposal_added_line");
+        assert_eq!(
+            records[0].symbol.signature,
+            "pub fn hello() { proposed(); }"
+        );
+        assert!(records[0].identity.source.is_none());
+        assert!(
+            records[0]
+                .identity
+                .node_id
+                .starts_with("graph-delta:v1:proposal:")
         );
     }
 

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -4311,8 +4311,8 @@ fn pre_edit_node_for_changed_line<'a>(
     if line.kind != graph_delta::ChangedLineKind::Added || hunk.old_count == 0 {
         return Err("changed line has no pre-edit coordinate and remains proposal-only");
     }
-    if let Some(old_line) = paired_replacement_old_line(hunk, line) {
-        return unique_node_at_line(ctx, &file.path, old_line);
+    if let Some(node) = replacement_block_pre_edit_node(ctx, file, hunk, line)? {
+        return Ok(node);
     }
     let new_line = line
         .grounding
@@ -4362,52 +4362,71 @@ fn pre_edit_node_for_changed_line<'a>(
     Ok(before_node)
 }
 
-fn paired_replacement_old_line(
+fn replacement_block_pre_edit_node<'a>(
+    ctx: &'a SearchContext<'_>,
+    file: &graph_delta::ChangedFileFact,
     hunk: &graph_delta::ChangedHunkFact,
     line: &graph_delta::ChangedLineFact,
-) -> Option<u32> {
+) -> Result<Option<&'a Node>, &'static str> {
     let line_index = hunk.changed_lines.iter().position(|candidate| {
         candidate.kind == line.kind
             && candidate.grounding.proposal_line == line.grounding.proposal_line
-    })?;
+    });
+    let Some(line_index) = line_index else {
+        return Ok(None);
+    };
     let mut added_start = line_index;
     while added_start > 0 {
         let previous = &hunk.changed_lines[added_start - 1];
         let current = &hunk.changed_lines[added_start];
         if previous.kind != graph_delta::ChangedLineKind::Added
-            || previous.grounding.proposal_line + 1 != current.grounding.proposal_line
+            || previous.grounding.proposal_line.checked_add(1)
+                != Some(current.grounding.proposal_line)
         {
             break;
         }
         added_start -= 1;
     }
     if added_start == 0 {
-        return None;
+        return Ok(None);
     }
     let removed_end = added_start;
     let last_removed = &hunk.changed_lines[removed_end - 1];
     if last_removed.kind != graph_delta::ChangedLineKind::Removed
-        || last_removed.grounding.proposal_line + 1
-            != hunk.changed_lines[added_start].grounding.proposal_line
+        || last_removed.grounding.proposal_line.checked_add(1)
+            != Some(hunk.changed_lines[added_start].grounding.proposal_line)
     {
-        return None;
+        return Ok(None);
     }
     let mut removed_start = removed_end - 1;
     while removed_start > 0 {
         let previous = &hunk.changed_lines[removed_start - 1];
         let current = &hunk.changed_lines[removed_start];
         if previous.kind != graph_delta::ChangedLineKind::Removed
-            || previous.grounding.proposal_line + 1 != current.grounding.proposal_line
+            || previous.grounding.proposal_line.checked_add(1)
+                != Some(current.grounding.proposal_line)
         {
             break;
         }
         removed_start -= 1;
     }
-    let added_offset = line_index.checked_sub(added_start)?;
-    hunk.changed_lines
-        .get(removed_start + added_offset)
-        .filter(|_| removed_start + added_offset < removed_end)
-        .and_then(|removed| removed.grounding.old_line)
+    let mut replacement_node = None;
+    for removed in &hunk.changed_lines[removed_start..removed_end] {
+        let old_line = removed
+            .grounding
+            .old_line
+            .ok_or("replacement removal has no pre-edit coordinate")?;
+        let node = unique_node_at_line(ctx, &file.path, old_line)?;
+        if replacement_node
+            .is_some_and(|candidate: &Node| candidate.stable_id() != node.stable_id())
+        {
+            return Err(
+                "replacement block spans multiple pre-edit symbols and remains proposal-only",
+            );
+        }
+        replacement_node = Some(node);
+    }
+    Ok(replacement_node)
 }
 
 fn unique_node_at_line<'a>(
@@ -13859,6 +13878,88 @@ mod tests {
                 .stable_id(),
             source.stable_id()
         );
+    }
+
+    #[test]
+    fn acceptance_delivery_multi_symbol_replacement_remains_proposal_only() {
+        let mut first = make_node("first", NodeKind::Function, "lib.rs");
+        first.line_start = 2;
+        first.line_end = 2;
+        let mut second = make_node("second", NodeKind::Function, "lib.rs");
+        second.line_start = 3;
+        second.line_end = 3;
+        let graph = make_graph_state(vec![first, second]);
+        let repository = tempfile::tempdir().unwrap();
+        let ctx = make_search_context(&graph, repository.path());
+        let removed_first = graph_delta::ChangedLineFact {
+            kind: graph_delta::ChangedLineKind::Removed,
+            grounding: graph_delta::ProposalLine {
+                root: "local".into(),
+                path: "lib.rs".into(),
+                proposal_line: 5,
+                old_line: Some(2),
+                new_line: None,
+            },
+            text: "pub fn first() {}".into(),
+        };
+        let removed_second = graph_delta::ChangedLineFact {
+            kind: graph_delta::ChangedLineKind::Removed,
+            grounding: graph_delta::ProposalLine {
+                root: "local".into(),
+                path: "lib.rs".into(),
+                proposal_line: 6,
+                old_line: Some(3),
+                new_line: None,
+            },
+            text: "pub fn second() {}".into(),
+        };
+        let added_second = graph_delta::ChangedLineFact {
+            kind: graph_delta::ChangedLineKind::Added,
+            grounding: graph_delta::ProposalLine {
+                root: "local".into(),
+                path: "lib.rs".into(),
+                proposal_line: 7,
+                old_line: None,
+                new_line: Some(2),
+            },
+            text: "pub fn second() {}".into(),
+        };
+        let added_first = graph_delta::ChangedLineFact {
+            kind: graph_delta::ChangedLineKind::Added,
+            grounding: graph_delta::ProposalLine {
+                root: "local".into(),
+                path: "lib.rs".into(),
+                proposal_line: 8,
+                old_line: None,
+                new_line: Some(3),
+            },
+            text: "pub fn first() {}".into(),
+        };
+        let hunk = graph_delta::ChangedHunkFact {
+            proposal_header_line: 4,
+            old_start: 2,
+            old_count: 2,
+            new_start: 2,
+            new_count: 2,
+            changed_lines: vec![
+                removed_first,
+                removed_second,
+                added_second.clone(),
+                added_first.clone(),
+            ],
+        };
+        let file = graph_delta::ChangedFileFact {
+            root: "local".into(),
+            path: "lib.rs".into(),
+            hunks: vec![hunk.clone()],
+        };
+
+        for added in [&added_second, &added_first] {
+            assert_eq!(
+                pre_edit_node_for_changed_line(&ctx, &file, &hunk, added).unwrap_err(),
+                "replacement block spans multiple pre-edit symbols and remains proposal-only"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -5,13 +5,17 @@
 //! parameters supplied by the caller.
 
 use std::cell::Cell;
-use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::io::Read;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Once;
 
-use crate::embed::{EMBEDDING_MODEL_NAME, SearchFilters, SearchMode, SearchOutcome};
+use crate::embed::{
+    EMBEDDING_MODEL_NAME, ExecutedSearchMode, NativeScoreKind, NativeScoreSource,
+    ObservedSearchOutcome, ScoreAdjustment, ScoreNormalization, SearchFilters, SearchMode,
+    SearchOutcome, SearchResult, SearchScoreProvenance, TestResultPolicy,
+};
 use crate::graph::index::GraphIndex;
 use crate::graph::{EdgeKind, ExtractionSource, Node, NodeKind};
 use crate::ranking;
@@ -29,6 +33,32 @@ use super::{
     SearchContext, SearchParams, node_passes_root_filter, search_result_passes_root_filter,
 };
 
+pub(crate) mod fusion;
+pub(crate) mod graph_delta;
+pub(crate) mod model;
+pub(crate) mod projection;
+pub(crate) mod render;
+pub(crate) mod source;
+pub(crate) mod task_context;
+
+use fusion::{
+    ChannelInput, EvidenceChannel, FusedCandidate, FusionPolicy, RawCandidateScore, ScoreKind,
+    fuse_ranked_channels,
+};
+use model::{
+    BodyPolicy, CandidateAudit, CandidateDisposition, CapabilityState, CapabilityStatus,
+    ContextRole as ProjectionRole, EvidenceProvenance, HydrationHandle, HydrationKind,
+    OmissionCode, ProjectedRelationship, ProjectionBudget, ProjectionInput, ProjectionOmission,
+    ProjectionRequest, RecordIdentity, RetrievalLane as ProjectionLane, SearchIntent,
+    SearchProjection, SelectedRecord, SelectionChannel, SelectionEvidence, SelectionSummary,
+    SourceSpan as ProjectionSourceSpan, SymbolSummary,
+};
+use task_context::{
+    ContextRole as TaskRole, EvidenceCandidate as TaskEvidenceCandidate, ExactCandidate,
+    ExactResolution, RetrievalLane as TaskLane, SelectionPolicy as TaskSelectionPolicy,
+    SelectionReason as TaskSelectionReason, SourceAnchor, TaskFacet,
+};
+
 /// When impact results exceed this node-count threshold, render a
 /// subsystem-grouped summary instead of listing every node.
 const IMPACT_SUMMARY_NODE_THRESHOLD: usize = 30;
@@ -44,6 +74,217 @@ const MAX_SOURCE_SPAN_BYTES: usize = 64 * 1024;
 const MAX_SOURCE_PATH_ENTRIES: usize = 50_000;
 const MAX_SOURCE_CANDIDATES: usize = 20;
 const STRICT_SEMANTIC_MODE: &str = "strict";
+const MAX_PROJECTED_OUTPUT_BYTES: usize = 256 * 1024;
+const MAX_PROJECTED_OUTPUT_TOKENS: usize = 64 * 1024;
+const MAX_PROJECTED_BODY_BYTES: usize = 64 * 1024;
+const MAX_PROJECTED_TOTAL_BODY_BYTES: usize = 256 * 1024;
+const MAX_CONTEXT_HOPS: u32 = 4;
+const MAX_PROPOSAL_BYTES: usize = 256 * 1024;
+const MAX_CONTEXT_LIST_VALUES: usize = 16;
+const MAX_CONTEXT_ENTRY_NODES: usize = 32;
+const EVIDENCE_CAPSULE_SCHEMA_VERSION: u8 = 1;
+const MAX_EVIDENCE_CAPSULE_BYTES: usize = 64 * 1024;
+const EVIDENCE_CAPSULE_PREFIX: &str = "evidence-cache-v1:";
+const SEMANTIC_EVIDENCE_CAPSULE_PREFIX: &str = "semantic-evidence-cache-v1:";
+
+const CONTEXT_ROLES: &[&str] = &[
+    "editable_source",
+    "definition_or_api_state",
+    "test",
+    "behavioral_analogue",
+    "direct_dependency",
+    "caller_or_impact",
+    "proposal_delta",
+];
+const CONTEXT_FACETS: &[&str] = &["behavior", "api_or_state", "test", "analogue", "proposal"];
+
+fn validate_named_values(
+    field: &str,
+    values: Option<&[String]>,
+    allowed: &[&str],
+) -> Result<(), String> {
+    let Some(values) = values else {
+        return Ok(());
+    };
+    if values.len() > MAX_CONTEXT_LIST_VALUES {
+        return Err(format!(
+            "{field} accepts at most {MAX_CONTEXT_LIST_VALUES} values"
+        ));
+    }
+    for value in values {
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        if !allowed.contains(&value) {
+            return Err(format!(
+                "unknown {field} `{value}`; allowed values: {}",
+                allowed.join(", ")
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_search_experience(params: &SearchParams) -> Result<(), String> {
+    if let Some(projection) = params.projection.as_deref().map(str::trim)
+        && !matches!(projection, "agent" | "evidence")
+    {
+        return Err(format!(
+            "unknown projection `{projection}`; allowed values: agent, evidence"
+        ));
+    }
+    if let Some(body_policy) = params.body_policy.as_deref().map(str::trim)
+        && !matches!(
+            body_policy,
+            "complete" | "focused_span" | "signature_only" | "minified" | "none"
+        )
+    {
+        return Err(format!(
+            "unknown body_policy `{body_policy}`; allowed values: complete, focused_span, signature_only, minified, none"
+        ));
+    }
+    if let Some(bytes) = params.max_output_bytes
+        && !(1..=MAX_PROJECTED_OUTPUT_BYTES).contains(&bytes)
+    {
+        return Err(format!(
+            "max_output_bytes must be between 1 and {MAX_PROJECTED_OUTPUT_BYTES}"
+        ));
+    }
+    if let Some(tokens) = params.max_output_tokens
+        && !(1..=MAX_PROJECTED_OUTPUT_TOKENS).contains(&tokens)
+    {
+        return Err(format!(
+            "max_output_tokens must be between 1 and {MAX_PROJECTED_OUTPUT_TOKENS}"
+        ));
+    }
+    if let Some(bytes) = params.max_body_bytes
+        && !(1..=MAX_PROJECTED_BODY_BYTES).contains(&bytes)
+    {
+        return Err(format!(
+            "max_body_bytes must be between 1 and {MAX_PROJECTED_BODY_BYTES}"
+        ));
+    }
+    if let Some(bytes) = params.max_total_body_bytes
+        && !(1..=MAX_PROJECTED_TOTAL_BODY_BYTES).contains(&bytes)
+    {
+        return Err(format!(
+            "max_total_body_bytes must be between 1 and {MAX_PROJECTED_TOTAL_BODY_BYTES}"
+        ));
+    }
+
+    validate_named_values(
+        "context role",
+        params.context_roles.as_deref(),
+        CONTEXT_ROLES,
+    )?;
+    validate_named_values(
+        "context facet",
+        params.context_facets.as_deref(),
+        CONTEXT_FACETS,
+    )?;
+
+    let context_mode = params.context_mode.as_deref().map(str::trim);
+    if let Some(mode) = context_mode
+        && !matches!(mode, "task" | "graph-delta-beta")
+    {
+        return Err(format!(
+            "unknown context_mode `{mode}`; allowed values: task, graph-delta-beta"
+        ));
+    }
+    if context_mode != Some("task")
+        && (params.context_roles.is_some() || params.context_facets.is_some())
+    {
+        return Err("context_roles/context_facets require context_mode=task".to_string());
+    }
+    if context_mode.is_some() {
+        if params.hops.unwrap_or(1) > MAX_CONTEXT_HOPS {
+            return Err(format!(
+                "task-context hops cannot exceed {MAX_CONTEXT_HOPS}"
+            ));
+        }
+        if params.depth.unwrap_or(1) > MAX_CONTEXT_HOPS {
+            return Err(format!(
+                "task-context depth cannot exceed {MAX_CONTEXT_HOPS}"
+            ));
+        }
+        if params
+            .nodes
+            .as_ref()
+            .is_some_and(|nodes| nodes.len() > MAX_CONTEXT_ENTRY_NODES)
+        {
+            return Err(format!(
+                "task context accepts at most {MAX_CONTEXT_ENTRY_NODES} entry nodes"
+            ));
+        }
+        if let Some(edge_types) = params.edge_types.as_deref() {
+            if edge_types.len() > MAX_CONTEXT_LIST_VALUES {
+                return Err(format!(
+                    "task context accepts at most {MAX_CONTEXT_LIST_VALUES} edge types"
+                ));
+            }
+            for edge_type in edge_types {
+                if parse_edge_kind(edge_type).is_none() {
+                    return Err(format!(
+                        "unknown task-context edge type `{edge_type}`; use a registered graph edge kind"
+                    ));
+                }
+            }
+        }
+    }
+    if context_mode == Some("task")
+        && params
+            .query
+            .as_deref()
+            .is_none_or(|query| query.trim().is_empty())
+    {
+        return Err("task context requires a non-empty query".to_string());
+    }
+    if context_mode == Some("graph-delta-beta")
+        && params
+            .proposal
+            .as_deref()
+            .is_none_or(|proposal| proposal.is_empty())
+    {
+        return Err("graph-delta-beta requires a proposal".to_string());
+    }
+    if params.proposal.is_some() && context_mode.is_none() {
+        return Err("proposal requires context_mode=task or graph-delta-beta".to_string());
+    }
+    if params
+        .context_roles
+        .as_deref()
+        .is_some_and(|roles| roles.iter().any(|role| role.trim() == "proposal_delta"))
+        && params.proposal.is_none()
+    {
+        return Err("the proposal_delta task role requires a proposal".to_string());
+    }
+    if let Some(proposal) = params.proposal.as_deref() {
+        if proposal.len() > MAX_PROPOSAL_BYTES {
+            return Err(format!(
+                "proposal exceeds the {MAX_PROPOSAL_BYTES}-byte hard limit"
+            ));
+        }
+        if proposal.as_bytes().contains(&0) {
+            return Err("proposal contains NUL bytes".to_string());
+        }
+    }
+    if strict_semantic_requested(params)
+        && (context_mode.is_some()
+            || params.projection.is_some()
+            || params.body_policy.is_some()
+            || params.max_output_bytes.is_some()
+            || params.max_output_tokens.is_some()
+            || params.max_body_bytes.is_some()
+            || params.max_total_body_bytes.is_some()
+            || params.context_roles.is_some()
+            || params.context_facets.is_some()
+            || params.proposal.is_some())
+    {
+        return Err("strict semantic qualification forbids product context controls".to_string());
+    }
+    Ok(())
+}
 
 fn sealed_semantic_bundle() -> bool {
     cfg!(feature = "swebench-semantic-bundle")
@@ -66,6 +307,7 @@ fn strict_semantic_requested(params: &SearchParams) -> bool {
         .as_deref()
         .is_some_and(|mode| mode.trim().eq_ignore_ascii_case(STRICT_SEMANTIC_MODE));
     let sealed_bundle_default = sealed_semantic_bundle()
+        && params.context_mode.is_none()
         && params.normalized_mode().is_none()
         && params
             .query
@@ -783,10 +1025,27 @@ fn format_enrichment_jobs(ctx: &SearchContext<'_>) -> String {
 
 /// Unified search entry point. Returns formatted markdown.
 pub async fn search(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
-    if strict_semantic_requested(params)
-        && let Err(reason) = strict_semantic_preflight(params, ctx).await
-    {
+    if let Err(reason) = validate_search_experience(params) {
+        return format!("Invalid search context: {reason}.");
+    }
+    let strict_semantic = strict_semantic_requested(params);
+    if strict_semantic && let Err(reason) = strict_semantic_preflight(params, ctx).await {
         return strict_semantic_failure(reason);
+    }
+
+    // The frozen #779 path deliberately bypasses every new product policy and
+    // keeps the established selection, ordering, and renderer byte-for-byte.
+    if strict_semantic {
+        return legacy_search_dispatch(params, ctx).await;
+    }
+
+    let normalized_params = normalize_product_context_controls(params);
+    let params = &normalized_params;
+
+    if let Some(node) = params.node.as_deref()
+        && node.starts_with("rna-hydrate-v1:")
+    {
+        return hydrate_from_handle(node, params, ctx).await;
     }
 
     if params.line.is_some()
@@ -800,6 +1059,54 @@ pub async fn search(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
             .unwrap_or_else(|error| format!("Source span lookup task failed: {error}."));
     }
 
+    // Traversal and batch rendering retain their established contracts until
+    // typed projection adapters exist. In particular, never reinterpret a
+    // node/mode request as a flat product search.
+    if params.context_mode.is_none()
+        && (params.normalized_mode().is_some()
+            || params
+                .node
+                .as_deref()
+                .is_some_and(|node| !node.trim().is_empty())
+            || params.nodes.as_ref().is_some_and(|nodes| !nodes.is_empty())
+            || params.target_subsystem.is_some())
+    {
+        return legacy_search_dispatch(params, ctx).await;
+    }
+
+    projected_search(params, ctx).await
+}
+
+fn normalize_product_context_controls(params: &SearchParams) -> SearchParams {
+    let mut normalized = params.clone();
+    let normalize_scalar = |value: &Option<String>| {
+        value
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    };
+    let normalize_list = |value: &Option<Vec<String>>| {
+        let values = value
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        (!values.is_empty()).then_some(values)
+    };
+    normalized.projection = normalize_scalar(&params.projection);
+    normalized.body_policy = normalize_scalar(&params.body_policy);
+    normalized.context_mode = normalize_scalar(&params.context_mode);
+    normalized.context_roles = normalize_list(&params.context_roles);
+    normalized.context_facets = normalize_list(&params.context_facets);
+    normalized.edge_types = normalize_list(&params.edge_types);
+    normalized
+}
+
+async fn legacy_search_dispatch(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
     let query = nonempty_query_preserving_bytes(params.query.as_deref());
     let node = params
         .node
@@ -871,6 +1178,4416 @@ pub async fn search(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
     }
 }
 
+fn projection_request(params: &SearchParams, intent: SearchIntent) -> ProjectionRequest {
+    let projection = match params.projection.as_deref() {
+        Some("evidence") => SearchProjection::Evidence,
+        _ => SearchProjection::Agent,
+    };
+    let body_policy = match params.body_policy.as_deref() {
+        Some("complete") => BodyPolicy::Complete,
+        Some("focused_span") => BodyPolicy::FocusedSpan,
+        Some("signature_only") => BodyPolicy::SignatureOnly,
+        Some("minified") => BodyPolicy::Minified,
+        Some("none") => BodyPolicy::NoBody,
+        _ if params.minify_body => BodyPolicy::Minified,
+        _ if params.include_body => BodyPolicy::Complete,
+        _ => BodyPolicy::SignatureOnly,
+    };
+    ProjectionRequest {
+        intent,
+        projection,
+        body_policy,
+        budget: ProjectionBudget {
+            max_rendered_bytes: params.max_output_bytes,
+            max_estimated_tokens: params.max_output_tokens,
+            per_record_body_bytes: params.max_body_bytes,
+            // The final renderer still enforces the complete output bound. This
+            // early body bound prevents source alone from consuming all of it.
+            total_body_bytes: params.max_total_body_bytes.or(params.max_output_bytes),
+        },
+    }
+}
+
+fn projection_source_reader(
+    params: &SearchParams,
+    repo_root: &Path,
+) -> Result<source::SourceReader, String> {
+    let mut all_roots = params.clone();
+    all_roots.root = Some("all".to_string());
+    source::SourceReader::new(
+        source_roots(&all_roots, repo_root),
+        source::SourceReadLimits::default(),
+    )
+    .map_err(|error| error.to_string())
+}
+
+async fn hydrate_from_handle(
+    encoded: &str,
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+) -> String {
+    let handle = match HydrationHandle::decode(encoded) {
+        Ok(handle) => handle,
+        Err(error) => return format!("Invalid hydration handle: {error}."),
+    };
+    match handle.kind {
+        HydrationKind::Source => {
+            let Some(page) = handle.source.clone() else {
+                return "Invalid hydration handle: source target is missing.".to_string();
+            };
+            if let Some(span_id) = handle.record_id.strip_prefix("span:") {
+                let authority = match ProjectionSourceSpan::from_stable_id(span_id) {
+                    Ok(authority) => authority,
+                    Err(error) => {
+                        return format!("Hydration span authority is invalid: {error}.");
+                    }
+                };
+                if !authority.contains(&page) {
+                    return "Hydration page is outside its bound source authority.".to_string();
+                }
+                let reader = match projection_source_reader(params, ctx.repo_root) {
+                    Ok(reader) => reader,
+                    Err(error) => {
+                        return format!("Hydration source projection unavailable: {error}.");
+                    }
+                };
+                if let Err(error) = reader.read(&page) {
+                    return format!("Hydration source validation failed: {error}.");
+                }
+                let selected =
+                    selected_for_source_span_hydration(&handle.record_id, authority, page);
+                let mut request = projection_request(params, SearchIntent::Hydrate);
+                request.projection = SearchProjection::Agent;
+                request.body_policy = BodyPolicy::FocusedSpan;
+                return render_projected_input(
+                    request,
+                    ProjectionInput {
+                        records: vec![selected],
+                        ..Default::default()
+                    },
+                    params,
+                    ctx,
+                );
+            }
+            let node = ctx
+                .graph_state
+                .nodes
+                .iter()
+                .find(|node| node.stable_id() == handle.record_id);
+            let Some(node) = node else {
+                return "Hydration source target is no longer present in the graph.".to_string();
+            };
+            // If the record still exists, bind the handle to its authoritative
+            // identity. A changed path/range fails closed instead of redirecting.
+            let Some(authority) = node_source_span(node) else {
+                return "Hydration source target has no current authoritative span.".to_string();
+            };
+            if !authority.contains(&page) {
+                return "Hydration handle no longer matches the indexed record source.".to_string();
+            }
+            let selected = selected_for_hydration(node, &handle.record_id, authority, page);
+            let mut request = projection_request(params, SearchIntent::Hydrate);
+            request.projection = SearchProjection::Agent;
+            request.body_policy = BodyPolicy::FocusedSpan;
+            render_projected_input(
+                request,
+                ProjectionInput {
+                    records: vec![selected],
+                    ..Default::default()
+                },
+                params,
+                ctx,
+            )
+        }
+        HydrationKind::Evidence => {
+            if handle
+                .record_id
+                .starts_with(SEMANTIC_EVIDENCE_CAPSULE_PREFIX)
+            {
+                return hydrate_semantic_evidence_capsule(&handle, params, ctx);
+            }
+            let (digest, node_id) = match parse_evidence_capsule_reference(&handle.record_id) {
+                Ok(reference) => reference,
+                Err(error) => return format!("Evidence hydration rejected: {error}."),
+            };
+            let directory = match evidence_capsule_directory(ctx.repo_root, false) {
+                Ok(directory) => directory,
+                Err(error) => return format!("Evidence hydration rejected: {error}."),
+            };
+            let path = directory.join(format!("{digest}.json"));
+            let bytes = match read_evidence_capsule_bytes(&path) {
+                Ok(bytes) => bytes,
+                Err(error) => return format!("Evidence hydration rejected: {error}."),
+            };
+            if blake3::hash(&bytes).to_hex().as_str() != digest {
+                return "Evidence hydration rejected: capsule digest mismatch.".to_string();
+            }
+            let capsule: EvidenceCapsuleV1 = match serde_json::from_slice(&bytes) {
+                Ok(capsule) => capsule,
+                Err(error) => {
+                    return format!("Evidence hydration rejected: invalid capsule: {error}.");
+                }
+            };
+            if capsule.schema_version != EVIDENCE_CAPSULE_SCHEMA_VERSION
+                || capsule.record_id != node_id
+                || capsule.query_digest.len() != 64
+                || !capsule
+                    .query_digest
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            {
+                return "Evidence hydration rejected: capsule binding mismatch.".to_string();
+            }
+            let canonical = match serde_json::to_vec(&capsule) {
+                Ok(canonical) => canonical,
+                Err(error) => {
+                    return format!(
+                        "Evidence hydration rejected: capsule canonicalization failed: {error}."
+                    );
+                }
+            };
+            if canonical != bytes {
+                return "Evidence hydration rejected: capsule is not canonical.".to_string();
+            }
+            let Some(node) = find_node(ctx.graph_state, node_id) else {
+                return "Evidence hydration rejected: selected node is no longer present."
+                    .to_string();
+            };
+            let current_hash = node_projection_digest(node);
+            if capsule.current_node_content_hash != current_hash
+                || capsule.evidence.content_hash.as_deref() != Some(current_hash.as_str())
+            {
+                return "Evidence hydration rejected: selected node content changed.".to_string();
+            }
+            let selected = SelectedRecord {
+                selection_rank: capsule.selection_rank,
+                identity: RecordIdentity {
+                    node_id: node_id.to_string(),
+                    source: node_source_span(node),
+                },
+                symbol: symbol_summary(node),
+                selection: capsule.selection,
+                evidence: capsule.evidence,
+                evidence_hydration: Some(handle),
+                focused_span: None,
+            };
+            let mut request = projection_request(params, SearchIntent::Hydrate);
+            request.projection = SearchProjection::Evidence;
+            request.body_policy = BodyPolicy::SignatureOnly;
+            render_projected_input(
+                request,
+                ProjectionInput {
+                    records: vec![selected],
+                    ..Default::default()
+                },
+                params,
+                ctx,
+            )
+        }
+    }
+}
+
+fn hydrate_semantic_evidence_capsule(
+    handle: &HydrationHandle,
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+) -> String {
+    let (digest, record_id) = match parse_semantic_evidence_capsule_reference(&handle.record_id) {
+        Ok(reference) => reference,
+        Err(error) => return format!("Semantic evidence hydration rejected: {error}."),
+    };
+    let directory = match evidence_capsule_directory(ctx.repo_root, false) {
+        Ok(directory) => directory,
+        Err(error) => return format!("Semantic evidence hydration rejected: {error}."),
+    };
+    let bytes = match read_evidence_capsule_bytes(&directory.join(format!("{digest}.json"))) {
+        Ok(bytes) => bytes,
+        Err(error) => return format!("Semantic evidence hydration rejected: {error}."),
+    };
+    if blake3::hash(&bytes).to_hex().as_str() != digest {
+        return "Semantic evidence hydration rejected: capsule digest mismatch.".into();
+    }
+    let capsule: SemanticEvidenceCapsuleV1 = match serde_json::from_slice(&bytes) {
+        Ok(capsule) => capsule,
+        Err(error) => {
+            return format!("Semantic evidence hydration rejected: invalid capsule: {error}.");
+        }
+    };
+    let body_hash = blake3::hash(capsule.body.as_bytes()).to_hex().to_string();
+    if capsule.schema_version != EVIDENCE_CAPSULE_SCHEMA_VERSION
+        || capsule.record_id != record_id
+        || capsule.evidence.content_hash.as_deref() != Some(body_hash.as_str())
+    {
+        return "Semantic evidence hydration rejected: capsule binding mismatch.".into();
+    }
+    let canonical = match serde_json::to_vec(&capsule) {
+        Ok(canonical) => canonical,
+        Err(error) => {
+            return format!(
+                "Semantic evidence hydration rejected: canonicalization failed: {error}."
+            );
+        }
+    };
+    if canonical != bytes {
+        return "Semantic evidence hydration rejected: capsule is not canonical.".into();
+    }
+    let mut symbol = capsule.symbol;
+    symbol.signature = capsule.body;
+    let mut selection = capsule.selection;
+    selection.reason = format!(
+        "{}; hydrated full content-addressed semantic row body",
+        selection.reason
+    );
+    let selected = SelectedRecord {
+        selection_rank: 0,
+        identity: RecordIdentity {
+            node_id: capsule.record_id,
+            source: None,
+        },
+        symbol,
+        selection,
+        evidence: capsule.evidence,
+        evidence_hydration: Some(handle.clone()),
+        focused_span: None,
+    };
+    let mut request = projection_request(params, SearchIntent::Hydrate);
+    request.projection = SearchProjection::Evidence;
+    request.body_policy = BodyPolicy::SignatureOnly;
+    render_projected_input(
+        request,
+        ProjectionInput {
+            records: vec![selected],
+            ..Default::default()
+        },
+        params,
+        ctx,
+    )
+}
+
+fn selected_for_source_span_hydration(
+    record_id: &str,
+    authority: ProjectionSourceSpan,
+    page: ProjectionSourceSpan,
+) -> SelectedRecord {
+    let display = format!("{}:{}-{}", page.path, page.start_line, page.end_line);
+    SelectedRecord {
+        selection_rank: 0,
+        identity: RecordIdentity {
+            node_id: record_id.to_string(),
+            source: Some(authority),
+        },
+        symbol: SymbolSummary {
+            name: display.clone(),
+            kind: "source_span".into(),
+            language: "text".into(),
+            signature: display,
+        },
+        selection: SelectionSummary {
+            channel: SelectionChannel::Exact,
+            reason: "checksum-bound coalesced source hydration".into(),
+            role: Some(ProjectionRole::EditableSource),
+            lane: Some(ProjectionLane::ExactReference),
+        },
+        evidence: SelectionEvidence::default(),
+        evidence_hydration: None,
+        focused_span: Some(page),
+    }
+}
+
+fn selected_for_hydration(
+    node: &Node,
+    record_id: &str,
+    authority: ProjectionSourceSpan,
+    page: ProjectionSourceSpan,
+) -> SelectedRecord {
+    let symbol = symbol_summary(node);
+    SelectedRecord {
+        selection_rank: 0,
+        identity: RecordIdentity {
+            node_id: record_id.to_string(),
+            source: Some(authority),
+        },
+        symbol,
+        selection: SelectionSummary {
+            channel: SelectionChannel::Exact,
+            reason: "verified source hydration handle".to_string(),
+            role: Some(ProjectionRole::EditableSource),
+            lane: Some(ProjectionLane::ExactReference),
+        },
+        evidence: SelectionEvidence::default(),
+        evidence_hydration: None,
+        focused_span: Some(page),
+    }
+}
+
+async fn projected_search(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
+    if params.context_mode.as_deref() == Some("graph-delta-beta") {
+        return projected_graph_delta(params, ctx).await;
+    }
+    let intent = if params.context_mode.as_deref() == Some("task") {
+        SearchIntent::Implement
+    } else {
+        SearchIntent::Discover
+    };
+    let request = projection_request(params, intent);
+    let (mut records, mut relationships, mut capabilities, mut omissions, mut candidate_audit) =
+        if params.context_mode.as_deref() == Some("task") {
+            match task_records(params, ctx).await {
+                Ok(output) => (
+                    output.records,
+                    output.relationships,
+                    output.capabilities,
+                    output.omissions,
+                    output.candidate_audit,
+                ),
+                Err(error) => return format!("Task context selection failed: {error}."),
+            }
+        } else {
+            let (fused, capabilities, product_score_audit) =
+                match projected_fused_candidates(params, ctx).await {
+                    Ok(result) => result,
+                    Err(error) => return format!("Search projection failed: {error}."),
+                };
+            let selected_limit = params.limit.unwrap_or(10);
+            let records = fused
+                .iter()
+                .take(selected_limit)
+                .enumerate()
+                .filter_map(|(rank, fused)| {
+                    find_node(ctx.graph_state, &fused.stable_id).map(|node| {
+                        let mut selected = selected_from_fused(
+                            node,
+                            fused,
+                            rank,
+                            SelectionPlacement::default(),
+                            params.query.as_deref(),
+                            ctx.repo_root,
+                        );
+                        append_selected_product_score_audit(
+                            &mut selected,
+                            product_score_audit.get(&fused.stable_id).map(Vec::as_slice),
+                            params.query.as_deref().unwrap_or_default(),
+                            ctx.repo_root,
+                        );
+                        selected
+                    })
+                })
+                .collect::<Vec<_>>();
+            let selected_ids = records
+                .iter()
+                .map(|record| record.identity.node_id.as_str())
+                .collect::<BTreeSet<_>>();
+            let candidate_audit = fused
+                .iter()
+                .enumerate()
+                .filter_map(|(rank, fused)| {
+                    let node = find_node(ctx.graph_state, &fused.stable_id)?;
+                    let selected = selected_ids.contains(fused.stable_id.as_str());
+                    let mut audit = candidate_audit_from_fused(
+                        node,
+                        fused,
+                        rank,
+                        selected,
+                        if selected {
+                            "selected within requested result limit"
+                        } else {
+                            "omitted after bounded candidate fusion by requested result limit"
+                        },
+                    );
+                    append_product_score_audit(
+                        &mut audit.evidence,
+                        product_score_audit.get(&fused.stable_id).map(Vec::as_slice),
+                    );
+                    Some(audit)
+                })
+                .collect();
+            (
+                records,
+                Vec::new(),
+                capabilities,
+                Vec::new(),
+                candidate_audit,
+            )
+        };
+    if params.context_mode.is_none() {
+        let (mut non_code, non_code_capabilities, mut non_code_audit) =
+            projected_non_code_records(params, ctx, records.len()).await;
+        records.append(&mut non_code);
+        capabilities.extend(non_code_capabilities);
+        candidate_audit.append(&mut non_code_audit);
+    }
+    records.retain(|record| {
+        let hydratable = record.identity.source.is_some() || record.evidence_hydration.is_some();
+        if !hydratable {
+            omissions.push(ProjectionOmission {
+                record_id: Some(record.identity.node_id.clone()),
+                source: None,
+                code: OmissionCode::MissingSource,
+                detail: "selected semantic-only record has no independently verifiable source or evidence hydration handle".into(),
+            });
+        }
+        hydratable
+    });
+    capabilities.push(evidence_capsule_capability(&records));
+    let mut seen_records = BTreeSet::new();
+    records.retain(|record| {
+        seen_records.insert((record.identity.node_id.clone(), record.selection.role))
+    });
+    records.sort_by(|left, right| {
+        left.selection_rank
+            .cmp(&right.selection_rank)
+            .then_with(|| left.identity.node_id.cmp(&right.identity.node_id))
+            .then_with(|| left.selection.role.cmp(&right.selection.role))
+    });
+    capabilities.extend(default_capabilities(ctx, request.projection).await);
+    capabilities = merge_capabilities(capabilities);
+    relationships.extend(projected_relationships(ctx.graph_state, &records));
+    relationships.sort();
+    relationships.dedup();
+    candidate_audit.sort_by(|left, right| {
+        left.candidate_rank
+            .cmp(&right.candidate_rank)
+            .then_with(|| left.identity.node_id.cmp(&right.identity.node_id))
+    });
+    render_projected_input(
+        request,
+        ProjectionInput {
+            records,
+            candidate_audit,
+            relationships,
+            omissions,
+            capabilities,
+        },
+        params,
+        ctx,
+    )
+}
+
+async fn projected_non_code_records(
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+    rank_offset: usize,
+) -> (
+    Vec<SelectedRecord>,
+    Vec<CapabilityStatus>,
+    Vec<CandidateAudit>,
+) {
+    let query = nonempty_query_preserving_bytes(params.query.as_deref()).unwrap_or("");
+    if !params.include_markdown && !params.include_artifacts {
+        return (Vec::new(), Vec::new(), Vec::new());
+    }
+    let limit = params.limit.unwrap_or(10).min(100);
+    let mut capabilities = Vec::new();
+    let mut orders = BTreeMap::<EvidenceChannel, Vec<String>>::new();
+    let mut synthetic = Vec::<(SearchResult, EvidenceChannel, usize)>::new();
+    let mut product_score_audit = BTreeMap::<String, Vec<ProductScoreAudit>>::new();
+    let (mut live_markdown, mut live_markdown_audit) =
+        projected_live_markdown_records(params, ctx, query, rank_offset);
+    let live_markdown_sources = live_markdown
+        .iter()
+        .filter_map(|record| {
+            record
+                .identity
+                .source
+                .as_ref()
+                .map(ProjectionSourceSpan::stable_id)
+        })
+        .collect::<BTreeSet<_>>();
+
+    let mut lexical = ctx
+        .graph_state
+        .nodes
+        .iter()
+        .filter(|node| node_delivery_class(node) != NodeDeliveryClass::Code)
+        .filter(|node| projected_node_passes(node, params, ctx))
+        .filter_map(|node| {
+            let score = if query.is_empty() {
+                1.0
+            } else {
+                non_code_lexical_score(node, query)
+            };
+            (score > 0.0).then_some((node.stable_id(), score))
+        })
+        .collect::<Vec<_>>();
+    lexical.sort_by(|left, right| {
+        right
+            .1
+            .total_cmp(&left.1)
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    lexical.truncate(limit.saturating_mul(3).min(100));
+    if !lexical.is_empty() {
+        orders.insert(
+            EvidenceChannel::ExactLexical,
+            lexical.into_iter().map(|(id, _)| id).collect(),
+        );
+    }
+
+    if let Some(embed_index) = ctx.embed_index {
+        let search_mode = parse_search_mode(params.search_mode.as_deref());
+        let filters = SearchFilters {
+            subsystem: params.subsystem.clone(),
+            file: params.file.clone(),
+            language: params.language.clone(),
+            min_complexity: params.min_complexity,
+        };
+        let over_fetch = limit.saturating_mul(5).clamp(20, 100);
+        let mut requests = Vec::new();
+        if params.include_markdown {
+            requests.push((
+                "markdown_search",
+                Some(vec!["code:markdown_section".to_string()]),
+                NodeDeliveryClass::Markdown,
+            ));
+        }
+        if params.include_artifacts {
+            requests.push((
+                "artifact_search",
+                params.artifact_types.clone(),
+                NodeDeliveryClass::Artifact,
+            ));
+        }
+        for (capability, artifact_types, class) in requests {
+            let scorer = {
+                let embed_index = embed_index.clone();
+                let query = query.to_owned();
+                let filters = filters.clone();
+                async move {
+                    embed_index
+                        .search_with_filters_observed(
+                            &query,
+                            artifact_types.as_deref(),
+                            over_fetch,
+                            search_mode,
+                            &filters,
+                            TestResultPolicy::Neutral,
+                        )
+                        .await
+                }
+            };
+            match isolate_embedding_scorer(scorer, search_mode).await {
+                Ok(ObservedSearchOutcome {
+                    outcome: SearchOutcome::Results(results),
+                    executed_mode,
+                    score_provenance,
+                }) => {
+                    let channel = executed_mode
+                        .map(evidence_channel_for_executed_mode)
+                        .unwrap_or(EvidenceChannel::Vector);
+                    merge_product_score_audit(
+                        &mut product_score_audit,
+                        aligned_product_score_audit(&results, score_provenance, channel),
+                    );
+                    let mut graph_order = Vec::new();
+                    for result in results {
+                        let result_class = embedding_result_delivery_class(&result);
+                        if result_class != class
+                            || !search_result_passes_root_filter(
+                                &result,
+                                &ctx.root_filter,
+                                &ctx.non_code_slugs,
+                            )
+                        {
+                            continue;
+                        }
+                        if let Some(node) = find_node(ctx.graph_state, &result.id) {
+                            if projected_node_passes(node, params, ctx)
+                                && node_delivery_class(node) == class
+                            {
+                                graph_order.push(node.stable_id());
+                            }
+                        } else if class == NodeDeliveryClass::Artifact {
+                            let rank = synthetic.len() + 1;
+                            synthetic.push((result, channel, rank));
+                        }
+                    }
+                    if !graph_order.is_empty() {
+                        orders.entry(channel).or_default().extend(graph_order);
+                    }
+                    capabilities.push(CapabilityStatus {
+                        capability: capability.into(),
+                        state: CapabilityState::Ready,
+                        detail: format!(
+                            "embedding query executed as {}",
+                            executed_mode.map_or("unknown", |mode| match mode {
+                                ExecutedSearchMode::Keyword => "keyword",
+                                ExecutedSearchMode::Semantic => "semantic",
+                                ExecutedSearchMode::HybridRrf => "hybrid_rrf",
+                            })
+                        ),
+                    });
+                }
+                Ok(ObservedSearchOutcome {
+                    outcome: SearchOutcome::NotReady,
+                    ..
+                }) => capabilities.push(CapabilityStatus {
+                    capability: capability.into(),
+                    state: CapabilityState::Unavailable,
+                    detail: "embedding table is not ready; bounded source lexical evidence used"
+                        .into(),
+                }),
+                Err(diagnostic) => capabilities.push(CapabilityStatus {
+                    capability: capability.into(),
+                    state: CapabilityState::Degraded,
+                    detail: diagnostic.render(),
+                }),
+            }
+        }
+    }
+
+    for order in orders.values_mut() {
+        let mut seen = BTreeSet::new();
+        order.retain(|id| seen.insert(id.clone()));
+        order.truncate(limit.saturating_mul(3).min(100));
+    }
+    let channels = orders
+        .into_iter()
+        .filter(|(_, order)| !order.is_empty())
+        .map(|(channel, order)| {
+            ChannelInput::new(
+                channel,
+                ScoreKind::WithinChannelRank,
+                order
+                    .into_iter()
+                    .enumerate()
+                    .map(|(rank, id)| RawCandidateScore::new(id, (rank + 1) as f64))
+                    .collect(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let fused = fuse_ranked_channels(FusionPolicy::ordinary_search(), &channels)
+        .unwrap_or_else(|_| Vec::new());
+    let mut superseded_markdown = BTreeSet::new();
+    let mut records = fused
+        .iter()
+        .take(limit)
+        .enumerate()
+        .filter_map(|(rank, fused)| {
+            let node = find_node(ctx.graph_state, &fused.stable_id)?;
+            if node_delivery_class(node) == NodeDeliveryClass::Markdown
+                && node_source_span(node)
+                    .as_ref()
+                    .is_some_and(|source| live_markdown_sources.contains(&source.stable_id()))
+            {
+                superseded_markdown.insert(fused.stable_id.clone());
+                return None;
+            }
+            let mut selected = selected_from_fused(
+                node,
+                fused,
+                rank_offset + rank,
+                SelectionPlacement::default(),
+                Some(query),
+                ctx.repo_root,
+            );
+            append_selected_product_score_audit(
+                &mut selected,
+                product_score_audit.get(&fused.stable_id).map(Vec::as_slice),
+                query,
+                ctx.repo_root,
+            );
+            Some(selected)
+        })
+        .collect::<Vec<_>>();
+    for record in &mut live_markdown {
+        record.selection_rank = rank_offset + records.len();
+        records.push(record.clone());
+    }
+    let mut candidate_audit = Vec::new();
+    let mut synthetic_seen = BTreeSet::new();
+    for (result, channel, channel_rank) in synthetic {
+        let audit_rank = rank_offset + channel_rank.saturating_sub(1);
+        if records.len() >= limit.saturating_mul(2)
+            || !synthetic_seen.insert((result.kind.clone(), result.id.clone()))
+        {
+            let mut audit = candidate_audit_from_embedding_result(
+                &result,
+                channel,
+                audit_rank,
+                false,
+                "omitted after bounded non-code candidate selection limit or duplicate identity",
+            );
+            append_product_score_audit(
+                &mut audit.evidence,
+                product_score_audit.get(&result.id).map(Vec::as_slice),
+            );
+            candidate_audit.push(audit);
+            continue;
+        }
+        let mut audit_seed = candidate_audit_from_embedding_result(
+            &result,
+            channel,
+            audit_rank,
+            true,
+            "selected from bounded semantic artifact candidates",
+        );
+        append_product_score_audit(
+            &mut audit_seed.evidence,
+            product_score_audit.get(&result.id).map(Vec::as_slice),
+        );
+        let result_id = result.id.clone();
+        match selected_from_embedding_result(
+            result,
+            channel,
+            channel_rank,
+            rank_offset + records.len(),
+            ctx.repo_root,
+            product_score_audit.get(&result_id).map(Vec::as_slice),
+        ) {
+            Ok(record) => {
+                records.push(record);
+                candidate_audit.push(audit_seed);
+            }
+            Err(error) => {
+                candidate_audit.push(CandidateAudit {
+                    disposition: CandidateDisposition::Omitted,
+                    reason: format!(
+                        "omitted because semantic evidence could not be sealed: {error}"
+                    ),
+                    ..audit_seed
+                });
+                capabilities.push(CapabilityStatus {
+                    capability: "semantic_artifact_hydration".into(),
+                    state: CapabilityState::Degraded,
+                    detail: format!("semantic-only artifact was omitted: {error}"),
+                });
+            }
+        }
+    }
+    let selected_ids = records
+        .iter()
+        .map(|record| record.identity.node_id.as_str())
+        .collect::<BTreeSet<_>>();
+    candidate_audit.extend(fused.iter().enumerate().filter_map(|(rank, candidate)| {
+        let node = find_node(ctx.graph_state, &candidate.stable_id)?;
+        let selected = selected_ids.contains(candidate.stable_id.as_str());
+        let superseded = superseded_markdown.contains(candidate.stable_id.as_str());
+        let mut audit = candidate_audit_from_fused(
+            node,
+            candidate,
+            rank_offset + rank,
+            selected,
+            if selected {
+                "selected from bounded non-code fused candidates"
+            } else if superseded {
+                "omitted because current source-ranked Markdown supersedes the indexed duplicate"
+            } else {
+                "omitted by the non-code result limit after bounded fusion"
+            },
+        );
+        append_product_score_audit(
+            &mut audit.evidence,
+            product_score_audit
+                .get(&candidate.stable_id)
+                .map(Vec::as_slice),
+        );
+        Some(audit)
+    }));
+    candidate_audit.append(&mut live_markdown_audit);
+    (records, capabilities, candidate_audit)
+}
+
+fn projected_live_markdown_records(
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+    query: &str,
+    rank_offset: usize,
+) -> (Vec<SelectedRecord>, Vec<CandidateAudit>) {
+    if !params.include_markdown {
+        return (Vec::new(), Vec::new());
+    }
+    let Some(chunks) = admitted_live_markdown_chunks(ctx) else {
+        return (Vec::new(), Vec::new());
+    };
+    let chunks = chunks
+        .into_iter()
+        .filter(|chunk| live_markdown_chunk_passes(chunk, params))
+        .collect::<Vec<_>>();
+    let limit = params.limit.unwrap_or(10).min(100);
+    let considered_limit = limit.saturating_mul(3).min(100);
+    let roots = source_roots(params, ctx.repo_root);
+    let scored = crate::markdown::search_chunks_ranked(&chunks, query);
+    let mut records = Vec::new();
+    let mut audit = Vec::new();
+    for (rank, scored) in scored.into_iter().take(considered_limit).enumerate() {
+        let Some(source) = markdown_chunk_source_span(scored.chunk, &roots) else {
+            continue;
+        };
+        let selected = records.len() < limit;
+        let record_id = source.stable_id();
+        let candidate_rank = rank_offset + rank + 1;
+        let signature = {
+            let section = scored.chunk.section_path();
+            if section.is_empty() {
+                scored.chunk.file_path.to_string_lossy().into_owned()
+            } else {
+                section
+            }
+        };
+        let language = match scored
+            .chunk
+            .file_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+        {
+            Some(extension) if extension.eq_ignore_ascii_case("rst") => "rst",
+            _ => "markdown",
+        };
+        let evidence = SelectionEvidence {
+            raw_scores: BTreeMap::from([(
+                "markdown.source_ranked_score".to_string(),
+                scored.score.to_string(),
+            )]),
+            content_hash: Some(
+                blake3::hash(scored.chunk.content.as_bytes())
+                    .to_hex()
+                    .to_string(),
+            ),
+            candidate_rank: Some(candidate_rank),
+            provenance: vec![EvidenceProvenance {
+                source: "live_markdown".into(),
+                detail: "current root-confined source ranked by heading/body lexical evidence"
+                    .into(),
+            }],
+            diagnostics: BTreeMap::new(),
+        };
+        audit.push(CandidateAudit {
+            candidate_rank,
+            identity: RecordIdentity {
+                node_id: record_id.clone(),
+                source: Some(source.clone()),
+            },
+            disposition: if selected {
+                CandidateDisposition::Selected
+            } else {
+                CandidateDisposition::Omitted
+            },
+            reason: if selected {
+                "selected from current source-ranked Markdown".into()
+            } else {
+                "omitted by the bounded live Markdown result limit".into()
+            },
+            evidence: evidence.clone(),
+        });
+        if selected {
+            records.push(SelectedRecord {
+                selection_rank: rank_offset + records.len(),
+                identity: RecordIdentity {
+                    node_id: record_id,
+                    source: Some(source),
+                },
+                symbol: SymbolSummary {
+                    name: if scored.chunk.heading_text.is_empty() {
+                        scored.chunk.file_path.to_string_lossy().into_owned()
+                    } else {
+                        scored.chunk.heading_text.clone()
+                    },
+                    kind: "markdown_section".into(),
+                    language: language.into(),
+                    signature,
+                },
+                selection: SelectionSummary {
+                    channel: SelectionChannel::Markdown,
+                    reason: format!(
+                        "current source-ranked Markdown at within-channel rank {}",
+                        rank + 1
+                    ),
+                    role: Some(ProjectionRole::DefinitionOrApiState),
+                    lane: Some(ProjectionLane::DefinitionOrState),
+                },
+                evidence,
+                evidence_hydration: None,
+                focused_span: None,
+            });
+        }
+    }
+    (records, audit)
+}
+
+fn live_markdown_chunk_passes(chunk: &crate::types::MarkdownChunk, params: &SearchParams) -> bool {
+    let language = match chunk
+        .file_path
+        .extension()
+        .and_then(|extension| extension.to_str())
+    {
+        Some(extension) if extension.eq_ignore_ascii_case("rst") => "rst",
+        _ => "markdown",
+    };
+    params
+        .kind
+        .as_ref()
+        .is_none_or(|kind| kind.eq_ignore_ascii_case("markdown_section"))
+        && params
+            .language
+            .as_ref()
+            .is_none_or(|expected| language.eq_ignore_ascii_case(expected))
+        && params.file.as_ref().is_none_or(|file| {
+            chunk
+                .file_path
+                .to_string_lossy()
+                .replace('\\', "/")
+                .contains(file)
+        })
+        && params.min_complexity.is_none()
+        && params.synthetic.is_none()
+        && params.subsystem.is_none()
+}
+
+fn markdown_chunk_source_span(
+    chunk: &crate::types::MarkdownChunk,
+    roots: &[(String, PathBuf)],
+) -> Option<ProjectionSourceSpan> {
+    let (root, _, relative) = roots
+        .iter()
+        .filter_map(|(root, path)| {
+            chunk
+                .file_path
+                .strip_prefix(path)
+                .ok()
+                .map(|relative| (root, path, relative))
+        })
+        .max_by_key(|(_, path, _)| path.components().count())?;
+    let content = fs::read(&chunk.file_path).ok()?;
+    let end_offset = chunk.byte_offset.checked_add(chunk.byte_len)?;
+    if end_offset > content.len() {
+        return None;
+    }
+    let start_line = content[..chunk.byte_offset]
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count()
+        .checked_add(1)?;
+    let end_line = content[..end_offset]
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count()
+        .checked_add(1)?;
+    let span = ProjectionSourceSpan {
+        root: root.clone(),
+        path: relative.to_string_lossy().replace('\\', "/"),
+        start_line: u32::try_from(start_line).ok()?,
+        end_line: u32::try_from(end_line).ok()?,
+    };
+    span.is_valid().then_some(span)
+}
+
+fn candidate_audit_from_embedding_result(
+    result: &SearchResult,
+    channel: EvidenceChannel,
+    rank: usize,
+    selected: bool,
+    reason: &str,
+) -> CandidateAudit {
+    CandidateAudit {
+        candidate_rank: rank + 1,
+        identity: RecordIdentity {
+            node_id: format!("artifact:{}:{}", result.kind, result.id),
+            source: None,
+        },
+        disposition: if selected {
+            CandidateDisposition::Selected
+        } else {
+            CandidateDisposition::Omitted
+        },
+        reason: reason.into(),
+        evidence: SelectionEvidence {
+            raw_scores: BTreeMap::from([(
+                format!("{}.adjusted_product_score", channel.label()),
+                result.score.to_string(),
+            )]),
+            content_hash: Some(blake3::hash(result.body.as_bytes()).to_hex().to_string()),
+            candidate_rank: Some(rank + 1),
+            provenance: vec![EvidenceProvenance {
+                source: channel.label().into(),
+                detail: "bounded semantic-only non-code candidate".into(),
+            }],
+            diagnostics: BTreeMap::new(),
+        },
+    }
+}
+
+fn non_code_lexical_score(node: &Node, query: &str) -> f64 {
+    let base = lexical_score(node, query);
+    if base > 1.0 {
+        return base;
+    }
+    let body = node.body.to_ascii_lowercase();
+    let terms = query_terms(query);
+    let matches = terms.iter().filter(|term| body.contains(*term)).count();
+    if matches == 0 {
+        0.0
+    } else {
+        20.0 + matches as f64
+    }
+}
+
+fn embedding_result_delivery_class(result: &SearchResult) -> NodeDeliveryClass {
+    if result.kind == "code:markdown_section" {
+        NodeDeliveryClass::Markdown
+    } else if result.kind.starts_with("code:") {
+        NodeDeliveryClass::Code
+    } else {
+        NodeDeliveryClass::Artifact
+    }
+}
+
+fn selected_from_embedding_result(
+    result: SearchResult,
+    channel: EvidenceChannel,
+    channel_rank: usize,
+    selection_rank: usize,
+    repo_root: &Path,
+    score_audit: Option<&[ProductScoreAudit]>,
+) -> Result<SelectedRecord, String> {
+    let node_id = format!("artifact:{}:{}", result.kind, result.id);
+    let signature = result.body.chars().take(2_048).collect::<String>();
+    let mut raw_scores = BTreeMap::new();
+    raw_scores.insert(
+        format!("{}.adjusted_product_score", channel.label()),
+        result.score.to_string(),
+    );
+    let mut selected = SelectedRecord {
+        selection_rank,
+        identity: RecordIdentity {
+            node_id,
+            source: None,
+        },
+        symbol: SymbolSummary {
+            name: result.title,
+            kind: result.kind,
+            language: "text".into(),
+            signature,
+        },
+        selection: SelectionSummary {
+            channel: SelectionChannel::Artifact,
+            reason: format!(
+                "semantic artifact observation via {} at within-channel rank {channel_rank}",
+                channel.label()
+            ),
+            role: Some(ProjectionRole::DefinitionOrApiState),
+            lane: Some(ProjectionLane::DefinitionOrState),
+        },
+        evidence: SelectionEvidence {
+            raw_scores,
+            content_hash: Some(blake3::hash(result.body.as_bytes()).to_hex().to_string()),
+            candidate_rank: Some(channel_rank),
+            provenance: vec![EvidenceProvenance {
+                source: channel.label().into(),
+                detail: "semantic-only artifact row; no graph identity was fabricated".into(),
+            }],
+            diagnostics: BTreeMap::new(),
+        },
+        evidence_hydration: None,
+        focused_span: None,
+    };
+    append_product_score_audit(&mut selected.evidence, score_audit);
+    selected.evidence_hydration = Some(persist_semantic_evidence_capsule(
+        repo_root,
+        &selected,
+        &result.body,
+    )?);
+    Ok(selected)
+}
+
+fn evidence_capsule_capability(records: &[SelectedRecord]) -> CapabilityStatus {
+    let available = records
+        .iter()
+        .filter(|record| record.evidence_hydration.is_some())
+        .count();
+    let (state, detail) = if records.is_empty() {
+        (
+            CapabilityState::Unavailable,
+            "no selected records required evidence capsules".to_string(),
+        )
+    } else if available == records.len() {
+        (
+            CapabilityState::Ready,
+            format!(
+                "{available}/{} selected records have checksum-bound repo-native evidence capsules",
+                records.len()
+            ),
+        )
+    } else {
+        (
+            CapabilityState::Degraded,
+            format!(
+                "{available}/{} selected records have checksum-bound repo-native evidence capsules",
+                records.len()
+            ),
+        )
+    };
+    CapabilityStatus {
+        capability: "evidence_hydration".into(),
+        state,
+        detail,
+    }
+}
+
+const TASK_LANE_CANDIDATE_LIMIT: usize = 12;
+const TASK_GRAPH_CANDIDATE_LIMIT: usize = 64;
+
+#[derive(Default)]
+struct TaskAdapterOutput {
+    records: Vec<SelectedRecord>,
+    relationships: Vec<ProjectedRelationship>,
+    capabilities: Vec<CapabilityStatus>,
+    omissions: Vec<ProjectionOmission>,
+    candidate_audit: Vec<CandidateAudit>,
+}
+
+struct TaskAssembly {
+    fused: FusedCandidate,
+    roles: BTreeSet<TaskRole>,
+    lanes: BTreeSet<TaskLane>,
+    facets: BTreeSet<TaskFacet>,
+    exact_reference: Option<String>,
+    channel_rank: u32,
+    reason: String,
+}
+
+async fn task_records(
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+) -> Result<TaskAdapterOutput, String> {
+    let task = task_context::parse_task(params.query.as_deref().unwrap_or_default())
+        .map_err(|error| error.to_string())?;
+    let candidate_nodes: BTreeMap<_, _> = ctx
+        .graph_state
+        .nodes
+        .iter()
+        .filter(|node| projected_node_passes(node, params, ctx))
+        .map(|node| (node.stable_id(), node))
+        .collect();
+    let exact_candidates = candidate_nodes
+        .iter()
+        .map(|(evidence_id, node)| ExactCandidate {
+            evidence_id: evidence_id.clone(),
+            display: node.id.name.clone(),
+            match_keys: BTreeSet::from([
+                node.id.name.clone(),
+                node.signature.clone(),
+                node.stable_id(),
+            ]),
+            source_file: node.id.file.to_string_lossy().replace('\\', "/"),
+            source_line: u32::try_from(node.line_start).ok(),
+        })
+        .collect::<Vec<_>>();
+
+    let mut output = TaskAdapterOutput::default();
+    let mut assemblies = BTreeMap::<String, TaskAssembly>::new();
+    let mut product_score_audit = BTreeMap::<String, Vec<ProductScoreAudit>>::new();
+    let resolutions =
+        task_context::resolve_exact_references(&task.exact_references, &exact_candidates);
+    let mut exact_hits = 0usize;
+    for resolution in resolutions {
+        match resolution.resolution {
+            ExactResolution::Hit(candidate) => {
+                exact_hits += 1;
+                let fused = single_channel_fused(
+                    &candidate.evidence_id,
+                    EvidenceChannel::ExactLexical,
+                    ScoreKind::ExactMatchTier,
+                );
+                merge_task_assembly(
+                    &mut assemblies,
+                    fused,
+                    TaskRole::EditableSource,
+                    TaskLane::ExactReference,
+                    task_facet_for_role(TaskRole::EditableSource),
+                    Some(resolution.reference.raw.clone()),
+                    0,
+                    format!(
+                        "exact reference {:?} resolved across the full filtered graph",
+                        resolution.reference.raw
+                    ),
+                );
+            }
+            ExactResolution::Ambiguous(candidates) => output.omissions.push(ProjectionOmission {
+                record_id: None,
+                source: None,
+                code: OmissionCode::MissingSource,
+                detail: format!(
+                    "exact reference {:?} is ambiguous across {} graph records: {}",
+                    resolution.reference.raw,
+                    candidates.len(),
+                    candidates
+                        .iter()
+                        .map(|candidate| candidate.evidence_id.as_str())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                ),
+            }),
+            ExactResolution::Miss => output.omissions.push(ProjectionOmission {
+                record_id: None,
+                source: None,
+                code: OmissionCode::MissingSource,
+                detail: format!(
+                    "exact reference {:?} did not resolve in the full filtered graph",
+                    resolution.reference.raw
+                ),
+            }),
+        }
+    }
+    output.capabilities.push(CapabilityStatus {
+        capability: "task_exact_reference_resolution".into(),
+        state: if exact_hits == task.exact_references.len() {
+            CapabilityState::Ready
+        } else {
+            CapabilityState::Degraded
+        },
+        detail: format!(
+            "resolved {exact_hits}/{} prose exact references against {} root-filtered graph records before ranked retrieval",
+            task.exact_references.len(),
+            exact_candidates.len()
+        ),
+    });
+
+    let requested_facets = requested_task_facets(params, &task.facets);
+    let lane_specs = [
+        (
+            TaskFacet::Behavior,
+            TaskRole::EditableSource,
+            TaskLane::EditableSource,
+            "behavior implementation editable source",
+        ),
+        (
+            TaskFacet::ApiOrState,
+            TaskRole::DefinitionOrApiState,
+            TaskLane::DefinitionOrState,
+            "API contract state definition",
+        ),
+        (
+            TaskFacet::Test,
+            TaskRole::Test,
+            TaskLane::Tests,
+            "tests regression assertions",
+        ),
+        (
+            TaskFacet::Analogue,
+            TaskRole::BehavioralAnalogue,
+            TaskLane::Analogues,
+            "existing behavioral analogue precedent",
+        ),
+    ];
+    let base_query = params.query.as_deref().unwrap_or_default();
+    for (facet, role, lane, qualifier) in lane_specs {
+        if !requested_facets.contains(&facet) {
+            continue;
+        }
+        let mut lane_params = params.clone();
+        lane_params.query = Some(format!("{base_query}\n{qualifier}"));
+        lane_params.limit = Some(TASK_LANE_CANDIDATE_LIMIT);
+        lane_params.node = None;
+        lane_params.nodes = None;
+        lane_params.mode = None;
+        let (fused, capabilities, lane_score_audit) =
+            projected_fused_candidates(&lane_params, ctx).await?;
+        merge_product_score_audit(&mut product_score_audit, lane_score_audit);
+        let observed = fused.len().min(TASK_LANE_CANDIDATE_LIMIT);
+        let mut eligible = 0usize;
+        let mut rejected = 0usize;
+        for (rank, candidate) in fused
+            .into_iter()
+            .take(TASK_LANE_CANDIDATE_LIMIT)
+            .enumerate()
+        {
+            let Some(node) = candidate_nodes.get(&candidate.stable_id).copied() else {
+                rejected += 1;
+                continue;
+            };
+            match task_lane_candidate_evidence(node, role, &assemblies, ctx.graph_state) {
+                Ok(role_evidence) => {
+                    eligible += 1;
+                    merge_task_assembly(
+                        &mut assemblies,
+                        candidate,
+                        role,
+                        lane,
+                        facet,
+                        None,
+                        u32::try_from(rank + 1).unwrap_or(u32::MAX),
+                        format!(
+                            "independent {lane:?} retrieval lane rank {}; {role_evidence}",
+                            rank + 1
+                        ),
+                    );
+                }
+                Err(reason) => {
+                    rejected += 1;
+                    let audit_rank = output.candidate_audit.len();
+                    let mut audit = candidate_audit_from_fused(
+                        node,
+                        &candidate,
+                        audit_rank,
+                        false,
+                        &format!("ineligible for independent {lane:?} lane: {reason}"),
+                    );
+                    append_product_score_audit(
+                        &mut audit.evidence,
+                        product_score_audit
+                            .get(&candidate.stable_id)
+                            .map(Vec::as_slice),
+                    );
+                    output.candidate_audit.push(audit);
+                }
+            }
+        }
+        let degraded = capabilities
+            .iter()
+            .any(|capability| capability.state != CapabilityState::Ready);
+        output.capabilities.extend(capabilities);
+        output.capabilities.push(CapabilityStatus {
+            capability: format!("task_lane_{}", projection_lane_for_task(lane)),
+            state: if eligible == 0 || degraded {
+                CapabilityState::Degraded
+            } else {
+                CapabilityState::Ready
+            },
+            detail: format!(
+                "independently queried {observed} bounded candidates; retained {eligible} role-eligible source-grounded candidates; rejected {rejected}"
+            ),
+        });
+        if eligible == 0 {
+            output.omissions.push(ProjectionOmission {
+                record_id: None,
+                source: None,
+                code: OmissionCode::MissingSource,
+                detail: format!(
+                    "independent {lane:?} task lane had no role-eligible source-grounded evidence"
+                ),
+            });
+        }
+    }
+
+    if requested_facets.contains(&TaskFacet::Proposal) {
+        let proposal_query = params.proposal.as_deref().unwrap_or(base_query);
+        let mut proposal_params = params.clone();
+        proposal_params.query = Some(proposal_query.to_string());
+        proposal_params.limit = Some(TASK_LANE_CANDIDATE_LIMIT);
+        proposal_params.node = None;
+        proposal_params.nodes = None;
+        proposal_params.mode = None;
+        let (fused, capabilities, proposal_score_audit) =
+            projected_fused_candidates(&proposal_params, ctx).await?;
+        merge_product_score_audit(&mut product_score_audit, proposal_score_audit);
+        let observed = fused.len().min(TASK_LANE_CANDIDATE_LIMIT);
+        for (rank, candidate) in fused
+            .into_iter()
+            .take(TASK_LANE_CANDIDATE_LIMIT)
+            .enumerate()
+        {
+            merge_task_assembly(
+                &mut assemblies,
+                candidate,
+                TaskRole::ProposalDelta,
+                TaskLane::ProposalDelta,
+                TaskFacet::Proposal,
+                None,
+                u32::try_from(rank + 1).unwrap_or(u32::MAX),
+                format!("independent proposal retrieval lane rank {}", rank + 1),
+            );
+        }
+        output.capabilities.extend(capabilities);
+        output.capabilities.push(CapabilityStatus {
+            capability: "task_lane_proposal_delta".into(),
+            state: if observed == 0 {
+                CapabilityState::Degraded
+            } else {
+                CapabilityState::Ready
+            },
+            detail: format!(
+                "independently queried proposal evidence and retained {observed} bounded candidates"
+            ),
+        });
+        match live_graph_delta_card(params, ctx) {
+            Ok(card) => {
+                for (rank, impact) in card.impacted_loci.iter().enumerate() {
+                    let Ok(node) = graph_delta_grounding_node(&impact.grounding, ctx) else {
+                        continue;
+                    };
+                    merge_task_assembly(
+                        &mut assemblies,
+                        single_channel_fused(
+                            &node.stable_id(),
+                            EvidenceChannel::Graph,
+                            ScoreKind::GraphHeuristic,
+                        ),
+                        TaskRole::ProposalDelta,
+                        TaskLane::ProposalDelta,
+                        TaskFacet::Proposal,
+                        None,
+                        u32::try_from(rank + 1).unwrap_or(u32::MAX),
+                        format!(
+                            "reused live graph-delta affected locus {} ({:?})",
+                            impact.label, impact.kind
+                        ),
+                    );
+                }
+                for changed in &card.changed_edges {
+                    output.relationships.push(ProjectedRelationship {
+                        from: changed.edge.key.from.clone(),
+                        kind: format!("graph_delta_{:?}_{}", changed.change, changed.edge.key.kind)
+                            .to_ascii_lowercase(),
+                        to: changed.edge.key.to.clone(),
+                        reason: "task proposal_delta reused the live graph-delta adapter".into(),
+                    });
+                }
+                output
+                    .capabilities
+                    .extend(card.capabilities.iter().map(|report| CapabilityStatus {
+                        capability: format!(
+                            "task_proposal_{}",
+                            graph_delta_capability_name(report.capability)
+                        ),
+                        state: match report.state {
+                            graph_delta::CapabilityState::Ready => CapabilityState::Ready,
+                            graph_delta::CapabilityState::Degraded => CapabilityState::Degraded,
+                            graph_delta::CapabilityState::Unavailable => {
+                                CapabilityState::Unavailable
+                            }
+                        },
+                        detail: report.detail.clone(),
+                    }));
+                output
+                    .omissions
+                    .extend(card.omissions.iter().map(|omission| {
+                        ProjectionOmission {
+                            record_id: omission.hydration_key.clone(),
+                            source: omission
+                                .grounding
+                                .as_ref()
+                                .and_then(graph_delta_projection_span),
+                            code: OmissionCode::MissingSource,
+                            detail: format!(
+                                "task proposal graph-delta {:?}: {}",
+                                omission.code, omission.detail
+                            ),
+                        }
+                    }));
+            }
+            Err(error) => {
+                output.capabilities.push(CapabilityStatus {
+                    capability: "task_proposal_graph_delta".into(),
+                    state: CapabilityState::Degraded,
+                    detail: error.clone(),
+                });
+                output.omissions.push(ProjectionOmission {
+                    record_id: None,
+                    source: None,
+                    code: OmissionCode::MissingSource,
+                    detail: format!(
+                        "task proposal could not enter live graph-delta adapter: {error}"
+                    ),
+                });
+            }
+        }
+    }
+
+    expand_task_graph(params, ctx, &mut assemblies, &mut output.relationships);
+
+    if assemblies.len() > task_context::MAX_SELECTION_CANDIDATES {
+        return Err(format!(
+            "task adapter produced {} candidates; limit is {}",
+            assemblies.len(),
+            task_context::MAX_SELECTION_CANDIDATES
+        ));
+    }
+    let reader = projection_source_reader(params, ctx.repo_root)?;
+    let mut bundles = BTreeMap::<String, Vec<SelectedRecord>>::new();
+    let mut typed = BTreeMap::<String, TaskEvidenceCandidate>::new();
+    for (id, assembly) in &assemblies {
+        let Some(node) = candidate_nodes.get(id).copied() else {
+            continue;
+        };
+        let mut records = Vec::new();
+        for role in &assembly.roles {
+            let projected_role = projection_role_for_task(*role);
+            let mut selected = selected_from_fused(
+                node,
+                &assembly.fused,
+                0,
+                SelectionPlacement {
+                    role: Some(projected_role),
+                    lane: Some(lane_for_role(projected_role)),
+                    reason: Some(assembly.reason.clone()),
+                },
+                params.query.as_deref(),
+                ctx.repo_root,
+            );
+            append_selected_product_score_audit(
+                &mut selected,
+                product_score_audit.get(id).map(Vec::as_slice),
+                params.query.as_deref().unwrap_or_default(),
+                ctx.repo_root,
+            );
+            records.push(selected);
+        }
+        let rendered_cost = rendered_task_bundle_cost(params, &reader, &records)?;
+        let source = node_source_span(node);
+        typed.insert(
+            id.clone(),
+            TaskEvidenceCandidate {
+                evidence_id: id.clone(),
+                roles: assembly.roles.clone(),
+                lanes: assembly.lanes.clone(),
+                facets: assembly.facets.clone(),
+                rendered_cost,
+                exact_reference: assembly.exact_reference.clone(),
+                source: SourceAnchor {
+                    path: node.id.file.to_string_lossy().replace('\\', "/"),
+                    start_line: source.as_ref().map_or(1, |span| span.start_line),
+                    end_line: source.as_ref().map_or(1, |span| span.end_line),
+                },
+                channel_rank: assembly.channel_rank,
+            },
+        );
+        bundles.insert(id.clone(), records);
+    }
+
+    let mut policy = TaskSelectionPolicy::default();
+    policy.rendered_budget = params
+        .max_output_bytes
+        .unwrap_or(policy.rendered_budget)
+        .min(task_context::MAX_RENDERED_BUDGET);
+    policy.per_record_limit = policy.rendered_budget;
+    policy.candidate_limit = typed.len().clamp(1, task_context::MAX_SELECTION_CANDIDATES);
+    policy.per_file_limit = policy.per_file_limit.min(policy.candidate_limit).max(1);
+    if let Some(required) = params.context_roles.as_ref() {
+        policy.required_roles = required
+            .iter()
+            .filter_map(|role| task_role_from_str(role))
+            .collect();
+    }
+    let selection = task_context::select_context(typed.values().cloned().collect(), &policy)
+        .map_err(|error| error.to_string())?;
+    let selected_ids = selection
+        .selected
+        .iter()
+        .map(|selected| selected.evidence_id.as_str())
+        .collect::<BTreeSet<_>>();
+    for (rank, selected) in selection.selected.iter().enumerate() {
+        let reason = task_selection_reason(&selected.reason);
+        if let Some(records) = bundles.get_mut(&selected.evidence_id) {
+            for record in records {
+                record.selection_rank = rank;
+                record.selection.reason = format!("{}; {reason}", record.selection.reason);
+                output.records.push(record.clone());
+            }
+        }
+    }
+    let omission_reasons = selection
+        .omitted
+        .iter()
+        .map(|omitted| {
+            (
+                omitted.evidence_id.as_str(),
+                format!("{:?}", omitted.reason),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    for (rank, (id, assembly)) in assemblies.iter().enumerate() {
+        let Some(node) = candidate_nodes.get(id).copied() else {
+            continue;
+        };
+        let selected = selected_ids.contains(id.as_str());
+        let mut audit = candidate_audit_from_fused(
+            node,
+            &assembly.fused,
+            rank,
+            selected,
+            if selected {
+                "selected by exact-first maximum-coverage projection cost"
+            } else {
+                omission_reasons
+                    .get(id.as_str())
+                    .map(String::as_str)
+                    .unwrap_or("omitted without marginal role/lane/facet coverage")
+            },
+        );
+        append_product_score_audit(
+            &mut audit.evidence,
+            product_score_audit.get(id).map(Vec::as_slice),
+        );
+        output.candidate_audit.push(audit);
+    }
+    for omitted in &selection.omitted {
+        output.omissions.push(ProjectionOmission {
+            record_id: Some(omitted.evidence_id.clone()),
+            source: candidate_nodes
+                .get(&omitted.evidence_id)
+                .and_then(|node| node_source_span(node)),
+            code: OmissionCode::RenderBudget,
+            detail: format!("task selector omission: {:?}", omitted.reason),
+        });
+    }
+    for role in &selection.missing_roles {
+        output.omissions.push(ProjectionOmission {
+            record_id: None,
+            source: None,
+            code: OmissionCode::MissingSource,
+            detail: format!("required task context role {role:?} is not covered"),
+        });
+    }
+    output.capabilities.push(CapabilityStatus {
+        capability: "task_context_selection".into(),
+        state: if selection.missing_roles.is_empty() {
+            CapabilityState::Ready
+        } else {
+            CapabilityState::Degraded
+        },
+        detail: format!(
+            "selected {} of {} candidates at {} rendered bytes; missing_roles={:?}",
+            selection.selected.len(),
+            typed.len(),
+            selection.rendered_cost,
+            selection.missing_roles
+        ),
+    });
+    Ok(output)
+}
+
+fn task_lane_candidate_evidence(
+    node: &Node,
+    role: TaskRole,
+    assemblies: &BTreeMap<String, TaskAssembly>,
+    graph: &GraphState,
+) -> Result<String, String> {
+    let span = node_source_span(node)
+        .ok_or_else(|| "candidate has no valid current source span".to_string())?;
+    let source_evidence = format!("{}:{}-{}", span.path, span.start_line, span.end_line);
+    match role {
+        TaskRole::EditableSource => {
+            if default_role(node) == ProjectionRole::Test {
+                return Err("test source cannot satisfy the editable behavior lane".into());
+            }
+            if !matches!(
+                &node.id.kind,
+                NodeKind::Function | NodeKind::Impl | NodeKind::Macro | NodeKind::ApiEndpoint
+            ) {
+                return Err(format!(
+                    "node kind {} is not executable behavior evidence",
+                    node.id.kind
+                ));
+            }
+            Ok(format!(
+                "role eligibility: executable production kind={} source={source_evidence}",
+                node.id.kind
+            ))
+        }
+        TaskRole::DefinitionOrApiState => {
+            if !matches!(
+                &node.id.kind,
+                NodeKind::Struct
+                    | NodeKind::Trait
+                    | NodeKind::Enum
+                    | NodeKind::TypeAlias
+                    | NodeKind::Const
+                    | NodeKind::Field
+                    | NodeKind::EnumVariant
+                    | NodeKind::ProtoMessage
+                    | NodeKind::SqlTable
+                    | NodeKind::ApiEndpoint
+            ) {
+                return Err(format!(
+                    "node kind {} is not typed API/state evidence",
+                    node.id.kind
+                ));
+            }
+            Ok(format!(
+                "role eligibility: typed API/state kind={} source={source_evidence}",
+                node.id.kind
+            ))
+        }
+        TaskRole::Test => {
+            if default_role(node) != ProjectionRole::Test {
+                return Err("production source cannot satisfy the test lane".into());
+            }
+            Ok(format!(
+                "role eligibility: test path/metadata source={source_evidence}"
+            ))
+        }
+        TaskRole::BehavioralAnalogue => {
+            if default_role(node) == ProjectionRole::Test
+                || !matches!(
+                    &node.id.kind,
+                    NodeKind::Function | NodeKind::Impl | NodeKind::Macro | NodeKind::ApiEndpoint
+                )
+            {
+                return Err(format!(
+                    "node kind {} is not production behavioral evidence",
+                    node.id.kind
+                ));
+            }
+            let candidate_id = node.stable_id();
+            let mut anchors = assemblies
+                .iter()
+                .filter(|(_, assembly)| assembly.roles.contains(&TaskRole::EditableSource))
+                .filter(|(id, _)| id.as_str() != candidate_id.as_str())
+                .collect::<Vec<_>>();
+            if anchors
+                .iter()
+                .any(|(_, assembly)| assembly.exact_reference.is_some())
+            {
+                anchors.retain(|(_, assembly)| assembly.exact_reference.is_some());
+            }
+            let candidate_edges = graph
+                .edges
+                .iter()
+                .filter(|edge| edge.from.to_stable_id() == candidate_id)
+                .map(|edge| (edge.kind.to_string(), edge.to.to_stable_id()))
+                .collect::<BTreeSet<_>>();
+            let mut corroborated = anchors
+                .into_iter()
+                .filter_map(|(anchor_id, _)| {
+                    let anchor = find_node(graph, anchor_id)?;
+                    if anchor.id.kind != node.id.kind {
+                        return None;
+                    }
+                    let anchor_edges = graph
+                        .edges
+                        .iter()
+                        .filter(|edge| edge.from.to_stable_id() == anchor_id.as_str())
+                        .map(|edge| (edge.kind.to_string(), edge.to.to_stable_id()))
+                        .collect::<BTreeSet<_>>();
+                    let shared = candidate_edges
+                        .intersection(&anchor_edges)
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    (!shared.is_empty()).then_some((anchor_id.clone(), shared))
+                })
+                .collect::<Vec<_>>();
+            corroborated.sort_by(|left, right| {
+                right
+                    .1
+                    .len()
+                    .cmp(&left.1.len())
+                    .then_with(|| left.0.cmp(&right.0))
+            });
+            let Some((anchor_id, shared)) = corroborated.first() else {
+                return Err(
+                    "same-kind retrieval lacks a shared typed graph target with an editable anchor"
+                        .into(),
+                );
+            };
+            Ok(format!(
+                "role eligibility: source={source_evidence} anchor={anchor_id} shared_typed_targets={}",
+                shared
+                    .iter()
+                    .map(|(kind, target)| format!("{kind}:{target}"))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ))
+        }
+        TaskRole::DirectDependency | TaskRole::CallerOrImpact | TaskRole::ProposalDelta => Ok(
+            format!("role eligibility: typed adapter source={source_evidence}"),
+        ),
+    }
+}
+
+fn requested_task_facets(
+    params: &SearchParams,
+    inferred: &BTreeSet<TaskFacet>,
+) -> BTreeSet<TaskFacet> {
+    if let Some(values) = params.context_facets.as_deref() {
+        return values
+            .iter()
+            .filter_map(|value| match value.as_str() {
+                "behavior" => Some(TaskFacet::Behavior),
+                "api_or_state" => Some(TaskFacet::ApiOrState),
+                "test" => Some(TaskFacet::Test),
+                "analogue" => Some(TaskFacet::Analogue),
+                "proposal" => Some(TaskFacet::Proposal),
+                _ => None,
+            })
+            .collect();
+    }
+    let mut facets = BTreeSet::from([
+        TaskFacet::Behavior,
+        TaskFacet::ApiOrState,
+        TaskFacet::Test,
+        TaskFacet::Analogue,
+    ]);
+    facets.extend(inferred.iter().copied());
+    if params.proposal.is_some() {
+        facets.insert(TaskFacet::Proposal);
+    }
+    facets
+}
+
+fn projection_lane_for_task(lane: TaskLane) -> &'static str {
+    match lane {
+        TaskLane::ExactReference => "exact_reference",
+        TaskLane::EditableSource => "editable_source",
+        TaskLane::DefinitionOrState => "definition_or_state",
+        TaskLane::Tests => "tests",
+        TaskLane::Analogues => "analogues",
+        TaskLane::Dependencies => "dependencies",
+        TaskLane::GraphImpact => "graph_impact",
+        TaskLane::ProposalDelta => "proposal_delta",
+    }
+}
+
+fn single_channel_fused(
+    id: &str,
+    channel: EvidenceChannel,
+    score_kind: ScoreKind,
+) -> FusedCandidate {
+    fuse_ranked_channels(
+        FusionPolicy::task_search(),
+        &[ChannelInput::new(
+            channel,
+            score_kind,
+            vec![RawCandidateScore::new(id.to_string(), 1.0)],
+        )],
+    )
+    .expect("single finite task candidate satisfies task fusion")
+    .remove(0)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn merge_task_assembly(
+    assemblies: &mut BTreeMap<String, TaskAssembly>,
+    fused: FusedCandidate,
+    role: TaskRole,
+    lane: TaskLane,
+    facet: TaskFacet,
+    exact_reference: Option<String>,
+    channel_rank: u32,
+    reason: String,
+) {
+    let id = fused.stable_id.clone();
+    let entry = assemblies.entry(id).or_insert_with(|| TaskAssembly {
+        fused,
+        roles: BTreeSet::new(),
+        lanes: BTreeSet::new(),
+        facets: BTreeSet::new(),
+        exact_reference: exact_reference.clone(),
+        channel_rank,
+        reason: reason.clone(),
+    });
+    entry.roles.insert(role);
+    entry.lanes.insert(lane);
+    entry.facets.insert(facet);
+    if entry.exact_reference.is_none() {
+        entry.exact_reference = exact_reference;
+    }
+    entry.channel_rank = entry.channel_rank.min(channel_rank);
+    if !entry.reason.contains(&reason) {
+        entry.reason.push_str("; ");
+        entry.reason.push_str(&reason);
+    }
+}
+
+fn expand_task_graph(
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+    assemblies: &mut BTreeMap<String, TaskAssembly>,
+    relationships: &mut Vec<ProjectedRelationship>,
+) {
+    let allowed = params.edge_types.as_ref().map(|labels| {
+        labels
+            .iter()
+            .filter_map(|label| parse_edge_kind(label))
+            .collect::<BTreeSet<_>>()
+    });
+    let hops = params
+        .hops
+        .or(params.depth)
+        .unwrap_or(1)
+        .min(MAX_CONTEXT_HOPS);
+    let incoming = params.direction.as_deref() != Some("outgoing");
+    let outgoing = params.direction.as_deref() != Some("incoming");
+    let mut queue = assemblies
+        .keys()
+        .cloned()
+        .map(|id| (id, 0u32))
+        .collect::<VecDeque<_>>();
+    let mut visited = assemblies.keys().cloned().collect::<BTreeSet<_>>();
+    let mut added = 0usize;
+    while let Some((current, depth)) = queue.pop_front() {
+        if depth >= hops || added >= TASK_GRAPH_CANDIDATE_LIMIT {
+            continue;
+        }
+        let mut adjacent = Vec::new();
+        for edge in &ctx.graph_state.edges {
+            if allowed
+                .as_ref()
+                .is_some_and(|allowed| !allowed.contains(&edge.kind))
+            {
+                continue;
+            }
+            let from = edge.from.to_stable_id();
+            let to = edge.to.to_stable_id();
+            if outgoing && from == current {
+                adjacent.push((to.clone(), true, edge));
+            }
+            if incoming && to == current {
+                adjacent.push((from, false, edge));
+            }
+        }
+        adjacent.sort_by(|left, right| {
+            left.0
+                .cmp(&right.0)
+                .then_with(|| left.2.kind.cmp(&right.2.kind))
+        });
+        for (neighbor_id, is_outgoing, edge) in adjacent {
+            if added >= TASK_GRAPH_CANDIDATE_LIMIT {
+                break;
+            }
+            let Some(node) = find_node(ctx.graph_state, &neighbor_id) else {
+                continue;
+            };
+            if !projected_node_passes(node, params, ctx) {
+                continue;
+            }
+            let role = if default_role(node) == ProjectionRole::Test
+                || matches!(&edge.kind, EdgeKind::TestedBy) && !is_outgoing
+            {
+                TaskRole::Test
+            } else if is_outgoing {
+                match &edge.kind {
+                    EdgeKind::Implements | EdgeKind::Defines | EdgeKind::HasField => {
+                        TaskRole::DefinitionOrApiState
+                    }
+                    _ => TaskRole::DirectDependency,
+                }
+            } else {
+                TaskRole::CallerOrImpact
+            };
+            let lane = task_lane_for_role(role);
+            let facet = task_facet_for_role(role);
+            let fused =
+                single_channel_fused(&neighbor_id, EvidenceChannel::Graph, ScoreKind::GraphHops);
+            merge_task_assembly(
+                assemblies,
+                fused,
+                role,
+                lane,
+                facet,
+                None,
+                depth.saturating_add(1),
+                format!(
+                    "typed graph {} {} at hop {}",
+                    if is_outgoing { "outgoing" } else { "incoming" },
+                    edge.kind,
+                    depth + 1
+                ),
+            );
+            relationships.push(ProjectedRelationship {
+                from: edge.from.to_stable_id(),
+                kind: edge.kind.to_string(),
+                to: edge.to.to_stable_id(),
+                reason: format!(
+                    "task graph expansion direction={} hop={} source={} confidence={:?}",
+                    if is_outgoing { "outgoing" } else { "incoming" },
+                    depth + 1,
+                    edge.source,
+                    edge.confidence
+                ),
+            });
+            if visited.insert(neighbor_id.clone()) {
+                added += 1;
+                queue.push_back((neighbor_id, depth + 1));
+            }
+        }
+    }
+    relationships.sort();
+    relationships.dedup_by(|left, right| {
+        left.from == right.from && left.kind == right.kind && left.to == right.to
+    });
+}
+
+fn rendered_task_bundle_cost(
+    params: &SearchParams,
+    reader: &source::SourceReader,
+    records: &[SelectedRecord],
+) -> Result<usize, String> {
+    let mut request = projection_request(params, SearchIntent::Implement);
+    request.projection = SearchProjection::Evidence;
+    request.budget.max_rendered_bytes = None;
+    request.budget.max_estimated_tokens = None;
+    let plan = projection::plan_projection(
+        request,
+        ProjectionInput {
+            records: records.to_vec(),
+            ..Default::default()
+        },
+        reader,
+    );
+    render::render_projection(&plan)
+        .map(|response| response.accounting.total.utf8_bytes.max(1))
+        .map_err(|error| format!("task candidate cost projection failed: {error}"))
+}
+
+fn candidate_audit_from_fused(
+    node: &Node,
+    fused: &FusedCandidate,
+    rank: usize,
+    selected: bool,
+    reason: &str,
+) -> CandidateAudit {
+    let mut evidence = SelectionEvidence {
+        candidate_rank: Some(rank + 1),
+        content_hash: Some(node_projection_digest(node)),
+        ..Default::default()
+    };
+    for channel in &fused.channels {
+        evidence.raw_scores.insert(
+            channel.channel.label().to_string(),
+            channel.raw_score.to_string(),
+        );
+        evidence.provenance.push(EvidenceProvenance {
+            source: channel.channel.label().to_string(),
+            detail: format!(
+                "kind={} rank={} depth={} contribution={}",
+                channel.score_kind.label(),
+                channel.rank,
+                channel.depth,
+                channel.contribution
+            ),
+        });
+    }
+    evidence
+        .diagnostics
+        .insert("final_score".into(), fused.final_score.to_string());
+    CandidateAudit {
+        candidate_rank: rank + 1,
+        identity: RecordIdentity {
+            node_id: node.stable_id(),
+            source: node_source_span(node),
+        },
+        disposition: if selected {
+            CandidateDisposition::Selected
+        } else {
+            CandidateDisposition::Omitted
+        },
+        reason: reason.to_string(),
+        evidence,
+    }
+}
+
+fn projection_role_for_task(role: TaskRole) -> ProjectionRole {
+    match role {
+        TaskRole::EditableSource => ProjectionRole::EditableSource,
+        TaskRole::DefinitionOrApiState => ProjectionRole::DefinitionOrApiState,
+        TaskRole::Test => ProjectionRole::Test,
+        TaskRole::BehavioralAnalogue => ProjectionRole::BehavioralAnalogue,
+        TaskRole::DirectDependency => ProjectionRole::DirectDependency,
+        TaskRole::CallerOrImpact => ProjectionRole::CallerOrImpact,
+        TaskRole::ProposalDelta => ProjectionRole::ProposalDelta,
+    }
+}
+
+fn task_lane_for_role(role: TaskRole) -> TaskLane {
+    match role {
+        TaskRole::EditableSource => TaskLane::EditableSource,
+        TaskRole::DefinitionOrApiState => TaskLane::DefinitionOrState,
+        TaskRole::Test => TaskLane::Tests,
+        TaskRole::BehavioralAnalogue => TaskLane::Analogues,
+        TaskRole::DirectDependency => TaskLane::Dependencies,
+        TaskRole::CallerOrImpact => TaskLane::GraphImpact,
+        TaskRole::ProposalDelta => TaskLane::ProposalDelta,
+    }
+}
+
+fn task_facet_for_role(role: TaskRole) -> TaskFacet {
+    match role {
+        TaskRole::DefinitionOrApiState => TaskFacet::ApiOrState,
+        TaskRole::Test => TaskFacet::Test,
+        TaskRole::BehavioralAnalogue => TaskFacet::Analogue,
+        TaskRole::ProposalDelta => TaskFacet::Proposal,
+        TaskRole::EditableSource | TaskRole::DirectDependency | TaskRole::CallerOrImpact => {
+            TaskFacet::Behavior
+        }
+    }
+}
+
+fn task_role_from_str(value: &str) -> Option<TaskRole> {
+    match value {
+        "editable_source" => Some(TaskRole::EditableSource),
+        "definition_or_api_state" => Some(TaskRole::DefinitionOrApiState),
+        "test" => Some(TaskRole::Test),
+        "behavioral_analogue" => Some(TaskRole::BehavioralAnalogue),
+        "direct_dependency" => Some(TaskRole::DirectDependency),
+        "caller_or_impact" => Some(TaskRole::CallerOrImpact),
+        "proposal_delta" => Some(TaskRole::ProposalDelta),
+        _ => None,
+    }
+}
+
+fn task_selection_reason(reason: &TaskSelectionReason) -> String {
+    match reason {
+        TaskSelectionReason::ExactReference { reference } => {
+            format!("exact task reference {reference:?}")
+        }
+        TaskSelectionReason::CoveragePerCost {
+            newly_covered_roles,
+            newly_covered_lanes,
+            newly_covered_facets,
+        } => format!(
+            "task coverage per cost: roles={newly_covered_roles:?} lanes={newly_covered_lanes:?} facets={newly_covered_facets:?}"
+        ),
+    }
+}
+
+async fn projected_graph_delta(params: &SearchParams, ctx: &SearchContext<'_>) -> String {
+    let card = match live_graph_delta_card(params, ctx) {
+        Ok(card) => card,
+        Err(error) => return format!("Graph-delta analysis failed: {error}."),
+    };
+    let (records, relationships, capabilities, omissions, candidate_audit) =
+        graph_delta_projection(&card, params, ctx);
+    render_projected_input(
+        projection_request(params, SearchIntent::Review),
+        ProjectionInput {
+            records,
+            candidate_audit,
+            relationships,
+            omissions,
+            capabilities,
+        },
+        params,
+        ctx,
+    )
+}
+
+fn live_graph_delta_card(
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+) -> Result<graph_delta::GraphDeltaCard, String> {
+    let proposal = params.proposal.clone().unwrap_or_default();
+    let root = graph_delta_request_root(params, ctx)?;
+    let proposal_input = if proposal.trim_start().starts_with('{') {
+        graph_delta::ProposalInput::StructuredJson(proposal)
+    } else {
+        graph_delta::ProposalInput::UnifiedDiff(proposal)
+    };
+    let limits = graph_delta::GraphDeltaLimits::default();
+    let mut overlay = graph_delta::parse_beta_proposal(
+        graph_delta::BetaGraphDeltaRequest {
+            beta: true,
+            root,
+            proposal: proposal_input,
+        },
+        &limits,
+    )
+    .map_err(|error| format!("proposal rejected: {error}"))?;
+    enrich_live_graph_delta(&mut overlay, ctx);
+    let mut endpoint_pairs = overlay
+        .edge_additions
+        .iter()
+        .map(|edge| graph_delta::EndpointPair {
+            from: edge.key.from.clone(),
+            to: edge.key.to.clone(),
+        })
+        .chain(
+            overlay
+                .edge_removals
+                .iter()
+                .map(|edge| graph_delta::EndpointPair {
+                    from: edge.from.clone(),
+                    to: edge.to.clone(),
+                }),
+        )
+        .collect::<Vec<_>>();
+    endpoint_pairs.sort();
+    endpoint_pairs.dedup();
+    endpoint_pairs.truncate(limits.endpoint_pairs);
+    graph_delta::analyze_graph_delta(
+        &graph_delta_snapshot(ctx.graph_state),
+        &overlay,
+        &endpoint_pairs,
+        &limits,
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn enrich_live_graph_delta(overlay: &mut graph_delta::EphemeralOverlay, ctx: &SearchContext<'_>) {
+    let mut grounded = BTreeMap::<(String, u32), String>::new();
+    let mut changed_nodes = BTreeSet::new();
+    let mut misses = Vec::new();
+    for file in &overlay.changed_files {
+        for hunk in &file.hunks {
+            for line in &hunk.changed_lines {
+                let current_line = match line.kind {
+                    graph_delta::ChangedLineKind::Added => line.grounding.new_line,
+                    graph_delta::ChangedLineKind::Removed => line.grounding.old_line,
+                };
+                let Some(current_line) = current_line else {
+                    misses.push((
+                        line.grounding.clone(),
+                        "changed line has no current coordinate",
+                    ));
+                    continue;
+                };
+                match unique_node_at_line(ctx, &file.path, current_line) {
+                    Ok(node) => {
+                        let id = node.stable_id();
+                        grounded.insert(
+                            (file.path.clone(), line.grounding.proposal_line),
+                            id.clone(),
+                        );
+                        changed_nodes.insert(id);
+                    }
+                    Err(reason) => misses.push((line.grounding.clone(), reason)),
+                }
+            }
+        }
+    }
+
+    for id in &changed_nodes {
+        if let Some(node) = find_node(ctx.graph_state, id)
+            && let Some(grounding) = graph_delta_node_grounding(node)
+        {
+            overlay.impacted.push(graph_delta::ImpactEvidence {
+                label: node.id.name.clone(),
+                kind: graph_delta_impact_kind(node, false),
+                grounding,
+            });
+        }
+    }
+
+    let mut relationship_lines = 0usize;
+    let mut inferred_lines = 0usize;
+    for file in &overlay.changed_files {
+        for hunk in &file.hunks {
+            for line in &hunk.changed_lines {
+                if !relationship_shaped_line(&line.text) {
+                    continue;
+                }
+                relationship_lines += 1;
+                let Some(source_id) =
+                    grounded.get(&(file.path.clone(), line.grounding.proposal_line))
+                else {
+                    continue;
+                };
+                match infer_changed_line_edge(line, source_id, ctx) {
+                    Ok(Some(edge)) => {
+                        inferred_lines += 1;
+                        match line.kind {
+                            graph_delta::ChangedLineKind::Added => {
+                                if !ctx.graph_state.edges.iter().any(|current| {
+                                    current.from.to_stable_id() == edge.key.from
+                                        && current.to.to_stable_id() == edge.key.to
+                                        && current.kind.to_string() == edge.key.kind
+                                }) {
+                                    overlay.edge_additions.push(edge);
+                                }
+                            }
+                            graph_delta::ChangedLineKind::Removed => {
+                                overlay.edge_removals.push(edge.key);
+                            }
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(reason) => misses.push((line.grounding.clone(), reason)),
+                }
+            }
+        }
+    }
+
+    let mut queue = changed_nodes
+        .iter()
+        .cloned()
+        .map(|id| (id, 0u32))
+        .collect::<VecDeque<_>>();
+    let mut visited = changed_nodes.clone();
+    while let Some((current, depth)) = queue.pop_front() {
+        if depth >= 2 || visited.len() >= TASK_GRAPH_CANDIDATE_LIMIT {
+            continue;
+        }
+        for edge in &ctx.graph_state.edges {
+            let from = edge.from.to_stable_id();
+            let to = edge.to.to_stable_id();
+            let (neighbor, caller) = if from == current {
+                (to, false)
+            } else if to == current {
+                (from, true)
+            } else {
+                continue;
+            };
+            if !visited.insert(neighbor.clone()) {
+                continue;
+            }
+            let Some(node) = find_node(ctx.graph_state, &neighbor) else {
+                continue;
+            };
+            let kind = graph_delta_impact_kind(node, caller);
+            if let Some(grounding) = graph_delta_node_grounding(node) {
+                overlay.impacted.push(graph_delta::ImpactEvidence {
+                    label: node.id.name.clone(),
+                    kind,
+                    grounding,
+                });
+            }
+            queue.push_back((neighbor, depth + 1));
+        }
+    }
+
+    let mut analogue_count = 0usize;
+    for changed_id in &changed_nodes {
+        let Some(changed) = find_node(ctx.graph_state, changed_id) else {
+            continue;
+        };
+        let changed_edges = outgoing_edge_kinds(ctx.graph_state, changed_id);
+        let Some(changed_grounding) = graph_delta_node_grounding(changed) else {
+            continue;
+        };
+        let mut candidates = ctx
+            .graph_state
+            .nodes
+            .iter()
+            .filter(|candidate| {
+                candidate.stable_id() != *changed_id && candidate.id.kind == changed.id.kind
+            })
+            .filter_map(|candidate| {
+                let candidate_edges = outgoing_edge_kinds(ctx.graph_state, &candidate.stable_id());
+                let overlap = candidate_edges.intersection(&changed_edges).count();
+                (overlap > 0).then_some((
+                    std::cmp::Reverse(overlap),
+                    candidate.stable_id(),
+                    candidate,
+                ))
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+        for (std::cmp::Reverse(overlap), _, analogue) in candidates.into_iter().take(2) {
+            if analogue_count >= 8 {
+                break;
+            }
+            let Some(analogue_grounding) = graph_delta_node_grounding(analogue) else {
+                continue;
+            };
+            analogue_count += 1;
+            overlay.analogues.push(graph_delta::BehavioralAnalogue {
+                label: format!("{} analogue {}", changed.id.name, analogue.id.name),
+                changed_locus: graph_delta::ImpactEvidence {
+                    label: changed.id.name.clone(),
+                    kind: graph_delta::ImpactKind::EditableLocus,
+                    grounding: changed_grounding.clone(),
+                },
+                analogue_locus: graph_delta::ImpactEvidence {
+                    label: analogue.id.name.clone(),
+                    kind: graph_delta::ImpactKind::BehavioralAnalogue,
+                    grounding: analogue_grounding.clone(),
+                },
+                similarity_basis: format!(
+                    "same symbol kind and {overlap} shared outgoing typed edge kinds"
+                ),
+            });
+            overlay
+                .behavioral_deltas
+                .push(graph_delta::BehavioralDelta {
+                    kind: graph_delta::BehavioralDeltaKind::Other,
+                    label: format!(
+                        "compare proposed behavior at {} with {}",
+                        changed.id.name, analogue.id.name
+                    ),
+                    changed_locus: changed_grounding.clone(),
+                    analogue_locus: Some(analogue_grounding),
+                });
+        }
+    }
+
+    overlay.omissions.retain(|omission| {
+        omission.code != graph_delta::GraphDeltaOmissionCode::LiveGraphInferenceDeferred
+    });
+    for (grounding, reason) in misses {
+        overlay.omissions.push(graph_delta::GraphDeltaOmission {
+            code: graph_delta::GraphDeltaOmissionCode::CapabilityDegraded,
+            detail: format!("live graph inference skipped changed line: {reason}"),
+            hydration_key: Some(
+                graph_delta::EvidenceGrounding::Proposal(grounding.clone()).stable_hydration_key(),
+            ),
+            grounding: Some(graph_delta::EvidenceGrounding::Proposal(grounding)),
+        });
+    }
+    set_graph_delta_capability(
+        &mut overlay.capabilities,
+        graph_delta::GraphDeltaCapability::LiveGraphInference,
+        if grounded.is_empty() || inferred_lines < relationship_lines {
+            graph_delta::CapabilityState::Degraded
+        } else {
+            graph_delta::CapabilityState::Ready
+        },
+        format!(
+            "uniquely grounded {}/{} changed lines and inferred {inferred_lines}/{relationship_lines} corroborated relationship lines",
+            grounded.len(),
+            overlay
+                .changed_files
+                .iter()
+                .flat_map(|file| &file.hunks)
+                .map(|hunk| hunk.changed_lines.len())
+                .sum::<usize>()
+        ),
+    );
+    set_graph_delta_capability(
+        &mut overlay.capabilities,
+        graph_delta::GraphDeltaCapability::ImpactTraversal,
+        if changed_nodes.is_empty() {
+            graph_delta::CapabilityState::Degraded
+        } else {
+            graph_delta::CapabilityState::Ready
+        },
+        format!(
+            "bounded typed impact traversal retained {} grounded loci",
+            overlay.impacted.len()
+        ),
+    );
+    set_graph_delta_capability(
+        &mut overlay.capabilities,
+        graph_delta::GraphDeltaCapability::BehavioralAnalogueDiscovery,
+        if analogue_count == 0 {
+            graph_delta::CapabilityState::Degraded
+        } else {
+            graph_delta::CapabilityState::Ready
+        },
+        format!("retained {analogue_count} source-grounded structural analogues"),
+    );
+    set_graph_delta_capability(
+        &mut overlay.capabilities,
+        graph_delta::GraphDeltaCapability::RouteAnalysis,
+        if overlay.edge_additions.is_empty() && overlay.edge_removals.is_empty() {
+            graph_delta::CapabilityState::Unavailable
+        } else {
+            graph_delta::CapabilityState::Ready
+        },
+        format!(
+            "derived {} typed edge additions and {} typed edge removals as route endpoints",
+            overlay.edge_additions.len(),
+            overlay.edge_removals.len()
+        ),
+    );
+}
+
+fn unique_node_at_line<'a>(
+    ctx: &'a SearchContext<'_>,
+    path: &str,
+    line: u32,
+) -> Result<&'a Node, &'static str> {
+    let mut candidates = ctx
+        .graph_state
+        .nodes
+        .iter()
+        .filter(|node| node.id.file.to_string_lossy().replace('\\', "/") == path)
+        .filter(|node| {
+            u32::try_from(node.line_start).is_ok_and(|start| start <= line)
+                && u32::try_from(node.line_end).is_ok_and(|end| end >= line)
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        left.line_end
+            .saturating_sub(left.line_start)
+            .cmp(&right.line_end.saturating_sub(right.line_start))
+            .then_with(|| left.stable_id().cmp(&right.stable_id()))
+    });
+    let Some(best) = candidates.first().copied() else {
+        return Err("no current graph node contains the changed line");
+    };
+    let best_width = best.line_end.saturating_sub(best.line_start);
+    if candidates
+        .iter()
+        .skip(1)
+        .any(|candidate| candidate.line_end.saturating_sub(candidate.line_start) == best_width)
+    {
+        return Err("multiple equally specific current graph nodes contain the changed line");
+    }
+    Ok(best)
+}
+
+fn relationship_shaped_line(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    trimmed.starts_with("use ")
+        || trimmed.starts_with("import ")
+        || trimmed.starts_with("from ")
+        || (text.contains('(') && text.contains(')'))
+}
+
+fn infer_changed_line_edge(
+    line: &graph_delta::ChangedLineFact,
+    source_id: &str,
+    ctx: &SearchContext<'_>,
+) -> Result<Option<graph_delta::WeightedEdge>, &'static str> {
+    let identifiers = line
+        .text
+        .split(|character: char| !(character == '_' || character.is_ascii_alphanumeric()))
+        .filter(|token| !token.is_empty())
+        .collect::<BTreeSet<_>>();
+    let compact = line
+        .text
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect::<String>();
+    let import_like = {
+        let trimmed = line.text.trim_start();
+        trimmed.starts_with("use ")
+            || trimmed.starts_with("import ")
+            || trimmed.starts_with("from ")
+    };
+    let mut matches = ctx
+        .graph_state
+        .nodes
+        .iter()
+        .filter(|node| node.stable_id() != source_id && identifiers.contains(node.id.name.as_str()))
+        .filter(|node| import_like || compact.contains(&format!("{}(", node.id.name)))
+        .collect::<Vec<_>>();
+    matches.sort_by_key(|node| node.stable_id());
+    matches.dedup_by_key(|node| node.stable_id());
+    let [target] = matches.as_slice() else {
+        return if matches.is_empty() {
+            Err("relationship-shaped line has no uniquely corroborated current endpoint")
+        } else {
+            Err("relationship-shaped line has multiple corroborated current endpoints")
+        };
+    };
+    let kind = if import_like { "references" } else { "calls" };
+    let key = graph_delta::EdgeKey {
+        from: source_id.to_string(),
+        to: target.stable_id(),
+        kind: kind.to_string(),
+    };
+    if line.kind == graph_delta::ChangedLineKind::Removed
+        && !ctx.graph_state.edges.iter().any(|edge| {
+            edge.from.to_stable_id() == key.from
+                && edge.to.to_stable_id() == key.to
+                && edge.kind.to_string() == key.kind
+        })
+    {
+        return Err("removed relationship is not corroborated by a persisted current edge");
+    }
+    Ok(Some(graph_delta::WeightedEdge {
+        key,
+        cost: 1,
+        priority: 0,
+        registration_order: line.grounding.proposal_line,
+        grounding: graph_delta::EvidenceGrounding::Proposal(line.grounding.clone()),
+    }))
+}
+
+fn graph_delta_node_grounding(node: &Node) -> Option<graph_delta::EvidenceGrounding> {
+    node_source_span(node).map(|span| {
+        graph_delta::EvidenceGrounding::CurrentSource(graph_delta::SourceSpan {
+            root: span.root,
+            path: span.path,
+            start_line: span.start_line,
+            end_line: span.end_line,
+        })
+    })
+}
+
+fn graph_delta_impact_kind(node: &Node, caller: bool) -> graph_delta::ImpactKind {
+    if default_role(node) == ProjectionRole::Test {
+        graph_delta::ImpactKind::Test
+    } else if caller {
+        graph_delta::ImpactKind::Caller
+    } else if matches!(
+        &node.id.kind,
+        NodeKind::Struct
+            | NodeKind::Trait
+            | NodeKind::Enum
+            | NodeKind::TypeAlias
+            | NodeKind::Field
+            | NodeKind::Const
+            | NodeKind::ApiEndpoint
+    ) {
+        graph_delta::ImpactKind::StateOrApi
+    } else {
+        graph_delta::ImpactKind::EditableLocus
+    }
+}
+
+fn outgoing_edge_kinds(graph: &GraphState, id: &str) -> BTreeSet<String> {
+    graph
+        .edges
+        .iter()
+        .filter(|edge| edge.from.to_stable_id() == id)
+        .map(|edge| edge.kind.to_string())
+        .collect()
+}
+
+fn set_graph_delta_capability(
+    capabilities: &mut Vec<graph_delta::CapabilityReport>,
+    capability: graph_delta::GraphDeltaCapability,
+    state: graph_delta::CapabilityState,
+    detail: String,
+) {
+    capabilities.retain(|report| report.capability != capability);
+    capabilities.push(graph_delta::CapabilityReport {
+        capability,
+        state,
+        detail,
+    });
+}
+
+#[allow(clippy::type_complexity)]
+fn graph_delta_projection(
+    card: &graph_delta::GraphDeltaCard,
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+) -> (
+    Vec<SelectedRecord>,
+    Vec<ProjectedRelationship>,
+    Vec<CapabilityStatus>,
+    Vec<ProjectionOmission>,
+    Vec<CandidateAudit>,
+) {
+    let mut by_role = BTreeMap::<(String, ProjectionRole), SelectedRecord>::new();
+    let mut relationships = Vec::new();
+    let mut omissions = card
+        .omissions
+        .iter()
+        .map(|omission| ProjectionOmission {
+            record_id: omission.hydration_key.clone(),
+            source: omission
+                .grounding
+                .as_ref()
+                .and_then(graph_delta_projection_span),
+            code: OmissionCode::MissingSource,
+            detail: format!("graph-delta {:?}: {}", omission.code, omission.detail),
+        })
+        .collect::<Vec<_>>();
+
+    for impact in &card.impacted_loci {
+        insert_graph_delta_impact(
+            impact,
+            graph_delta_role(impact.kind),
+            params,
+            ctx,
+            &mut by_role,
+            &mut omissions,
+        );
+    }
+    for impact in &card.impacted_tests {
+        insert_graph_delta_impact(
+            impact,
+            ProjectionRole::Test,
+            params,
+            ctx,
+            &mut by_role,
+            &mut omissions,
+        );
+    }
+    for impact in &card.impacted_state_or_api {
+        insert_graph_delta_impact(
+            impact,
+            ProjectionRole::DefinitionOrApiState,
+            params,
+            ctx,
+            &mut by_role,
+            &mut omissions,
+        );
+    }
+    for bypassed in &card.bypassed_loci {
+        if let Some(node) = find_node(ctx.graph_state, &bypassed.id)
+            && node_source_span(node).is_some()
+        {
+            insert_graph_delta_node(
+                node,
+                ProjectionRole::CallerOrImpact,
+                "route comparison found this current locus bypassed after the proposal",
+                params,
+                ctx,
+                &mut by_role,
+            );
+        } else {
+            omissions.push(ProjectionOmission {
+                record_id: Some(bypassed.id.clone()),
+                source: None,
+                code: OmissionCode::MissingSource,
+                detail: "graph-delta bypassed locus has no hydratable current source".into(),
+            });
+        }
+    }
+    for analogue in &card.behavioral_analogues {
+        insert_graph_delta_impact(
+            &analogue.changed_locus,
+            ProjectionRole::ProposalDelta,
+            params,
+            ctx,
+            &mut by_role,
+            &mut omissions,
+        );
+        insert_graph_delta_impact(
+            &analogue.analogue_locus,
+            ProjectionRole::BehavioralAnalogue,
+            params,
+            ctx,
+            &mut by_role,
+            &mut omissions,
+        );
+        relationships.push(ProjectedRelationship {
+            from: analogue.changed_locus.grounding.stable_hydration_key(),
+            kind: "behavioral_analogue".into(),
+            to: analogue.analogue_locus.grounding.stable_hydration_key(),
+            reason: format!("{}; {}", analogue.label, analogue.similarity_basis),
+        });
+    }
+    for item in &card.affected_locus_checklist {
+        let impact = graph_delta::ImpactEvidence {
+            label: item.label.clone(),
+            kind: item
+                .kinds
+                .iter()
+                .next()
+                .copied()
+                .unwrap_or(graph_delta::ImpactKind::EditableLocus),
+            grounding: item.grounding.clone(),
+        };
+        insert_graph_delta_impact(
+            &impact,
+            graph_delta_role(impact.kind),
+            params,
+            ctx,
+            &mut by_role,
+            &mut omissions,
+        );
+    }
+    for changed in &card.changed_edges {
+        relationships.push(ProjectedRelationship {
+            from: changed.edge.key.from.clone(),
+            kind: format!("graph_delta_{:?}_{}", changed.change, changed.edge.key.kind)
+                .to_ascii_lowercase(),
+            to: changed.edge.key.to.clone(),
+            reason: format!(
+                "typed proposed edge {:?}; cost={} priority={} grounding={}",
+                changed.change,
+                changed.edge.cost,
+                changed.edge.priority,
+                changed.edge.grounding.stable_hydration_key()
+            ),
+        });
+    }
+    for route in &card.routes {
+        relationships.push(ProjectedRelationship {
+            from: route.endpoints.from.clone(),
+            kind: "graph_delta_route".into(),
+            to: route.endpoints.to.clone(),
+            reason: format!(
+                "change={:?} before_paths={} after_paths={}",
+                route.change,
+                route.before.alternatives.len(),
+                route.after.alternatives.len()
+            ),
+        });
+    }
+    for delta in &card.behavioral_deltas {
+        relationships.push(ProjectedRelationship {
+            from: delta.changed_locus.stable_hydration_key(),
+            kind: format!("behavioral_delta_{:?}", delta.kind).to_ascii_lowercase(),
+            to: delta
+                .analogue_locus
+                .as_ref()
+                .map(graph_delta::EvidenceGrounding::stable_hydration_key)
+                .unwrap_or_else(|| delta.changed_locus.stable_hydration_key()),
+            reason: delta.label.clone(),
+        });
+    }
+
+    let mut candidates = by_role.into_values().collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        graph_delta_record_priority(left)
+            .cmp(&graph_delta_record_priority(right))
+            .then_with(|| left.identity.node_id.cmp(&right.identity.node_id))
+            .then_with(|| left.selection.role.cmp(&right.selection.role))
+    });
+    let record_limit = params.limit.unwrap_or(20).min(100);
+    let mut selected_keys = BTreeSet::<(String, Option<ProjectionRole>)>::new();
+    let mut selected_order = Vec::<(String, Option<ProjectionRole>)>::new();
+    let mut covered_roles = BTreeSet::new();
+    for candidate in &candidates {
+        let Some(role) = candidate.selection.role else {
+            continue;
+        };
+        if selected_order.len() >= record_limit {
+            break;
+        }
+        if covered_roles.insert(role) {
+            let key = (candidate.identity.node_id.clone(), Some(role));
+            selected_keys.insert(key.clone());
+            selected_order.push(key);
+        }
+    }
+    for candidate in &candidates {
+        if selected_order.len() >= record_limit {
+            break;
+        }
+        let key = (candidate.identity.node_id.clone(), candidate.selection.role);
+        if selected_keys.insert(key.clone()) {
+            selected_order.push(key);
+        }
+    }
+    let mut records = selected_order
+        .iter()
+        .filter_map(|key| {
+            candidates.iter().find(|candidate| {
+                candidate.identity.node_id.as_str() == key.0.as_str()
+                    && candidate.selection.role == key.1
+            })
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    for (rank, record) in records.iter_mut().enumerate() {
+        record.selection_rank = rank;
+    }
+    let mut candidate_audit = candidates
+        .iter()
+        .enumerate()
+        .map(|(rank, candidate)| {
+            let selected = selected_keys.contains(&(
+                candidate.identity.node_id.clone(),
+                candidate.selection.role,
+            ));
+            CandidateAudit {
+                candidate_rank: rank + 1,
+                identity: candidate.identity.clone(),
+                disposition: if selected {
+                    CandidateDisposition::Selected
+                } else {
+                    CandidateDisposition::Omitted
+                },
+                reason: if selected {
+                    "selected by deterministic graph-delta diagnostic-role coverage and priority"
+                        .into()
+                } else {
+                    format!(
+                        "omitted after deterministic diagnostic-role selection reached record limit {record_limit}"
+                    )
+                },
+                evidence: candidate.evidence.clone(),
+            }
+        })
+        .collect::<Vec<_>>();
+    for candidate in &candidates {
+        if selected_keys.contains(&(candidate.identity.node_id.clone(), candidate.selection.role)) {
+            continue;
+        }
+        omissions.push(ProjectionOmission {
+            record_id: Some(candidate.identity.node_id.clone()),
+            source: candidate.identity.source.clone(),
+            code: OmissionCode::RenderBudget,
+            detail: format!(
+                "graph-delta {:?} locus was not rendered after deterministic diagnostic-role selection reached record limit {record_limit}; evidence remains in candidate audit",
+                candidate.selection.role
+            ),
+        });
+    }
+    let mut audited_ids = candidate_audit
+        .iter()
+        .map(|audit| audit.identity.node_id.clone())
+        .collect::<BTreeSet<_>>();
+    let mut unhydrated = omissions
+        .iter()
+        .filter_map(|omission| {
+            let id = omission.record_id.clone()?;
+            (!audited_ids.contains(&id)).then_some((id, omission))
+        })
+        .collect::<Vec<_>>();
+    unhydrated.sort_by(|left, right| {
+        left.0
+            .cmp(&right.0)
+            .then_with(|| left.1.detail.cmp(&right.1.detail))
+    });
+    for (id, omission) in unhydrated {
+        if !audited_ids.insert(id.clone()) {
+            continue;
+        }
+        candidate_audit.push(CandidateAudit {
+            candidate_rank: candidate_audit.len() + 1,
+            identity: RecordIdentity {
+                node_id: id,
+                source: omission.source.clone(),
+            },
+            disposition: CandidateDisposition::Omitted,
+            reason: format!(
+                "graph-delta candidate could not be rendered: {}",
+                omission.detail
+            ),
+            evidence: SelectionEvidence::default(),
+        });
+    }
+    let projection_omitted = candidates.len().saturating_sub(records.len());
+    let audited_omitted = candidate_audit
+        .iter()
+        .filter(|audit| audit.disposition == CandidateDisposition::Omitted)
+        .count();
+    let mut capabilities = card
+        .capabilities
+        .iter()
+        .map(|report| CapabilityStatus {
+            capability: graph_delta_capability_name(report.capability).into(),
+            state: match report.state {
+                graph_delta::CapabilityState::Ready => CapabilityState::Ready,
+                graph_delta::CapabilityState::Degraded => CapabilityState::Degraded,
+                graph_delta::CapabilityState::Unavailable => CapabilityState::Unavailable,
+            },
+            detail: report.detail.clone(),
+        })
+        .collect::<Vec<_>>();
+    capabilities.extend([
+        CapabilityStatus {
+            capability: "graph_delta_card_coverage".into(),
+            state: if audited_omitted == 0 {
+                CapabilityState::Ready
+            } else {
+                CapabilityState::Degraded
+            },
+            detail: format!(
+                "beta={}; files={}; routes={}; changed_edges={}; impacted={}; tests={}; state_or_api={}; bypassed={}; behavioral_deltas={}; analogues={}; checklist={}; adapter_omissions={}; projection_candidates={}; rendered={}; projection_omitted={}; audited_omitted={}",
+                card.beta,
+                card.changed_files.len(),
+                card.routes.len(),
+                card.changed_edges.len(),
+                card.impacted_loci.len(),
+                card.impacted_tests.len(),
+                card.impacted_state_or_api.len(),
+                card.bypassed_loci.len(),
+                card.behavioral_deltas.len(),
+                card.behavioral_analogues.len(),
+                card.affected_locus_checklist.len(),
+                card.omissions.len(),
+                candidates.len(),
+                records.len(),
+                projection_omitted,
+                audited_omitted
+            ),
+        },
+        CapabilityStatus {
+            capability: "graph_delta_changed_files".into(),
+            state: CapabilityState::Ready,
+            detail: card
+                .changed_files
+                .iter()
+                .map(|file| format!("{}:{} hunks", file.path, file.hunks.len()))
+                .collect::<Vec<_>>()
+                .join(", "),
+        },
+        CapabilityStatus {
+            capability: "graph_delta_affected_locus_checklist".into(),
+            state: if card.affected_locus_checklist.is_empty() || audited_omitted > 0 {
+                CapabilityState::Degraded
+            } else {
+                CapabilityState::Ready
+            },
+            detail: card
+                .affected_locus_checklist
+                .iter()
+                .map(|item| format!("{}={}", item.stable_id, item.label))
+                .collect::<Vec<_>>()
+                .join(", "),
+        },
+        CapabilityStatus {
+            capability: "proposal_overlay_persistence".into(),
+            state: CapabilityState::Ready,
+            detail: "analysis projected an immutable GraphState snapshot; no live node, edge, source, index, or worktree state was mutated".into(),
+        },
+    ]);
+    relationships.sort();
+    relationships.dedup();
+    (
+        records,
+        relationships,
+        capabilities,
+        omissions,
+        candidate_audit,
+    )
+}
+
+fn graph_delta_record_priority(record: &SelectedRecord) -> u8 {
+    match record.selection.role {
+        Some(ProjectionRole::ProposalDelta) => 0,
+        Some(ProjectionRole::Test) => 1,
+        Some(ProjectionRole::DefinitionOrApiState) => 2,
+        Some(ProjectionRole::BehavioralAnalogue) => 3,
+        Some(ProjectionRole::CallerOrImpact) => 4,
+        Some(ProjectionRole::EditableSource) => 5,
+        Some(ProjectionRole::DirectDependency) => 6,
+        None => 7,
+    }
+}
+
+fn graph_delta_projection_span(
+    grounding: &graph_delta::EvidenceGrounding,
+) -> Option<ProjectionSourceSpan> {
+    match grounding {
+        graph_delta::EvidenceGrounding::CurrentSource(span) => Some(ProjectionSourceSpan {
+            root: span.root.clone(),
+            path: span.path.clone(),
+            start_line: span.start_line,
+            end_line: span.end_line,
+        }),
+        graph_delta::EvidenceGrounding::Proposal(_) => None,
+    }
+}
+
+fn graph_delta_grounding_node<'a>(
+    grounding: &graph_delta::EvidenceGrounding,
+    ctx: &'a SearchContext<'_>,
+) -> Result<&'a Node, &'static str> {
+    match grounding {
+        graph_delta::EvidenceGrounding::CurrentSource(span) => {
+            unique_node_at_line(ctx, &span.path, span.start_line)
+        }
+        graph_delta::EvidenceGrounding::Proposal(line) => {
+            let current_line = line
+                .new_line
+                .or(line.old_line)
+                .ok_or("proposal line has no current coordinate")?;
+            unique_node_at_line(ctx, &line.path, current_line)
+        }
+    }
+}
+
+fn insert_graph_delta_impact(
+    impact: &graph_delta::ImpactEvidence,
+    role: ProjectionRole,
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+    by_role: &mut BTreeMap<(String, ProjectionRole), SelectedRecord>,
+    omissions: &mut Vec<ProjectionOmission>,
+) {
+    match graph_delta_grounding_node(&impact.grounding, ctx) {
+        Ok(node) => insert_graph_delta_node(
+            node,
+            role,
+            &format!(
+                "graph-delta {:?} {} grounded by {}",
+                impact.kind,
+                impact.label,
+                impact.grounding.stable_hydration_key()
+            ),
+            params,
+            ctx,
+            by_role,
+        ),
+        Err(reason) => omissions.push(ProjectionOmission {
+            record_id: Some(impact.grounding.stable_hydration_key()),
+            source: graph_delta_projection_span(&impact.grounding),
+            code: OmissionCode::MissingSource,
+            detail: format!(
+                "graph-delta impact {:?} could not hydrate: {reason}",
+                impact.label
+            ),
+        }),
+    }
+}
+
+fn insert_graph_delta_node(
+    node: &Node,
+    role: ProjectionRole,
+    reason: &str,
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+    by_role: &mut BTreeMap<(String, ProjectionRole), SelectedRecord>,
+) {
+    let id = node.stable_id();
+    let mut selected =
+        selected_from_exact_node(node, 0, reason, params.query.as_deref(), ctx.repo_root);
+    selected.selection.role = Some(role);
+    selected.selection.lane = Some(lane_for_role(role));
+    by_role.entry((id, role)).or_insert(selected);
+}
+
+fn graph_delta_role(kind: graph_delta::ImpactKind) -> ProjectionRole {
+    match kind {
+        graph_delta::ImpactKind::EditableLocus => ProjectionRole::ProposalDelta,
+        graph_delta::ImpactKind::Test => ProjectionRole::Test,
+        graph_delta::ImpactKind::StateOrApi => ProjectionRole::DefinitionOrApiState,
+        graph_delta::ImpactKind::Caller => ProjectionRole::CallerOrImpact,
+        graph_delta::ImpactKind::BehavioralAnalogue => ProjectionRole::BehavioralAnalogue,
+    }
+}
+
+fn graph_delta_capability_name(capability: graph_delta::GraphDeltaCapability) -> &'static str {
+    match capability {
+        graph_delta::GraphDeltaCapability::ProposalParsing => "graph_delta_proposal_parsing",
+        graph_delta::GraphDeltaCapability::LiveGraphInference => "graph_delta_live_graph_inference",
+        graph_delta::GraphDeltaCapability::RouteAnalysis => "graph_delta_route_analysis",
+        graph_delta::GraphDeltaCapability::ImpactTraversal => "graph_delta_impact_traversal",
+        graph_delta::GraphDeltaCapability::BehavioralAnalogueDiscovery => {
+            "graph_delta_behavioral_analogue_discovery"
+        }
+    }
+}
+
+fn graph_delta_request_root(
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+) -> Result<String, String> {
+    if let Some(root) = params
+        .root
+        .as_deref()
+        .map(str::trim)
+        .filter(|root| !root.is_empty() && *root != "all")
+    {
+        return Ok(root.to_owned());
+    }
+    if let Some(root) = ctx
+        .root_filter
+        .as_deref()
+        .map(str::trim)
+        .filter(|root| !root.is_empty() && *root != "all")
+    {
+        return Ok(root.to_owned());
+    }
+    let roots = ctx
+        .graph_state
+        .nodes
+        .iter()
+        .map(|node| node.id.root.as_str())
+        .filter(|root| !root.is_empty())
+        .collect::<BTreeSet<_>>();
+    match roots.len() {
+        1 => Ok((*roots.first().expect("one root exists")).to_owned()),
+        0 => Err("an explicit root is required because the live graph has no root identity".into()),
+        _ => Err("an explicit root is required for a multi-root graph-delta request".into()),
+    }
+}
+
+fn graph_delta_snapshot(graph: &GraphState) -> graph_delta::GraphSnapshot {
+    let mut nodes: Vec<_> = graph
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            let span = node_source_span(node)?;
+            safe_graph_delta_path(&span.path).then_some(graph_delta::GraphNode {
+                id: node.stable_id(),
+                grounding: graph_delta::EvidenceGrounding::CurrentSource(graph_delta::SourceSpan {
+                    root: span.root,
+                    path: span.path,
+                    start_line: span.start_line,
+                    end_line: span.end_line,
+                }),
+            })
+        })
+        .collect();
+    nodes.sort();
+    nodes.dedup_by(|left, right| left.id == right.id);
+    let grounding_by_id = nodes
+        .iter()
+        .map(|node| (node.id.clone(), node.grounding.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let mut edges = graph
+        .edges
+        .iter()
+        .filter_map(|edge| {
+            let from = edge.from.to_stable_id();
+            let to = edge.to.to_stable_id();
+            let grounding = grounding_by_id.get(&from)?.clone();
+            grounding_by_id.get(&to)?;
+            Some(graph_delta::WeightedEdge {
+                key: graph_delta::EdgeKey {
+                    from,
+                    to,
+                    kind: edge.kind.to_string(),
+                },
+                cost: 1,
+                priority: 0,
+                registration_order: 0,
+                grounding,
+            })
+        })
+        .collect::<Vec<_>>();
+    edges.sort_by(|left, right| left.key.cmp(&right.key));
+    for (index, edge) in edges.iter_mut().enumerate() {
+        edge.registration_order = u32::try_from(index).unwrap_or(u32::MAX);
+    }
+    graph_delta::GraphSnapshot { nodes, edges }
+}
+
+fn safe_graph_delta_path(path: &str) -> bool {
+    !path.is_empty()
+        && Path::new(path)
+            .components()
+            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
+}
+
+fn render_projected_input(
+    request: ProjectionRequest,
+    input: ProjectionInput,
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+) -> String {
+    let reader = match projection_source_reader(params, ctx.repo_root) {
+        Ok(reader) => reader,
+        Err(error) => return format!("Search source projection unavailable: {error}."),
+    };
+    let plan = projection::plan_projection(request, input, &reader);
+    render::render_projection(&plan)
+        .map(|response| response.text)
+        .unwrap_or_else(|error| format!("Search render failed: {error}."))
+}
+
+async fn projected_fused_candidates(
+    params: &SearchParams,
+    ctx: &SearchContext<'_>,
+) -> Result<
+    (
+        Vec<FusedCandidate>,
+        Vec<CapabilityStatus>,
+        BTreeMap<String, Vec<ProductScoreAudit>>,
+    ),
+    String,
+> {
+    let query = nonempty_query_preserving_bytes(params.query.as_deref()).unwrap_or("");
+    let has_filters = params.kind.is_some()
+        || params.language.is_some()
+        || params.file.is_some()
+        || params.synthetic.is_some()
+        || params.min_complexity.is_some()
+        || params.subsystem.is_some()
+        || params.sort_by.is_some();
+    let has_identity = params
+        .node
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+        || params.nodes.as_ref().is_some_and(|nodes| !nodes.is_empty());
+    if query.is_empty() && !has_filters && !has_identity {
+        return Err("Empty query; provide a query, node, nodes, or browse filter".to_string());
+    }
+
+    let candidate_limit = if params.context_mode.as_deref() == Some("task") {
+        params.limit.unwrap_or(40).clamp(20, 100)
+    } else {
+        params.limit.unwrap_or(10).clamp(20, 100)
+    };
+    let mut final_orders = BTreeMap::<EvidenceChannel, Vec<String>>::new();
+    let mut final_scores = BTreeMap::<EvidenceChannel, (ScoreKind, Vec<RawCandidateScore>)>::new();
+    let mut product_score_audit = BTreeMap::<String, Vec<ProductScoreAudit>>::new();
+    let mut capabilities = Vec::new();
+    let mut nodes = if has_identity {
+        resolve_projected_entry_nodes(params, ctx)
+    } else {
+        let search_mode = parse_search_mode(params.search_mode.as_deref());
+        let result = flat_code_symbol_search_with_diagnostics(
+            query,
+            search_mode,
+            candidate_limit,
+            params,
+            ctx.graph_state,
+            ctx,
+            params.sort_by.as_deref() == Some("complexity"),
+            params.sort_by.as_deref() == Some("importance"),
+        )
+        .await;
+        if let Some(reason) = result.strict_failure {
+            return Err(reason.to_string());
+        }
+        if let Some(diagnostic) = result.scorer_diagnostic {
+            capabilities.push(CapabilityStatus {
+                capability: "semantic_search".into(),
+                state: CapabilityState::Degraded,
+                detail: diagnostic.render(),
+            });
+        }
+        final_scores = result.score_evidence;
+        product_score_audit = result.product_score_audit;
+        final_orders = result.order_evidence;
+        let mut matches = result.matches;
+        // Fuse the union of bounded per-channel observations. The legacy flat
+        // list is still retained for legacy rendering, but it must not evict a
+        // candidate from another channel before calibrated fusion sees it.
+        let mut observed_ids = BTreeSet::new();
+        for order in final_orders.values() {
+            observed_ids.extend(order.iter().cloned());
+        }
+        for id in observed_ids {
+            if let Some(node) = find_node(ctx.graph_state, &id) {
+                matches.push(node);
+            }
+        }
+        matches
+    };
+
+    let mut graph_ids = BTreeSet::new();
+    if has_identity && params.normalized_mode().is_some() {
+        let seeds: Vec<_> = nodes.iter().map(|node| node.stable_id()).collect();
+        for seed in seeds {
+            for id in projected_traversal_ids(params, ctx.graph_state, &seed) {
+                graph_ids.insert(id.clone());
+                if let Some(node) = find_node(ctx.graph_state, &id) {
+                    nodes.push(node);
+                }
+            }
+        }
+    }
+    let mut unique = BTreeMap::new();
+    for node in nodes
+        .into_iter()
+        .filter(|node| projected_node_passes(node, params, ctx))
+    {
+        unique.entry(node.stable_id()).or_insert(node);
+    }
+    let nodes: Vec<_> = unique.values().copied().collect();
+    if nodes.is_empty() {
+        return Ok((Vec::new(), capabilities, product_score_audit));
+    }
+
+    let mut channels = Vec::new();
+    if !final_orders.contains_key(&EvidenceChannel::ExactLexical) {
+        channels.push(ChannelInput::new(
+            EvidenceChannel::ExactLexical,
+            ScoreKind::LexicalHeuristic,
+            nodes
+                .iter()
+                .map(|node| RawCandidateScore::new(node.stable_id(), lexical_score(node, query)))
+                .collect(),
+        ));
+    }
+    let scored_channels = final_scores.keys().copied().collect::<BTreeSet<_>>();
+    for (channel, (score_kind, scores)) in final_scores {
+        let scores = scores
+            .into_iter()
+            .filter(|score| unique.contains_key(&score.stable_id))
+            .collect::<Vec<_>>();
+        if scores.is_empty() {
+            continue;
+        }
+        channels.push(ChannelInput::new(channel, score_kind, scores));
+    }
+    for (channel, order) in final_orders {
+        if scored_channels.contains(&channel) {
+            continue;
+        }
+        if order.is_empty() {
+            continue;
+        }
+        channels.push(ChannelInput::new(
+            channel,
+            ScoreKind::WithinChannelRank,
+            order
+                .into_iter()
+                .enumerate()
+                .filter(|(_, id)| unique.contains_key(id))
+                .map(|(rank, id)| RawCandidateScore::new(id, (rank + 1) as f64))
+                .collect(),
+        ));
+    }
+    if !channels
+        .iter()
+        .any(|channel| channel.channel == EvidenceChannel::Structural)
+        && graph_ids.is_empty()
+    {
+        channels.push(ChannelInput::new(
+            EvidenceChannel::Structural,
+            ScoreKind::EdgeDegree,
+            nodes
+                .iter()
+                .map(|node| {
+                    RawCandidateScore::new(
+                        node.stable_id(),
+                        edge_degree(ctx.graph_state, node) as f64,
+                    )
+                })
+                .collect(),
+        ));
+    }
+    if !graph_ids.is_empty() {
+        channels.push(ChannelInput::new(
+            EvidenceChannel::Graph,
+            ScoreKind::GraphHeuristic,
+            graph_ids
+                .into_iter()
+                .filter_map(|id| {
+                    find_node(ctx.graph_state, &id).map(|node| {
+                        RawCandidateScore::new(id, edge_degree(ctx.graph_state, node) as f64)
+                    })
+                })
+                .collect(),
+        ));
+    }
+    let policy = if params.context_mode.as_deref() == Some("task") {
+        FusionPolicy::task_search()
+    } else {
+        FusionPolicy::ordinary_search()
+    };
+    fuse_ranked_channels(policy, &channels)
+        .map(|fused| (fused, capabilities, product_score_audit))
+        .map_err(|error| error.to_string())
+}
+
+fn resolve_projected_entry_nodes<'a>(
+    params: &SearchParams,
+    ctx: &'a SearchContext<'_>,
+) -> Vec<&'a Node> {
+    let requested = params
+        .nodes
+        .as_ref()
+        .map(|values| values.iter().map(String::as_str).collect::<Vec<_>>())
+        .unwrap_or_else(|| params.node.as_deref().into_iter().collect());
+    let mut matches = Vec::new();
+    for value in requested {
+        let value = value.trim();
+        let mut found: Vec<_> = ctx
+            .graph_state
+            .nodes
+            .iter()
+            .filter(|node| node.stable_id() == value || node.id.name == value)
+            .collect();
+        found.sort_by_key(|node| node.stable_id());
+        matches.extend(found);
+    }
+    matches
+}
+
+fn projected_traversal_ids(params: &SearchParams, graph: &GraphState, seed: &str) -> Vec<String> {
+    let hops = params
+        .hops
+        .or(params.depth)
+        .unwrap_or(1)
+        .min(MAX_CONTEXT_HOPS) as usize;
+    match params.normalized_mode() {
+        Some("impact") => graph.index.impact(seed, hops, None),
+        Some("reachable") => graph.index.reachable(seed, hops, None),
+        _ => {
+            let mut ids = graph
+                .index
+                .neighbors(seed, None, petgraph::Direction::Outgoing);
+            ids.extend(
+                graph
+                    .index
+                    .neighbors(seed, None, petgraph::Direction::Incoming),
+            );
+            ids.sort();
+            ids.dedup();
+            ids
+        }
+    }
+}
+
+fn projected_node_passes(node: &Node, params: &SearchParams, ctx: &SearchContext<'_>) -> bool {
+    let included = match node_delivery_class(node) {
+        NodeDeliveryClass::Code => true,
+        NodeDeliveryClass::Markdown => params.include_markdown,
+        NodeDeliveryClass::Artifact => {
+            params.include_artifacts
+                && params.artifact_types.as_ref().is_none_or(|types| {
+                    let kind = artifact_kind(node);
+                    types.is_empty() || types.iter().any(|expected| expected == kind)
+                })
+        }
+    };
+    included
+        && node_passes_root_filter(&node.id.root, &ctx.root_filter, &ctx.non_code_slugs)
+        && params
+            .kind
+            .as_ref()
+            .is_none_or(|kind| node.id.kind.to_string().eq_ignore_ascii_case(kind))
+        && params
+            .language
+            .as_ref()
+            .is_none_or(|language| node.language.eq_ignore_ascii_case(language))
+        && params
+            .file
+            .as_ref()
+            .is_none_or(|file| node.id.file.to_string_lossy().contains(file))
+        && params.min_complexity.is_none_or(|minimum| {
+            node.metadata
+                .get("cyclomatic")
+                .and_then(|value| value.parse::<u32>().ok())
+                .is_some_and(|value| value >= minimum)
+        })
+        && params.synthetic.is_none_or(|expected| {
+            node.metadata
+                .get("synthetic")
+                .is_some_and(|value| value == "true")
+                == expected
+        })
+        && params.subsystem.as_ref().is_none_or(|expected| {
+            node.metadata
+                .get(crate::server::SUBSYSTEM_KEY)
+                .is_some_and(|actual| subsystem_matches(actual, expected))
+        })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeDeliveryClass {
+    Code,
+    Markdown,
+    Artifact,
+}
+
+fn node_delivery_class(node: &Node) -> NodeDeliveryClass {
+    if node.metadata.contains_key("oh_kind") || node.id.kind == NodeKind::PrMerge {
+        NodeDeliveryClass::Artifact
+    } else if node.id.kind == NodeKind::MarkdownSection
+        || matches!(
+            node.language.to_ascii_lowercase().as_str(),
+            "markdown" | "rst"
+        )
+    {
+        NodeDeliveryClass::Markdown
+    } else {
+        NodeDeliveryClass::Code
+    }
+}
+
+fn artifact_kind(node: &Node) -> &str {
+    node.metadata
+        .get("oh_kind")
+        .map(String::as_str)
+        .unwrap_or_else(|| match &node.id.kind {
+            NodeKind::PrMerge => "merge",
+            _ => "artifact",
+        })
+}
+
+fn lexical_score(node: &Node, query: &str) -> f64 {
+    if query.is_empty() {
+        return 1.0;
+    }
+    let query = query.to_lowercase();
+    let name = node.id.name.to_lowercase();
+    if name == query {
+        100.0
+    } else if name.contains(&query) {
+        80.0
+    } else if node.signature.to_lowercase().contains(&query) {
+        60.0
+    } else if node
+        .id
+        .file
+        .to_string_lossy()
+        .to_lowercase()
+        .contains(&query)
+    {
+        40.0
+    } else {
+        1.0
+    }
+}
+
+fn edge_degree(graph: &GraphState, node: &Node) -> usize {
+    graph
+        .edges
+        .iter()
+        .filter(|edge| edge.from == node.id || edge.to == node.id)
+        .count()
+}
+
+fn find_node<'a>(graph: &'a GraphState, id: &str) -> Option<&'a Node> {
+    graph.nodes.iter().find(|node| node.stable_id() == id)
+}
+
+fn symbol_summary(node: &Node) -> SymbolSummary {
+    SymbolSummary {
+        name: node.id.name.clone(),
+        kind: node.id.kind.to_string(),
+        language: node.language.clone(),
+        signature: node.signature.clone(),
+    }
+}
+
+fn node_projection_digest(node: &Node) -> String {
+    let canonical = serde_json::to_vec(&(
+        node.stable_id(),
+        node.id.name.as_str(),
+        node.id.kind.to_string(),
+        node.language.as_str(),
+        node.signature.as_str(),
+        node.body.as_str(),
+        node_source_span(node),
+    ))
+    .expect("node projection fields are JSON serializable");
+    blake3::hash(&canonical).to_hex().to_string()
+}
+
+fn node_source_span(node: &Node) -> Option<ProjectionSourceSpan> {
+    let start_line = u32::try_from(node.line_start).ok()?;
+    let end_line = u32::try_from(node.line_end).ok()?;
+    let span = ProjectionSourceSpan {
+        root: node.id.root.clone(),
+        path: node.id.file.to_string_lossy().replace('\\', "/"),
+        start_line,
+        end_line,
+    };
+    span.is_valid().then_some(span)
+}
+
+fn default_role(node: &Node) -> ProjectionRole {
+    let path = node.id.file.to_string_lossy().to_ascii_lowercase();
+    if path.contains("test")
+        || node
+            .metadata
+            .get("is_test")
+            .is_some_and(|value| value == "true")
+    {
+        ProjectionRole::Test
+    } else if matches!(
+        &node.id.kind,
+        NodeKind::Struct
+            | NodeKind::Trait
+            | NodeKind::Enum
+            | NodeKind::TypeAlias
+            | NodeKind::Const
+            | NodeKind::ApiEndpoint
+            | NodeKind::SqlTable
+            | NodeKind::ProtoMessage
+    ) {
+        ProjectionRole::DefinitionOrApiState
+    } else {
+        ProjectionRole::EditableSource
+    }
+}
+
+fn lane_for_role(role: ProjectionRole) -> ProjectionLane {
+    match role {
+        ProjectionRole::EditableSource => ProjectionLane::EditableSource,
+        ProjectionRole::DefinitionOrApiState => ProjectionLane::DefinitionOrState,
+        ProjectionRole::Test => ProjectionLane::Tests,
+        ProjectionRole::BehavioralAnalogue => ProjectionLane::Analogues,
+        ProjectionRole::DirectDependency => ProjectionLane::Dependencies,
+        ProjectionRole::CallerOrImpact => ProjectionLane::GraphImpact,
+        ProjectionRole::ProposalDelta => ProjectionLane::ProposalDelta,
+    }
+}
+
+fn channel_for_evidence(channel: EvidenceChannel) -> SelectionChannel {
+    match channel {
+        EvidenceChannel::ExactLexical => SelectionChannel::Exact,
+        EvidenceChannel::FullText
+        | EvidenceChannel::Vector
+        | EvidenceChannel::HybridRrf
+        | EvidenceChannel::Rerank => SelectionChannel::Semantic,
+        EvidenceChannel::Graph => SelectionChannel::Graph,
+        EvidenceChannel::Structural => SelectionChannel::Lexical,
+    }
+}
+
+fn evidence_channel_for_executed_mode(mode: ExecutedSearchMode) -> EvidenceChannel {
+    match mode {
+        ExecutedSearchMode::Keyword => EvidenceChannel::FullText,
+        ExecutedSearchMode::Semantic => EvidenceChannel::Vector,
+        ExecutedSearchMode::HybridRrf => EvidenceChannel::HybridRrf,
+    }
+}
+
+fn product_test_policy(params: &SearchParams, query: &str) -> TestResultPolicy {
+    let explicit_role = params
+        .context_roles
+        .as_deref()
+        .is_some_and(|roles| roles.iter().any(|role| role == "test"));
+    let explicit_facet = params
+        .context_facets
+        .as_deref()
+        .is_some_and(|facets| facets.iter().any(|facet| facet == "test"));
+    let query_requests_tests = query
+        .split(|character: char| !character.is_alphanumeric() && character != '_')
+        .any(|term| {
+            matches!(
+                term.to_ascii_lowercase().as_str(),
+                "test" | "tests" | "testing" | "spec" | "specs" | "regression" | "fixture"
+            )
+        });
+    if explicit_role || explicit_facet || query_requests_tests {
+        TestResultPolicy::Neutral
+    } else {
+        TestResultPolicy::Demote
+    }
+}
+
+const FOCUSED_SOURCE_LINES: u32 = 40;
+const FOCUSED_SOURCE_CONTEXT_BEFORE: u32 = 12;
+
+fn query_focused_span(
+    node: &Node,
+    source: &ProjectionSourceSpan,
+    query: Option<&str>,
+) -> (Option<ProjectionSourceSpan>, Option<String>) {
+    let line_count = source
+        .end_line
+        .saturating_sub(source.start_line)
+        .saturating_add(1);
+    if line_count <= FOCUSED_SOURCE_LINES {
+        return (None, None);
+    }
+
+    let query = query.unwrap_or_default().to_ascii_lowercase();
+    let node_name = node.id.name.to_ascii_lowercase();
+    let mut terms = BTreeMap::<String, u32>::new();
+    if node_name.len() >= 3 && query.contains(&node_name) {
+        terms.insert(node_name.clone(), 1);
+    }
+    for term in query.split(|character: char| !character.is_alphanumeric() && character != '_') {
+        if term.len() >= 3
+            && !matches!(
+                term,
+                "and"
+                    | "the"
+                    | "for"
+                    | "with"
+                    | "from"
+                    | "this"
+                    | "that"
+                    | "into"
+                    | "when"
+                    | "where"
+                    | "should"
+                    | "must"
+            )
+        {
+            let behavior_weight = if matches!(
+                term,
+                "behavior"
+                    | "behaviour"
+                    | "error"
+                    | "failure"
+                    | "state"
+                    | "contract"
+                    | "regression"
+                    | "validate"
+                    | "persist"
+                    | "discard"
+            ) {
+                8
+            } else if term == node_name {
+                1
+            } else {
+                4
+            };
+            terms
+                .entry(term.to_owned())
+                .and_modify(|weight| *weight = (*weight).max(behavior_weight))
+                .or_insert(behavior_weight);
+        }
+    }
+
+    let body_lines = node
+        .body
+        .lines()
+        .map(str::to_ascii_lowercase)
+        .collect::<Vec<_>>();
+    let matched = body_lines
+        .iter()
+        .enumerate()
+        .filter_map(|(line_number, line)| {
+            let matched_terms = terms
+                .iter()
+                .filter(|(term, _)| line.contains(term.as_str()))
+                .collect::<Vec<_>>();
+            let score = matched_terms
+                .iter()
+                .map(|(_, weight)| **weight)
+                .sum::<u32>();
+            (score > 0).then(|| {
+                (
+                    score,
+                    std::cmp::Reverse(line_number),
+                    matched_terms
+                        .iter()
+                        .map(|(term, _)| term.as_str())
+                        .collect::<Vec<_>>()
+                        .join(","),
+                )
+            })
+        })
+        .max()
+        .map(|(score, std::cmp::Reverse(line), terms)| (line, score, terms));
+    let (match_offset, grounding) = matched.map_or_else(
+        || {
+            (
+                0usize,
+                "fallback:first_window:no_query_term_matched_authoritative_body".to_string(),
+            )
+        },
+        |(line, score, terms)| {
+            (
+                line,
+                format!(
+                    "query_terms={terms:?}; score={score}; body_line={}",
+                    line + 1
+                ),
+            )
+        },
+    );
+    let matched_line = source
+        .start_line
+        .saturating_add(u32::try_from(match_offset).unwrap_or(u32::MAX))
+        .min(source.end_line);
+    let mut start_line = matched_line
+        .saturating_sub(FOCUSED_SOURCE_CONTEXT_BEFORE)
+        .max(source.start_line);
+    let mut end_line = start_line
+        .saturating_add(FOCUSED_SOURCE_LINES - 1)
+        .min(source.end_line);
+    if end_line.saturating_sub(start_line).saturating_add(1) < FOCUSED_SOURCE_LINES {
+        start_line = end_line
+            .saturating_sub(FOCUSED_SOURCE_LINES - 1)
+            .max(source.start_line);
+        end_line = start_line
+            .saturating_add(FOCUSED_SOURCE_LINES - 1)
+            .min(source.end_line);
+    }
+    (
+        Some(ProjectionSourceSpan {
+            start_line,
+            end_line,
+            ..source.clone()
+        }),
+        Some(grounding),
+    )
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceCapsuleV1 {
+    schema_version: u8,
+    record_id: String,
+    query_digest: String,
+    selection_rank: usize,
+    selection: SelectionSummary,
+    evidence: SelectionEvidence,
+    current_node_content_hash: String,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SemanticEvidenceCapsuleV1 {
+    schema_version: u8,
+    record_id: String,
+    symbol: SymbolSummary,
+    selection: SelectionSummary,
+    evidence: SelectionEvidence,
+    body: String,
+}
+
+fn persist_semantic_evidence_capsule(
+    repo_root: &Path,
+    selected: &SelectedRecord,
+    body: &str,
+) -> Result<HydrationHandle, String> {
+    let content_hash = blake3::hash(body.as_bytes()).to_hex().to_string();
+    if selected.evidence.content_hash.as_deref() != Some(content_hash.as_str()) {
+        return Err("semantic row body does not match its selection evidence hash".into());
+    }
+    let capsule = SemanticEvidenceCapsuleV1 {
+        schema_version: EVIDENCE_CAPSULE_SCHEMA_VERSION,
+        record_id: selected.identity.node_id.clone(),
+        symbol: selected.symbol.clone(),
+        selection: selected.selection.clone(),
+        evidence: selected.evidence.clone(),
+        body: body.to_string(),
+    };
+    let bytes = serde_json::to_vec(&capsule)
+        .map_err(|error| format!("semantic evidence capsule serialization failed: {error}"))?;
+    if bytes.len() > MAX_EVIDENCE_CAPSULE_BYTES {
+        return Err(format!(
+            "semantic evidence capsule is {} bytes; limit is {MAX_EVIDENCE_CAPSULE_BYTES}",
+            bytes.len()
+        ));
+    }
+    let digest = blake3::hash(&bytes).to_hex().to_string();
+    let directory = evidence_capsule_directory(repo_root, true)?;
+    let destination = directory.join(format!("{digest}.json"));
+    if destination.exists() {
+        let existing = read_evidence_capsule_bytes(&destination)?;
+        if existing != bytes {
+            return Err("content-addressed semantic evidence capsule collision".into());
+        }
+    } else {
+        write_evidence_capsule_atomic(&directory, &destination, &digest, &bytes)?;
+    }
+    Ok(HydrationHandle::evidence(format!(
+        "{SEMANTIC_EVIDENCE_CAPSULE_PREFIX}{digest}:{}",
+        selected.identity.node_id
+    )))
+}
+
+fn persist_evidence_capsule(
+    repo_root: &Path,
+    query: &str,
+    selected: &SelectedRecord,
+) -> Result<HydrationHandle, String> {
+    let current_node_content_hash = selected
+        .evidence
+        .content_hash
+        .clone()
+        .ok_or_else(|| "selected record has no authoritative content hash".to_string())?;
+    let capsule = EvidenceCapsuleV1 {
+        schema_version: EVIDENCE_CAPSULE_SCHEMA_VERSION,
+        record_id: selected.identity.node_id.clone(),
+        query_digest: blake3::hash(query.as_bytes()).to_hex().to_string(),
+        selection_rank: selected.selection_rank,
+        selection: selected.selection.clone(),
+        evidence: selected.evidence.clone(),
+        current_node_content_hash,
+    };
+    let bytes = serde_json::to_vec(&capsule)
+        .map_err(|error| format!("evidence capsule serialization failed: {error}"))?;
+    if bytes.len() > MAX_EVIDENCE_CAPSULE_BYTES {
+        return Err(format!(
+            "evidence capsule is {} bytes; limit is {MAX_EVIDENCE_CAPSULE_BYTES}",
+            bytes.len()
+        ));
+    }
+    let digest = blake3::hash(&bytes).to_hex().to_string();
+    let directory = evidence_capsule_directory(repo_root, true)?;
+    let destination = directory.join(format!("{digest}.json"));
+    if destination.exists() {
+        let existing = read_evidence_capsule_bytes(&destination)?;
+        if existing != bytes {
+            return Err("content-addressed evidence capsule collision".into());
+        }
+    } else {
+        write_evidence_capsule_atomic(&directory, &destination, &digest, &bytes)?;
+    }
+    Ok(HydrationHandle::evidence(format!(
+        "{EVIDENCE_CAPSULE_PREFIX}{digest}:{}",
+        selected.identity.node_id
+    )))
+}
+
+fn evidence_capsule_directory(repo_root: &Path, create: bool) -> Result<PathBuf, String> {
+    let mut current = repo_root.to_path_buf();
+    for component in [".oh", ".cache", "search_evidence", "v1"] {
+        current.push(component);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(format!(
+                    "evidence cache component is a symlink: {}",
+                    current.display()
+                ));
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                return Err(format!(
+                    "evidence cache component is not a directory: {}",
+                    current.display()
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound && create => {
+                if let Err(create_error) = fs::create_dir(&current)
+                    && create_error.kind() != std::io::ErrorKind::AlreadyExists
+                {
+                    return Err(format!(
+                        "failed to create evidence cache {}: {create_error}",
+                        current.display()
+                    ));
+                }
+                let metadata = fs::symlink_metadata(&current).map_err(|metadata_error| {
+                    format!(
+                        "failed to verify evidence cache {}: {metadata_error}",
+                        current.display()
+                    )
+                })?;
+                if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                    return Err(format!(
+                        "evidence cache component is not a real directory: {}",
+                        current.display()
+                    ));
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err("evidence cache is unavailable".into());
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to inspect evidence cache {}: {error}",
+                    current.display()
+                ));
+            }
+        }
+    }
+    Ok(current)
+}
+
+fn write_evidence_capsule_atomic(
+    directory: &Path,
+    destination: &Path,
+    digest: &str,
+    bytes: &[u8],
+) -> Result<(), String> {
+    let mut temporary = None;
+    for attempt in 0..16u8 {
+        let path = directory.join(format!(".{digest}.tmp-{}-{attempt}", std::process::id()));
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(mut file) => {
+                file.write_all(bytes)
+                    .and_then(|()| file.sync_all())
+                    .map_err(|error| format!("failed to seal evidence capsule: {error}"))?;
+                temporary = Some(path);
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(format!("failed to create evidence capsule: {error}"));
+            }
+        }
+    }
+    let temporary = temporary.ok_or_else(|| "evidence capsule temp slots exhausted".to_string())?;
+    match fs::hard_link(&temporary, destination) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let existing = read_evidence_capsule_bytes(destination)?;
+            if existing != bytes {
+                let _ = fs::remove_file(&temporary);
+                return Err("content-addressed evidence capsule collision".into());
+            }
+        }
+        Err(error) => {
+            let _ = fs::remove_file(&temporary);
+            return Err(format!("failed to publish evidence capsule: {error}"));
+        }
+    }
+    fs::remove_file(&temporary)
+        .map_err(|error| format!("failed to remove evidence capsule temp file: {error}"))?;
+    Ok(())
+}
+
+fn read_evidence_capsule_bytes(path: &Path) -> Result<Vec<u8>, String> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("failed to inspect evidence capsule: {error}"))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err("evidence capsule is not a regular file".into());
+    }
+    if metadata.len() > MAX_EVIDENCE_CAPSULE_BYTES as u64 {
+        return Err(format!(
+            "evidence capsule exceeds {MAX_EVIDENCE_CAPSULE_BYTES} bytes"
+        ));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    fs::File::open(path)
+        .and_then(|mut file| {
+            std::io::Read::by_ref(&mut file)
+                .take(MAX_EVIDENCE_CAPSULE_BYTES as u64 + 1)
+                .read_to_end(&mut bytes)
+        })
+        .map_err(|error| format!("failed to read evidence capsule: {error}"))?;
+    if bytes.len() > MAX_EVIDENCE_CAPSULE_BYTES {
+        return Err(format!(
+            "evidence capsule exceeds {MAX_EVIDENCE_CAPSULE_BYTES} bytes"
+        ));
+    }
+    Ok(bytes)
+}
+
+fn parse_evidence_capsule_reference(record_id: &str) -> Result<(&str, &str), String> {
+    let reference = record_id
+        .strip_prefix(EVIDENCE_CAPSULE_PREFIX)
+        .ok_or_else(|| "unsupported evidence hydration reference".to_string())?;
+    let (digest, node_id) = reference
+        .split_once(':')
+        .ok_or_else(|| "invalid evidence hydration reference".to_string())?;
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        || node_id.is_empty()
+    {
+        return Err("invalid evidence hydration reference".into());
+    }
+    Ok((digest, node_id))
+}
+
+fn parse_semantic_evidence_capsule_reference(record_id: &str) -> Result<(&str, &str), String> {
+    let reference = record_id
+        .strip_prefix(SEMANTIC_EVIDENCE_CAPSULE_PREFIX)
+        .ok_or_else(|| "unsupported semantic evidence hydration reference".to_string())?;
+    let (digest, semantic_id) = reference
+        .split_once(':')
+        .ok_or_else(|| "invalid semantic evidence hydration reference".to_string())?;
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        || semantic_id.is_empty()
+    {
+        return Err("invalid semantic evidence hydration reference".into());
+    }
+    Ok((digest, semantic_id))
+}
+
+#[derive(Default)]
+struct SelectionPlacement {
+    role: Option<ProjectionRole>,
+    lane: Option<ProjectionLane>,
+    reason: Option<String>,
+}
+
+fn selected_from_fused(
+    node: &Node,
+    fused: &FusedCandidate,
+    rank: usize,
+    placement: SelectionPlacement,
+    query: Option<&str>,
+    repo_root: &Path,
+) -> SelectedRecord {
+    let SelectionPlacement { role, lane, reason } = placement;
+    let source = node_source_span(node);
+    let (focused_span, focus_grounding) = source
+        .as_ref()
+        .map(|span| query_focused_span(node, span, query))
+        .unwrap_or((None, None));
+    let mut evidence = SelectionEvidence {
+        candidate_rank: Some(rank + 1),
+        content_hash: Some(node_projection_digest(node)),
+        ..Default::default()
+    };
+    for channel in &fused.channels {
+        evidence.raw_scores.insert(
+            channel.channel.label().to_string(),
+            channel.raw_score.to_string(),
+        );
+        evidence.provenance.push(EvidenceProvenance {
+            source: channel.channel.label().to_string(),
+            detail: format!(
+                "kind={} rank={} depth={} normalized_rank_micros={} weight={} contribution={}",
+                channel.score_kind.label(),
+                channel.rank,
+                channel.depth,
+                channel.normalized_rank_micros,
+                channel.weight,
+                channel.contribution
+            ),
+        });
+    }
+    let tie_vector = fused
+        .tie_break
+        .channel_ranks
+        .iter()
+        .map(|entry| {
+            format!(
+                "{}={}",
+                entry.channel.label(),
+                entry
+                    .rank
+                    .map_or_else(|| "none".to_string(), |rank| rank.to_string())
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let fusion_reason = fused.final_reason.summary();
+    evidence.diagnostics.insert(
+        "fusion_policy".into(),
+        fused.final_reason.policy.label().into(),
+    );
+    if let Some(focus_grounding) = focus_grounding {
+        evidence
+            .diagnostics
+            .insert("focus_grounding".into(), focus_grounding);
+    }
+    evidence
+        .diagnostics
+        .insert("final_score".into(), fused.final_score.to_string());
+    evidence
+        .diagnostics
+        .insert("final_reason".into(), fusion_reason.clone());
+    evidence.diagnostics.insert(
+        "tie_break".into(),
+        format!(
+            "channel_ranks=[{tie_vector}] stable_id_utf8={:?}",
+            fused.tie_break.stable_id_utf8
+        ),
+    );
+    let role = role.unwrap_or_else(|| default_role(node));
+    let lane = lane.unwrap_or_else(|| lane_for_role(role));
+    let selection_channel = match node_delivery_class(node) {
+        NodeDeliveryClass::Markdown => SelectionChannel::Markdown,
+        NodeDeliveryClass::Artifact => SelectionChannel::Artifact,
+        NodeDeliveryClass::Code => channel_for_evidence(fused.final_reason.leading_channel),
+    };
+    let reason = reason.map_or(fusion_reason.clone(), |task_reason| {
+        format!("{fusion_reason}; {task_reason}")
+    });
+    let mut selected = SelectedRecord {
+        selection_rank: rank,
+        identity: RecordIdentity {
+            node_id: node.stable_id(),
+            source,
+        },
+        symbol: symbol_summary(node),
+        selection: SelectionSummary {
+            channel: selection_channel,
+            reason,
+            role: Some(role),
+            lane: Some(lane),
+        },
+        evidence,
+        evidence_hydration: None,
+        focused_span,
+    };
+    match persist_evidence_capsule(repo_root, query.unwrap_or_default(), &selected) {
+        Ok(handle) => selected.evidence_hydration = Some(handle),
+        Err(error) => {
+            selected
+                .evidence
+                .diagnostics
+                .insert("evidence_hydration".into(), format!("unavailable: {error}"));
+        }
+    }
+    selected
+}
+
+fn selected_from_exact_node(
+    node: &Node,
+    rank: usize,
+    reason: &str,
+    query: Option<&str>,
+    repo_root: &Path,
+) -> SelectedRecord {
+    let fused = fuse_ranked_channels(
+        FusionPolicy::ordinary_search(),
+        &[ChannelInput::new(
+            EvidenceChannel::ExactLexical,
+            ScoreKind::ExactMatchTier,
+            vec![RawCandidateScore::new(node.stable_id(), 1.0)],
+        )],
+    )
+    .expect("a single finite exact candidate satisfies ordinary fusion")
+    .remove(0);
+    selected_from_fused(
+        node,
+        &fused,
+        rank,
+        SelectionPlacement {
+            role: None,
+            lane: Some(ProjectionLane::ExactReference),
+            reason: Some(reason.to_string()),
+        },
+        query,
+        repo_root,
+    )
+}
+
+async fn default_capabilities(
+    ctx: &SearchContext<'_>,
+    projection: SearchProjection,
+) -> Vec<CapabilityStatus> {
+    let semantic_attached = ctx.embed_index.is_some();
+    let semantic_probe = match ctx.embed_index {
+        Some(index) => index.has_table().await,
+        None => Ok(false),
+    };
+    let semantic_available = semantic_probe.as_ref().copied().unwrap_or(false);
+    let semantic = if let Some(status) = ctx.embed_status {
+        let readiness = status.capability_readiness(semantic_attached, semantic_available);
+        CapabilityStatus {
+            capability: "semantic_search".into(),
+            state: projection_capability_state(readiness.state),
+            detail: readiness.detail,
+        }
+    } else {
+        match semantic_probe {
+            Ok(true) => CapabilityStatus {
+                capability: "semantic_search".into(),
+                state: CapabilityState::Ready,
+                detail: "embedding table was probed and is queryable".into(),
+            },
+            Ok(false) if semantic_attached => CapabilityStatus {
+                capability: "semantic_search".into(),
+                state: CapabilityState::Degraded,
+                detail: "embedding index is attached but its table is not queryable".into(),
+            },
+            Ok(false) => CapabilityStatus {
+                capability: "semantic_search".into(),
+                state: CapabilityState::Unavailable,
+                detail: "embedding index is not attached; lexical/graph evidence used".into(),
+            },
+            Err(error) => CapabilityStatus {
+                capability: "semantic_search".into(),
+                state: CapabilityState::Degraded,
+                detail: format!("embedding readiness probe failed: {error}"),
+            },
+        }
+    };
+    let lsp = ctx.lsp_status.map_or_else(
+        || CapabilityStatus {
+            capability: "lsp_call_references".into(),
+            state: CapabilityState::Unavailable,
+            detail: "LSP status is not attached".into(),
+        },
+        |status| {
+            let readiness = status.call_reference_readiness();
+            CapabilityStatus {
+                capability: "lsp_call_references".into(),
+                state: projection_capability_state(readiness.state),
+                detail: readiness.detail,
+            }
+        },
+    );
+    let mut capabilities = vec![semantic, lsp.clone()];
+    if projection == SearchProjection::Evidence {
+        capabilities.push(CapabilityStatus {
+            capability: "readiness_diagnostics".into(),
+            state: lsp.state,
+            detail: format_verbose_readiness(
+                ctx.graph_state,
+                ctx,
+                semantic_attached,
+                semantic_available,
+            ),
+        });
+    }
+    capabilities
+}
+
+fn projection_capability_state(state: CapabilityReadinessState) -> CapabilityState {
+    match state {
+        CapabilityReadinessState::Ready => CapabilityState::Ready,
+        CapabilityReadinessState::Partial
+        | CapabilityReadinessState::Running
+        | CapabilityReadinessState::Stale => CapabilityState::Degraded,
+        CapabilityReadinessState::Failed
+        | CapabilityReadinessState::Unavailable
+        | CapabilityReadinessState::NotNeeded => CapabilityState::Unavailable,
+    }
+}
+
+fn merge_capabilities(capabilities: Vec<CapabilityStatus>) -> Vec<CapabilityStatus> {
+    let severity = |state| match state {
+        CapabilityState::Ready => 0,
+        CapabilityState::Degraded => 1,
+        CapabilityState::Unavailable => 2,
+    };
+    let mut merged = BTreeMap::<String, CapabilityStatus>::new();
+    for capability in capabilities {
+        match merged.entry(capability.capability.clone()) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(capability);
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                let current = entry.get_mut();
+                if severity(capability.state) > severity(current.state) {
+                    current.state = capability.state;
+                }
+                if !current.detail.contains(&capability.detail) {
+                    current.detail.push_str("; ");
+                    current.detail.push_str(&capability.detail);
+                }
+            }
+        }
+    }
+    merged.into_values().collect()
+}
+
+fn projected_relationships(
+    graph: &GraphState,
+    records: &[SelectedRecord],
+) -> Vec<ProjectedRelationship> {
+    let ids: BTreeSet<_> = records
+        .iter()
+        .map(|record| record.identity.node_id.as_str())
+        .collect();
+    let mut relationships: Vec<_> = graph
+        .edges
+        .iter()
+        .filter_map(|edge| {
+            let from = edge.from.to_stable_id();
+            let to = edge.to.to_stable_id();
+            (ids.contains(from.as_str()) && ids.contains(to.as_str())).then(|| {
+                ProjectedRelationship {
+                    from,
+                    kind: edge.kind.to_string(),
+                    to,
+                    reason: format!("{} {:?}", edge.source, edge.confidence),
+                }
+            })
+        })
+        .collect();
+    relationships.sort();
+    relationships.dedup();
+    relationships
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct EmbeddingScorerDiagnostic {
     failure: &'static str,
@@ -926,9 +5643,9 @@ impl Drop for ScorerPanicRedactionGuard {
     }
 }
 
-async fn poll_scorer_with_content_safe_panic_hook<F>(scorer: F) -> anyhow::Result<SearchOutcome>
+async fn poll_scorer_with_content_safe_panic_hook<F, T>(scorer: F) -> anyhow::Result<T>
 where
-    F: std::future::Future<Output = anyhow::Result<SearchOutcome>>,
+    F: std::future::Future<Output = anyhow::Result<T>>,
 {
     let mut scorer = Box::pin(scorer);
     std::future::poll_fn(move |cx| {
@@ -956,12 +5673,13 @@ impl EmbeddingScorerDiagnostic {
     }
 }
 
-async fn isolate_embedding_scorer<F>(
+async fn isolate_embedding_scorer<F, T>(
     scorer: F,
     mode: SearchMode,
-) -> Result<SearchOutcome, EmbeddingScorerDiagnostic>
+) -> Result<T, EmbeddingScorerDiagnostic>
 where
-    F: std::future::Future<Output = anyhow::Result<SearchOutcome>> + Send + 'static,
+    F: std::future::Future<Output = anyhow::Result<T>> + Send + 'static,
+    T: Send + 'static,
 {
     install_scorer_panic_hook();
     match tokio::spawn(poll_scorer_with_content_safe_panic_hook(scorer)).await {
@@ -1022,20 +5740,180 @@ fn test_embedding_scorer_panic_payload() -> Option<String> {
 
 struct FlatCodeSymbolSearch<'a> {
     matches: Vec<&'a Node>,
+    /// Per-channel candidate order after supplements and optional reranking.
+    order_evidence: BTreeMap<EvidenceChannel, Vec<String>>,
+    /// Native scorer values that remain available at this seam. Channels not
+    /// present here truthfully fall back to within-channel order evidence.
+    score_evidence: BTreeMap<EvidenceChannel, (ScoreKind, Vec<RawCandidateScore>)>,
+    /// Backend-native score provenance is audit-only. Product fusion continues
+    /// to consume the final adjusted result order, never these incomparable
+    /// native values.
+    product_score_audit: BTreeMap<String, Vec<ProductScoreAudit>>,
     scorer_diagnostic: Option<EmbeddingScorerDiagnostic>,
     strict_failure: Option<&'static str>,
 }
 
-fn markdown_search_section(
-    params: &SearchParams,
-    query_str: &str,
-    ctx: &SearchContext<'_>,
-    limit: usize,
-) -> Option<String> {
-    if !params.include_markdown || query_str.is_empty() {
-        return None;
-    }
+#[derive(Debug, Clone, PartialEq)]
+struct ProductScoreAudit {
+    channel: EvidenceChannel,
+    provenance: SearchScoreProvenance,
+    adjusted_product_score: f32,
+}
 
+fn aligned_product_score_audit(
+    results: &[SearchResult],
+    provenance: Vec<SearchScoreProvenance>,
+    channel: EvidenceChannel,
+) -> BTreeMap<String, Vec<ProductScoreAudit>> {
+    if results.len() != provenance.len()
+        || results
+            .iter()
+            .zip(&provenance)
+            .any(|(result, score)| result.id != score.result_id)
+    {
+        tracing::warn!(
+            result_count = results.len(),
+            provenance_count = provenance.len(),
+            "Embedding score audit was not aligned with returned results; native audit omitted"
+        );
+        return BTreeMap::new();
+    }
+    results
+        .iter()
+        .zip(provenance)
+        .map(|(result, provenance)| {
+            (
+                result.id.clone(),
+                vec![ProductScoreAudit {
+                    channel,
+                    provenance,
+                    adjusted_product_score: result.score,
+                }],
+            )
+        })
+        .collect()
+}
+
+fn merge_product_score_audit(
+    target: &mut BTreeMap<String, Vec<ProductScoreAudit>>,
+    source: BTreeMap<String, Vec<ProductScoreAudit>>,
+) {
+    for (id, audits) in source {
+        let entry = target.entry(id).or_default();
+        for audit in audits {
+            if !entry.contains(&audit) {
+                entry.push(audit);
+            }
+        }
+    }
+}
+
+fn append_product_score_audit(
+    evidence: &mut SelectionEvidence,
+    audits: Option<&[ProductScoreAudit]>,
+) {
+    let Some(audits) = audits else {
+        return;
+    };
+    for (index, audit) in audits.iter().enumerate() {
+        let prefix = format!("score_audit.{}.{}", audit.channel.label(), index + 1);
+        evidence.raw_scores.insert(
+            format!("{prefix}.native_value"),
+            audit.provenance.native_value.to_string(),
+        );
+        evidence.diagnostics.extend([
+            (
+                format!("{prefix}.native_kind"),
+                native_score_kind_label(audit.provenance.native_kind).into(),
+            ),
+            (
+                format!("{prefix}.native_source"),
+                native_score_source_label(audit.provenance.native_source).into(),
+            ),
+            (
+                format!("{prefix}.normalization"),
+                score_normalization_label(audit.provenance.normalization).into(),
+            ),
+            (
+                format!("{prefix}.normalized_score"),
+                audit.provenance.normalized_score.to_string(),
+            ),
+            (
+                format!("{prefix}.adjustment"),
+                score_adjustment_label(audit.provenance.adjustment).into(),
+            ),
+            (
+                format!("{prefix}.adjusted_product_score"),
+                audit.adjusted_product_score.to_string(),
+            ),
+        ]);
+        evidence.provenance.push(EvidenceProvenance {
+            source: format!("{}_native_score", audit.channel.label()),
+            detail: format!(
+                "kind={} source={} normalization={} adjustment={}; native audit did not replace adjusted product order",
+                native_score_kind_label(audit.provenance.native_kind),
+                native_score_source_label(audit.provenance.native_source),
+                score_normalization_label(audit.provenance.normalization),
+                score_adjustment_label(audit.provenance.adjustment)
+            ),
+        });
+    }
+}
+
+fn append_selected_product_score_audit(
+    selected: &mut SelectedRecord,
+    audits: Option<&[ProductScoreAudit]>,
+    query: &str,
+    repo_root: &Path,
+) {
+    if audits.is_none_or(<[ProductScoreAudit]>::is_empty) {
+        return;
+    }
+    append_product_score_audit(&mut selected.evidence, audits);
+    match persist_evidence_capsule(repo_root, query, selected) {
+        Ok(handle) => selected.evidence_hydration = Some(handle),
+        Err(error) => {
+            selected
+                .evidence
+                .diagnostics
+                .insert("evidence_hydration".into(), format!("unavailable: {error}"));
+            selected.evidence_hydration = None;
+        }
+    }
+}
+
+const fn native_score_kind_label(kind: NativeScoreKind) -> &'static str {
+    match kind {
+        NativeScoreKind::Bm25 => "bm25",
+        NativeScoreKind::CosineDistance => "cosine_distance",
+        NativeScoreKind::HybridRrfRelevance => "hybrid_rrf_relevance",
+    }
+}
+
+const fn native_score_source_label(source: NativeScoreSource) -> &'static str {
+    match source {
+        NativeScoreSource::Backend => "backend",
+        NativeScoreSource::DeterministicFallback => "deterministic_fallback",
+    }
+}
+
+const fn score_normalization_label(normalization: ScoreNormalization) -> &'static str {
+    match normalization {
+        ScoreNormalization::NonNegativeSaturation => "non_negative_saturation",
+        ScoreNormalization::OneMinusDistanceFloorZero => "one_minus_distance_floor_zero",
+    }
+}
+
+const fn score_adjustment_label(adjustment: ScoreAdjustment) -> &'static str {
+    match adjustment {
+        ScoreAdjustment::None => "none",
+        ScoreAdjustment::TestPathDemotion70Percent => "test_path_demotion_70_percent",
+    }
+}
+
+fn admitted_live_markdown_chunks(
+    ctx: &SearchContext<'_>,
+) -> Option<Vec<crate::types::MarkdownChunk>> {
     let paths = crate::walk::walk_repo_files(ctx.repo_root, &["md", "rst"]).ok()?;
     let chunks: Vec<_> = paths
         .into_iter()
@@ -1077,6 +5955,20 @@ fn markdown_search_section(
     } else {
         chunks
     };
+    Some(filtered_chunks)
+}
+
+fn markdown_search_section(
+    params: &SearchParams,
+    query_str: &str,
+    ctx: &SearchContext<'_>,
+    limit: usize,
+) -> Option<String> {
+    if !params.include_markdown || query_str.is_empty() {
+        return None;
+    }
+
+    let filtered_chunks = admitted_live_markdown_chunks(ctx)?;
     let scored = crate::markdown::search_chunks_ranked(&filtered_chunks, query_str);
     if scored.is_empty() {
         return None;
@@ -1159,6 +6051,7 @@ async fn search_flat(
         matches,
         mut scorer_diagnostic,
         strict_failure,
+        ..
     } = flat_code_symbol_search_with_diagnostics(
         query_str,
         search_mode,
@@ -1354,6 +6247,9 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
 
     // Closure: does a node pass path/name + all active filters?
     let node_passes_filters = |n: &Node| -> bool {
+        if node_delivery_class(n) != NodeDeliveryClass::Code {
+            return false;
+        }
         if complexity_search && n.id.kind != NodeKind::Function {
             return false;
         }
@@ -1443,6 +6339,13 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
     };
     let has_embed_filters = embed_filters.to_sql().is_some();
     let mut scorer_diagnostic = None;
+    // Preserve every independently observed channel order. A candidate may be
+    // present in lexical, semantic, graph, and rerank lanes simultaneously;
+    // provenance must be a union, never a single mutable "origin" label.
+    let mut order_evidence = BTreeMap::<EvidenceChannel, Vec<String>>::new();
+    let mut score_evidence =
+        BTreeMap::<EvidenceChannel, (ScoreKind, Vec<RawCandidateScore>)>::new();
+    let mut product_score_audit = BTreeMap::<String, Vec<ProductScoreAudit>>::new();
 
     // Try embed-ranked search for code symbols when query is non-empty.
     // For path/name queries use only the name part so the embedding attends to
@@ -1454,13 +6357,20 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
                 tokio::task::yield_now().await;
                 panic!("{panic_payload}");
                 #[allow(unreachable_code)]
-                Ok(SearchOutcome::NotReady)
+                Ok(ObservedSearchOutcome {
+                    outcome: SearchOutcome::NotReady,
+                    executed_mode: None,
+                    score_provenance: Vec::new(),
+                })
             };
             match isolate_embedding_scorer(scorer, search_mode).await {
                 Err(diagnostic) => {
                     if strict_semantic {
                         return FlatCodeSymbolSearch {
                             matches: Vec::new(),
+                            order_evidence: BTreeMap::new(),
+                            score_evidence: BTreeMap::new(),
+                            product_score_audit: BTreeMap::new(),
                             scorer_diagnostic: None,
                             strict_failure: Some("embedding scorer panicked"),
                         };
@@ -1484,9 +6394,10 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
                 let embed_idx = embed_idx.clone();
                 let embed_query = embed_query_str.to_string();
                 let embed_filters = embed_filters.clone();
+                let test_policy = product_test_policy(params, query_str);
                 async move {
                     if strict_semantic {
-                        embed_idx
+                        let outcome = embed_idx
                             .search_with_filters_strict(
                                 &embed_query,
                                 None,
@@ -1494,39 +6405,69 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
                                 SearchMode::Hybrid,
                                 &embed_filters,
                             )
-                            .await
+                            .await?;
+                        Ok(ObservedSearchOutcome {
+                            outcome,
+                            executed_mode: Some(ExecutedSearchMode::HybridRrf),
+                            score_provenance: Vec::new(),
+                        })
                     } else {
                         embed_idx
-                            .search_with_filters(
+                            .search_with_filters_observed(
                                 &embed_query,
                                 None,
                                 over_fetch,
                                 search_mode,
                                 &embed_filters,
+                                test_policy,
                             )
                             .await
                     }
                 }
             };
             match isolate_embedding_scorer(scorer, search_mode).await {
-                Ok(SearchOutcome::Results(results)) => {
+                Ok(ObservedSearchOutcome {
+                    outcome: SearchOutcome::Results(results),
+                    executed_mode,
+                    score_provenance,
+                }) => {
                     used_embed = true;
+                    let channel = executed_mode
+                        .map(evidence_channel_for_executed_mode)
+                        .unwrap_or(EvidenceChannel::Vector);
+                    if !strict_semantic {
+                        merge_product_score_audit(
+                            &mut product_score_audit,
+                            aligned_product_score_audit(&results, score_provenance, channel),
+                        );
+                    }
                     // Keep only code results, resolve to graph nodes via HashMap (O(1)), apply filters.
                     // node_passes_filters already handles the path/name split check.
-                    results
+                    let found: Vec<_> = results
                         .iter()
                         .filter(|r| r.kind.starts_with("code:"))
-                        .filter_map(|r| graph_state.node_by_stable_id(&r.id, node_index_map))
-                        .filter(|n| node_passes_filters(n))
+                        .filter_map(|result| {
+                            graph_state.node_by_stable_id(&result.id, node_index_map)
+                        })
+                        .filter(|node| node_passes_filters(node))
                         .take(rerank_over_fetch)
-                        .collect()
+                        .collect();
+                    order_evidence
+                        .insert(channel, found.iter().map(|node| node.stable_id()).collect());
+                    found
                 }
                 // Embedding index not ready -- ordinary search falls through to
                 // name/signature matching; strict qualification stops here.
-                Ok(SearchOutcome::NotReady) => {
+                Ok(ObservedSearchOutcome {
+                    outcome: SearchOutcome::NotReady,
+                    ..
+                }) => {
                     if strict_semantic {
                         return FlatCodeSymbolSearch {
                             matches: Vec::new(),
+                            order_evidence: BTreeMap::new(),
+                            score_evidence: BTreeMap::new(),
+                            product_score_audit: BTreeMap::new(),
                             scorer_diagnostic: None,
                             strict_failure: Some("embedding index is not ready"),
                         };
@@ -1537,6 +6478,9 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
                     if strict_semantic {
                         return FlatCodeSymbolSearch {
                             matches: Vec::new(),
+                            order_evidence: BTreeMap::new(),
+                            score_evidence: BTreeMap::new(),
+                            product_score_audit: BTreeMap::new(),
                             scorer_diagnostic: None,
                             strict_failure: Some("strict hybrid embedding search failed"),
                         };
@@ -1563,6 +6507,9 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
         if strict_semantic {
             return FlatCodeSymbolSearch {
                 matches: Vec::new(),
+                order_evidence: BTreeMap::new(),
+                score_evidence: BTreeMap::new(),
+                product_score_audit: BTreeMap::new(),
                 scorer_diagnostic: None,
                 strict_failure: Some("embedding search produced no admissible code results"),
             };
@@ -1654,6 +6601,10 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
                 .unwrap_or(0);
             cb.cmp(&ca)
         });
+        order_evidence.insert(
+            EvidenceChannel::Structural,
+            matches.iter().map(|node| node.stable_id()).collect(),
+        );
     } else if sort_by_importance {
         matches.sort_by(|a, b| {
             let ia = a
@@ -1671,6 +6622,10 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
                 (None, None) => std::cmp::Ordering::Equal,
             }
         });
+        order_evidence.insert(
+            EvidenceChannel::Structural,
+            matches.iter().map(|node| node.stable_id()).collect(),
+        );
     } else if !used_embed {
         // Only apply text-match ranking for fallback results; embed results
         // are already ranked by the embedding index.
@@ -1688,6 +6643,9 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
     if strict_semantic && matches.is_empty() {
         return FlatCodeSymbolSearch {
             matches: Vec::new(),
+            order_evidence: BTreeMap::new(),
+            score_evidence: BTreeMap::new(),
+            product_score_audit: BTreeMap::new(),
             scorer_diagnostic: None,
             strict_failure: Some("strict embedding search produced no admissible code results"),
         };
@@ -1734,10 +6692,31 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
         match rerank_result {
             Ok(Ok(reranked)) => {
                 let original_matches = matches.clone();
+                score_evidence.insert(
+                    EvidenceChannel::Rerank,
+                    (
+                        ScoreKind::CrossEncoderScore,
+                        reranked
+                            .iter()
+                            .filter_map(|result| {
+                                original_matches.get(result.original_index).map(|node| {
+                                    RawCandidateScore::new(
+                                        node.stable_id(),
+                                        f64::from(result.score),
+                                    )
+                                })
+                            })
+                            .collect(),
+                    ),
+                );
                 matches = reranked
                     .iter()
                     .filter_map(|r| original_matches.get(r.original_index).copied())
                     .collect();
+                order_evidence.insert(
+                    EvidenceChannel::Rerank,
+                    matches.iter().map(|node| node.stable_id()).collect(),
+                );
                 tracing::debug!(
                     "Reranked {} candidates for query \"{}\"",
                     reranked.len(),
@@ -1748,6 +6727,9 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
                 if strict_semantic {
                     return FlatCodeSymbolSearch {
                         matches: Vec::new(),
+                        order_evidence: BTreeMap::new(),
+                        score_evidence: BTreeMap::new(),
+                        product_score_audit: BTreeMap::new(),
                         scorer_diagnostic: None,
                         strict_failure: Some("strict cross-encoder reranking failed"),
                     };
@@ -1762,6 +6744,9 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
                 if strict_semantic {
                     return FlatCodeSymbolSearch {
                         matches: Vec::new(),
+                        order_evidence: BTreeMap::new(),
+                        score_evidence: BTreeMap::new(),
+                        product_score_audit: BTreeMap::new(),
                         scorer_diagnostic: None,
                         strict_failure: Some("strict reranking task panicked"),
                     };
@@ -1771,9 +6756,34 @@ async fn flat_code_symbol_search_with_diagnostics<'a>(
         }
     }
 
+    // Independently observe bounded lexical order even when semantic search
+    // already found the same candidates. This records contributors without
+    // evicting a semantic tail merely to make a lexical supplement visible.
+    if !query_lower.is_empty() && !sort_by_complexity && !sort_by_importance {
+        let mut lexical: Vec<&Node> = graph_state
+            .nodes
+            .iter()
+            .filter(|node| {
+                (path_name.is_some() || node_matches_text_query(node, &query_lower, &text_terms))
+                    && node_passes_filters(node)
+            })
+            .collect();
+        let sort_key = name_filter_lower.as_deref().unwrap_or(&query_lower);
+        sort_symbol_text_matches(&mut lexical, sort_key, &text_terms, &graph_state.index);
+        lexical.truncate(rerank_over_fetch.min(100));
+        if !lexical.is_empty() {
+            order_evidence.insert(
+                EvidenceChannel::ExactLexical,
+                lexical.into_iter().map(|node| node.stable_id()).collect(),
+            );
+        }
+    }
     matches.truncate(limit);
     FlatCodeSymbolSearch {
         matches,
+        order_evidence,
+        score_evidence,
+        product_score_audit,
         scorer_diagnostic,
         strict_failure: None,
     }
@@ -2928,6 +7938,9 @@ fn sort_symbol_text_matches(
         .collect();
 
     matches.sort_by(|a, b| {
+        if std::ptr::eq(*a, *b) {
+            return std::cmp::Ordering::Equal;
+        }
         let score_cmp = scores
             .get(&(*b as *const Node))
             .copied()
@@ -2942,12 +7955,18 @@ fn sort_symbol_text_matches(
             return score_cmp;
         }
 
-        let mut pair = [*a, *b];
-        ranking::sort_symbol_matches(&mut pair, query_lower, index);
-        if std::ptr::eq(pair[0], *a) {
-            std::cmp::Ordering::Less
-        } else {
-            std::cmp::Ordering::Greater
+        // `sort_symbol_matches` intentionally returns Equal for several legacy
+        // ties. Probe both input orders to distinguish a real preference from
+        // stable-sort retention, then close every true tie by stable ID. This
+        // keeps the comparator antisymmetric and byte-stable across reopen.
+        let mut forward = [*a, *b];
+        ranking::sort_symbol_matches(&mut forward, query_lower, index);
+        let mut reverse = [*b, *a];
+        ranking::sort_symbol_matches(&mut reverse, query_lower, index);
+        match (std::ptr::eq(forward[0], *a), std::ptr::eq(reverse[0], *a)) {
+            (true, true) => std::cmp::Ordering::Less,
+            (false, false) => std::cmp::Ordering::Greater,
+            _ => a.stable_id().as_bytes().cmp(b.stable_id().as_bytes()),
         }
     });
 }
@@ -3314,7 +8333,8 @@ mod tests {
 
         let result = search(&params, &ctx).await;
 
-        assert!(result.contains("## Search: \"auth\""));
+        assert!(result.contains("# RNA search context"));
+        assert!(result.contains("projection: agent"));
         assert!(result.contains("auth_handler"));
         assert!(!result.contains("Unknown mode"));
     }
@@ -3408,6 +8428,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -3480,6 +8501,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -3574,6 +8596,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -3602,6 +8625,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -3650,6 +8674,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -3705,6 +8730,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -3737,6 +8763,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -3794,6 +8821,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -3860,6 +8888,7 @@ mod tests {
             &SearchParams {
                 query: Some("caller".into()),
                 verbose: true,
+                projection: Some("evidence".into()),
                 include_artifacts: false,
                 include_markdown: false,
                 ..Default::default()
@@ -3916,6 +8945,7 @@ mod tests {
             &SearchParams {
                 query: Some("caller".into()),
                 verbose: true,
+                projection: Some("evidence".into()),
                 include_artifacts: false,
                 include_markdown: false,
                 ..Default::default()
@@ -3974,6 +9004,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -4048,6 +9079,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -4099,6 +9131,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -4162,6 +9195,7 @@ mod tests {
         let params = SearchParams {
             query: Some("caller".into()),
             verbose: true,
+            projection: Some("evidence".into()),
             include_artifacts: false,
             include_markdown: false,
             ..Default::default()
@@ -4268,7 +9302,7 @@ mod tests {
     async fn test_scorer_error_does_not_echo_repository_content() {
         let diagnostic = match isolate_embedding_scorer(
             async {
-                Err(anyhow::anyhow!(
+                Err::<ObservedSearchOutcome, anyhow::Error>(anyhow::anyhow!(
                     "failed near src/private/customer.rs for secret-query"
                 ))
             },
@@ -4891,8 +9925,12 @@ mod tests {
             "Fallback should find by name even with search_mode=semantic"
         );
         assert!(
-            result.contains("Code symbols"),
-            "Should have code symbols section"
+            result.contains("## Results"),
+            "Should have projected results"
+        );
+        assert!(
+            !result.contains("evidence.raw_scores"),
+            "default agent projection must hide scorer internals"
         );
     }
 
@@ -6578,5 +11616,548 @@ mod tests {
         assert!(rendered.contains("benchmark per-file LSP completeness**: partial/degraded"));
         assert!(rendered.contains(&report.digest));
         assert!(rendered.contains("0/1 included files covered"));
+    }
+
+    #[test]
+    fn search_experience_validation_rejects_unknown_and_unbounded_controls() {
+        let unknown_projection = SearchParams {
+            projection: Some("raw".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            validate_search_experience(&unknown_projection).unwrap_err(),
+            "unknown projection `raw`; allowed values: agent, evidence"
+        );
+
+        let unknown_role = SearchParams {
+            context_mode: Some("task".to_string()),
+            query: Some("change the renderer".to_string()),
+            context_roles: Some(vec!["everything".to_string()]),
+            ..Default::default()
+        };
+        assert!(
+            validate_search_experience(&unknown_role)
+                .unwrap_err()
+                .contains("unknown context role `everything`")
+        );
+
+        let too_many_hops = SearchParams {
+            context_mode: Some("task".to_string()),
+            query: Some("change the renderer".to_string()),
+            hops: Some(MAX_CONTEXT_HOPS + 1),
+            ..Default::default()
+        };
+        assert_eq!(
+            validate_search_experience(&too_many_hops).unwrap_err(),
+            "task-context hops cannot exceed 4"
+        );
+    }
+
+    #[test]
+    fn graph_delta_beta_requires_bounded_non_binary_proposal() {
+        let missing = SearchParams {
+            context_mode: Some("graph-delta-beta".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            validate_search_experience(&missing).unwrap_err(),
+            "graph-delta-beta requires a proposal"
+        );
+
+        let binary = SearchParams {
+            context_mode: Some("graph-delta-beta".to_string()),
+            proposal: Some("diff\0payload".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            validate_search_experience(&binary).unwrap_err(),
+            "proposal contains NUL bytes"
+        );
+
+        let valid = SearchParams {
+            context_mode: Some("graph-delta-beta".to_string()),
+            proposal: Some("--- a/src/lib.rs\n+++ b/src/lib.rs\n".to_string()),
+            ..Default::default()
+        };
+        assert!(validate_search_experience(&valid).is_ok());
+    }
+
+    #[test]
+    fn focused_span_scores_all_lines_and_prefers_behavioral_terms() {
+        let mut node = make_node(
+            "projected_search",
+            NodeKind::Function,
+            "src/service/search.rs",
+        );
+        node.line_start = 1;
+        node.line_end = 80;
+        node.body = (1..=80)
+            .map(|line| match line {
+                2 => "projected_search signature mention".to_string(),
+                67 => "regression behavior preserves discarded evidence".to_string(),
+                _ => format!("ordinary line {line}"),
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let source = node_source_span(&node).unwrap();
+        let (focused, grounding) = query_focused_span(
+            &node,
+            &source,
+            Some("projected_search regression behavior discarded evidence"),
+        );
+        let focused = focused.expect("long source should receive a focused window");
+        assert!(
+            focused.start_line > 40,
+            "behavioral sentinel must beat the name-only line"
+        );
+        assert!(focused.start_line <= 67 && focused.end_line >= 67);
+        assert!(grounding.unwrap().contains("regression"));
+    }
+
+    #[test]
+    fn product_context_normalization_is_shared_and_preserves_query_and_proposal_bytes() {
+        let params = SearchParams {
+            query: Some("  exact query bytes  ".into()),
+            proposal: Some("  exact proposal bytes  ".into()),
+            projection: Some(" evidence ".into()),
+            body_policy: Some(" focused_span ".into()),
+            context_mode: Some(" task ".into()),
+            context_roles: Some(vec![" test ".into(), "".into()]),
+            context_facets: Some(vec![" behavior ".into(), "   ".into()]),
+            edge_types: Some(vec![" calls ".into()]),
+            ..Default::default()
+        };
+        let normalized = normalize_product_context_controls(&params);
+        assert_eq!(normalized.query, params.query);
+        assert_eq!(normalized.proposal, params.proposal);
+        assert_eq!(normalized.projection.as_deref(), Some("evidence"));
+        assert_eq!(normalized.body_policy.as_deref(), Some("focused_span"));
+        assert_eq!(normalized.context_mode.as_deref(), Some("task"));
+        assert_eq!(normalized.context_roles, Some(vec!["test".into()]));
+        assert_eq!(normalized.context_facets, Some(vec!["behavior".into()]));
+        assert_eq!(normalized.edge_types, Some(vec!["calls".into()]));
+    }
+
+    #[tokio::test]
+    async fn semantic_only_artifact_capsule_hydrates_full_body_without_graph_identity() {
+        let repository = tempfile::tempdir().unwrap();
+        let body = "full semantic row body with a terminal sentinel";
+        let selected = SelectedRecord {
+            selection_rank: 0,
+            identity: RecordIdentity {
+                node_id: "artifact:metis:fixture".into(),
+                source: None,
+            },
+            symbol: SymbolSummary {
+                name: "fixture".into(),
+                kind: "metis".into(),
+                language: "text".into(),
+                signature: "truncated".into(),
+            },
+            selection: SelectionSummary {
+                channel: SelectionChannel::Artifact,
+                reason: "semantic fixture".into(),
+                role: Some(ProjectionRole::DefinitionOrApiState),
+                lane: Some(ProjectionLane::DefinitionOrState),
+            },
+            evidence: SelectionEvidence {
+                content_hash: Some(blake3::hash(body.as_bytes()).to_hex().to_string()),
+                ..Default::default()
+            },
+            evidence_hydration: None,
+            focused_span: None,
+        };
+        let handle = persist_semantic_evidence_capsule(repository.path(), &selected, body).unwrap();
+        let graph = make_graph_state(Vec::new());
+        let ctx = make_search_context(&graph, repository.path());
+        let response = search(
+            &SearchParams {
+                node: Some(handle.encode()),
+                projection: Some("evidence".into()),
+                ..Default::default()
+            },
+            &ctx,
+        )
+        .await;
+        assert!(response.contains("terminal sentinel"));
+        assert!(response.contains("content-addressed semantic row body"));
+    }
+
+    #[tokio::test]
+    async fn task_exact_reference_is_resolved_before_ranked_lane_truncation() {
+        let repository = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repository.path().join("src")).unwrap();
+        std::fs::write(
+            repository.path().join("src/lib.rs"),
+            "fn target_symbol() {}\n",
+        )
+        .unwrap();
+        let mut nodes = (0..30)
+            .map(|index| {
+                let mut node = make_node(
+                    &format!("unrelated_{index}"),
+                    NodeKind::Function,
+                    "src/lib.rs",
+                );
+                node.line_start = 1;
+                node.line_end = 1;
+                node
+            })
+            .collect::<Vec<_>>();
+        let mut target = make_node("target_symbol", NodeKind::Function, "src/lib.rs");
+        target.line_start = 1;
+        target.line_end = 1;
+        let target_id = target.stable_id();
+        nodes.push(target);
+        let graph = make_graph_state(nodes);
+        let ctx = make_search_context(&graph, repository.path());
+        let output = task_records(
+            &SearchParams {
+                query: Some("Fix `target_symbol` behavior and add a regression test".into()),
+                context_mode: Some("task".into()),
+                include_artifacts: false,
+                include_markdown: false,
+                ..Default::default()
+            },
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(
+            output
+                .records
+                .iter()
+                .any(|record| record.identity.node_id == target_id)
+        );
+        assert!(output.capabilities.iter().any(|capability| {
+            capability.capability == "task_exact_reference_resolution"
+                && capability.state == CapabilityState::Ready
+        }));
+    }
+
+    #[test]
+    fn task_test_lane_rejects_production_code_without_test_evidence() {
+        let mut production = make_node("production_handler", NodeKind::Function, "src/lib.rs");
+        production.line_start = 1;
+        production.line_end = 1;
+        let mut regression = make_node(
+            "production_handler_regression",
+            NodeKind::Function,
+            "tests/regression.rs",
+        );
+        regression.line_start = 1;
+        regression.line_end = 1;
+        let graph = make_graph_state(vec![production.clone(), regression.clone()]);
+        let assemblies = BTreeMap::new();
+
+        let rejection =
+            task_lane_candidate_evidence(&production, TaskRole::Test, &assemblies, &graph)
+                .unwrap_err();
+        assert!(rejection.contains("production source cannot satisfy the test lane"));
+        assert!(
+            task_lane_candidate_evidence(&regression, TaskRole::Test, &assemblies, &graph,)
+                .unwrap()
+                .contains("test path/metadata")
+        );
+    }
+
+    #[test]
+    fn native_score_audit_is_separate_from_adjusted_product_order() {
+        let mut evidence = SelectionEvidence::default();
+        append_product_score_audit(
+            &mut evidence,
+            Some(&[ProductScoreAudit {
+                channel: EvidenceChannel::FullText,
+                provenance: SearchScoreProvenance {
+                    result_id: "candidate".into(),
+                    native_kind: NativeScoreKind::Bm25,
+                    native_value: 12.0,
+                    native_source: NativeScoreSource::Backend,
+                    normalization: ScoreNormalization::NonNegativeSaturation,
+                    normalized_score: 12.0 / 13.0,
+                    adjustment: ScoreAdjustment::TestPathDemotion70Percent,
+                },
+                adjusted_product_score: (12.0 / 13.0) * 0.7,
+            }]),
+        );
+        assert_eq!(
+            evidence
+                .raw_scores
+                .get("score_audit.fts.1.native_value")
+                .map(String::as_str),
+            Some("12")
+        );
+        assert_eq!(
+            evidence
+                .diagnostics
+                .get("score_audit.fts.1.adjustment")
+                .map(String::as_str),
+            Some("test_path_demotion_70_percent")
+        );
+        assert!(
+            evidence
+                .diagnostics
+                .contains_key("score_audit.fts.1.adjusted_product_score")
+        );
+        assert!(!evidence.raw_scores.contains_key("bm25_score"));
+    }
+
+    #[test]
+    fn task_analogue_lane_rejects_unrelated_same_kind_code() {
+        let mut anchor = make_node("changed_behavior", NodeKind::Function, "src/changed.rs");
+        anchor.line_start = 1;
+        anchor.line_end = 1;
+        let mut candidate = make_node("unrelated_behavior", NodeKind::Function, "src/other.rs");
+        candidate.line_start = 1;
+        candidate.line_end = 1;
+        let mut helper = make_node("shared_helper", NodeKind::Function, "src/helper.rs");
+        helper.line_start = 1;
+        helper.line_end = 1;
+        let mut assemblies = BTreeMap::new();
+        merge_task_assembly(
+            &mut assemblies,
+            single_channel_fused(
+                &anchor.stable_id(),
+                EvidenceChannel::ExactLexical,
+                ScoreKind::ExactMatchTier,
+            ),
+            TaskRole::EditableSource,
+            TaskLane::ExactReference,
+            TaskFacet::Behavior,
+            Some("changed_behavior".into()),
+            0,
+            "exact anchor".into(),
+        );
+        let unrelated_graph =
+            make_graph_state(vec![anchor.clone(), candidate.clone(), helper.clone()]);
+        let rejection = task_lane_candidate_evidence(
+            &candidate,
+            TaskRole::BehavioralAnalogue,
+            &assemblies,
+            &unrelated_graph,
+        )
+        .unwrap_err();
+        assert!(rejection.contains("lacks a shared typed graph target"));
+
+        let corroborated_graph = make_graph_state_with_edges(
+            vec![anchor.clone(), candidate.clone(), helper.clone()],
+            vec![
+                make_edge(&anchor, &helper, EdgeKind::Calls),
+                make_edge(&candidate, &helper, EdgeKind::Calls),
+            ],
+        );
+        assert!(
+            task_lane_candidate_evidence(
+                &candidate,
+                TaskRole::BehavioralAnalogue,
+                &assemblies,
+                &corroborated_graph,
+            )
+            .unwrap()
+            .contains("shared_typed_targets=calls:")
+        );
+    }
+
+    #[tokio::test]
+    async fn two_rna_self_tasks_deliver_exact_source_and_test_roles() {
+        let repository = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repository.path().join("src/service")).unwrap();
+        let source = std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("src/service/search.rs"),
+        )
+        .unwrap();
+        std::fs::write(repository.path().join("src/service/search.rs"), &source).unwrap();
+        let line_of = |needle: &str| {
+            u32::try_from(
+                source
+                    .lines()
+                    .position(|line| line.contains(needle))
+                    .expect("RNA self fixture symbol exists")
+                    + 1,
+            )
+            .unwrap()
+        };
+        let node_at = |name: &str, needle: &str| {
+            let mut node = make_node(name, NodeKind::Function, "src/service/search.rs");
+            let line = line_of(needle);
+            node.line_start = line as usize;
+            node.line_end = line as usize;
+            node.body = source.lines().nth(line as usize - 1).unwrap().to_string();
+            node
+        };
+        let projected = node_at("projected_search", "async fn projected_search(");
+        let delta = node_at("projected_graph_delta", "async fn projected_graph_delta(");
+        let mut task_test = node_at(
+            "task_exact_reference_is_resolved_before_ranked_lane_truncation",
+            "async fn task_exact_reference_is_resolved_before_ranked_lane_truncation(",
+        );
+        task_test.metadata.insert("is_test".into(), "true".into());
+        let mut delta_test = node_at(
+            "live_graph_delta_infers_corroborated_edges_without_mutating_graph",
+            "fn live_graph_delta_infers_corroborated_edges_without_mutating_graph(",
+        );
+        delta_test.metadata.insert("is_test".into(), "true".into());
+        let graph = make_graph_state_with_edges(
+            vec![
+                projected.clone(),
+                delta.clone(),
+                task_test.clone(),
+                delta_test.clone(),
+            ],
+            vec![
+                make_edge(&task_test, &projected, EdgeKind::TestedBy),
+                make_edge(&delta_test, &delta, EdgeKind::TestedBy),
+            ],
+        );
+        let ctx = make_search_context(&graph, repository.path());
+        for (query, expected) in [
+            (
+                "Change `projected_search` behavior and verify the regression test",
+                projected.stable_id(),
+            ),
+            (
+                "Review `projected_graph_delta` API state and its existing analogue test",
+                delta.stable_id(),
+            ),
+        ] {
+            let output = task_records(
+                &SearchParams {
+                    query: Some(query.into()),
+                    context_mode: Some("task".into()),
+                    include_artifacts: false,
+                    include_markdown: false,
+                    ..Default::default()
+                },
+                &ctx,
+            )
+            .await
+            .unwrap();
+            assert!(output.records.iter().any(|record| {
+                record.identity.node_id == expected
+                    && record.selection.role == Some(ProjectionRole::EditableSource)
+            }));
+            assert!(
+                output
+                    .records
+                    .iter()
+                    .any(|record| record.selection.role == Some(ProjectionRole::Test))
+            );
+        }
+    }
+
+    #[test]
+    fn task_graph_expansion_honors_edge_types_and_hops_for_graph_only_nodes() {
+        let mut a = make_node("a", NodeKind::Function, "src/lib.rs");
+        let mut b = make_node("b", NodeKind::Function, "src/lib.rs");
+        let mut c = make_node("c", NodeKind::Function, "src/lib.rs");
+        for node in [&mut a, &mut b, &mut c] {
+            node.line_start = 1;
+            node.line_end = 1;
+        }
+        let graph = make_graph_state_with_edges(
+            vec![a.clone(), b.clone(), c.clone()],
+            vec![
+                make_edge(&a, &b, EdgeKind::Calls),
+                make_edge(&b, &c, EdgeKind::DependsOn),
+            ],
+        );
+        let repository = PathBuf::from("/tmp/task-graph-fixture");
+        let ctx = make_search_context(&graph, &repository);
+        let mut assemblies = BTreeMap::new();
+        merge_task_assembly(
+            &mut assemblies,
+            single_channel_fused(
+                &a.stable_id(),
+                EvidenceChannel::ExactLexical,
+                ScoreKind::ExactMatchTier,
+            ),
+            TaskRole::EditableSource,
+            TaskLane::ExactReference,
+            TaskFacet::Behavior,
+            Some("a".into()),
+            0,
+            "seed".into(),
+        );
+        let mut relationships = Vec::new();
+        expand_task_graph(
+            &SearchParams {
+                edge_types: Some(vec!["calls".into()]),
+                hops: Some(2),
+                ..Default::default()
+            },
+            &ctx,
+            &mut assemblies,
+            &mut relationships,
+        );
+        assert!(assemblies.contains_key(&b.stable_id()));
+        assert!(!assemblies.contains_key(&c.stable_id()));
+        assert_eq!(relationships.len(), 1);
+    }
+
+    #[test]
+    fn live_graph_delta_infers_corroborated_edges_without_mutating_graph() {
+        let mut caller = make_node("caller", NodeKind::Function, "src/lib.rs");
+        caller.line_start = 1;
+        caller.line_end = 3;
+        let mut callee = make_node("callee", NodeKind::Function, "src/lib.rs");
+        callee.line_start = 5;
+        callee.line_end = 5;
+        let mut replacement = make_node("replacement", NodeKind::Function, "src/lib.rs");
+        replacement.line_start = 7;
+        replacement.line_end = 7;
+        let graph = make_graph_state_with_edges(
+            vec![caller.clone(), callee.clone(), replacement.clone()],
+            vec![make_edge(&caller, &callee, EdgeKind::Calls)],
+        );
+        let nodes_before = graph.nodes.iter().map(Node::stable_id).collect::<Vec<_>>();
+        let edges_before = graph
+            .edges
+            .iter()
+            .map(|edge| {
+                (
+                    edge.from.to_stable_id(),
+                    edge.to.to_stable_id(),
+                    edge.kind.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let repository = PathBuf::from("/tmp/graph-delta-fixture");
+        let ctx = make_search_context(&graph, &repository);
+        let card = live_graph_delta_card(
+            &SearchParams {
+                context_mode: Some("graph-delta-beta".into()),
+                root: Some("local".into()),
+                proposal: Some(
+                    "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1,3 +1,3 @@\n fn caller() {\n-    callee();\n+    replacement();\n }\n"
+                        .into(),
+                ),
+                ..Default::default()
+            },
+            &ctx,
+        )
+        .unwrap();
+        assert_eq!(card.changed_edges.len(), 2);
+        assert_eq!(card.routes.len(), 2);
+        assert!(
+            card.impacted_loci
+                .iter()
+                .any(|impact| impact.label == "caller")
+        );
+        assert_eq!(
+            nodes_before,
+            graph.nodes.iter().map(Node::stable_id).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            edges_before,
+            graph
+                .edges
+                .iter()
+                .map(|edge| (
+                    edge.from.to_stable_id(),
+                    edge.to.to_stable_id(),
+                    edge.kind.clone()
+                ))
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/src/service/search/fusion.rs
+++ b/src/service/search/fusion.rs
@@ -1,0 +1,1368 @@
+//! Deterministic, scale-invariant fusion for agent-facing search evidence.
+//!
+//! Raw scorer values are meaningful only inside the channel that produced
+//! them.  This module therefore uses raw values solely to establish a stable
+//! within-channel rank, converts that rank to fixed-point credit, and combines
+//! only those comparable credits.  A positive rescaling of a channel's raw
+//! values cannot change the fused result as long as its within-channel order
+//! is unchanged.
+//!
+//! The frozen strict semantic search path is intentionally not replaced by
+//! the ordinary or task policies below.  `strict_semantic_isolation` exists as
+//! a validation boundary for callers that need typed evidence: it accepts only
+//! the sealed hybrid-RRF candidate set plus its exact reranker permutation,
+//! forbids every fallback channel, and preserves reranker order.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+/// Fixed-point representation of a fully normalized within-channel rank.
+pub(crate) const NORMALIZED_RANK_SCALE: u64 = 1_000_000;
+
+/// Evidence lanes that can participate in product search ranking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum EvidenceChannel {
+    ExactLexical,
+    FullText,
+    Vector,
+    HybridRrf,
+    Rerank,
+    Structural,
+    Graph,
+}
+
+impl EvidenceChannel {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::ExactLexical => "exact_lexical",
+            Self::FullText => "fts",
+            Self::Vector => "vector",
+            Self::HybridRrf => "hybrid_rrf",
+            Self::Rerank => "rerank",
+            Self::Structural => "structural",
+            Self::Graph => "graph",
+        }
+    }
+
+    const fn accepts(self, kind: ScoreKind) -> bool {
+        if matches!(kind, ScoreKind::WithinChannelRank) {
+            return true;
+        }
+        match self {
+            Self::ExactLexical => matches!(
+                kind,
+                ScoreKind::ExactMatchTier | ScoreKind::LexicalHeuristic
+            ),
+            Self::FullText => matches!(kind, ScoreKind::Bm25Score),
+            Self::Vector => matches!(
+                kind,
+                ScoreKind::CosineDistance | ScoreKind::CosineSimilarity
+            ),
+            Self::HybridRrf => matches!(kind, ScoreKind::ReciprocalRankFusion),
+            Self::Rerank => matches!(kind, ScoreKind::CrossEncoderScore),
+            Self::Structural => matches!(
+                kind,
+                ScoreKind::PageRank | ScoreKind::EdgeDegree | ScoreKind::StructuralHeuristic
+            ),
+            Self::Graph => {
+                matches!(kind, ScoreKind::GraphHeuristic | ScoreKind::GraphHops)
+            }
+        }
+    }
+}
+
+/// The native meaning of a raw score before it is reduced to channel rank.
+///
+/// None of these values is assumed to be a calibrated probability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// The complete typed inventory is rendered in evidence output even though a
+// particular build may not compile every optional scorer producer.
+#[allow(dead_code)]
+pub(crate) enum ScoreKind {
+    /// The producer retained only its final within-channel order, not the
+    /// backend's native scorer values. The raw value is the one-based rank.
+    WithinChannelRank,
+    ExactMatchTier,
+    LexicalHeuristic,
+    Bm25Score,
+    CosineDistance,
+    CosineSimilarity,
+    ReciprocalRankFusion,
+    CrossEncoderScore,
+    PageRank,
+    EdgeDegree,
+    StructuralHeuristic,
+    GraphHeuristic,
+    GraphHops,
+}
+
+impl ScoreKind {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::WithinChannelRank => "within_channel_rank",
+            Self::ExactMatchTier => "exact_match_tier",
+            Self::LexicalHeuristic => "lexical_heuristic",
+            Self::Bm25Score => "bm25_score",
+            Self::CosineDistance => "cosine_distance",
+            Self::CosineSimilarity => "cosine_similarity",
+            Self::ReciprocalRankFusion => "rrf_score",
+            Self::CrossEncoderScore => "cross_encoder_score",
+            Self::PageRank => "pagerank",
+            Self::EdgeDegree => "edge_degree",
+            Self::StructuralHeuristic => "structural_heuristic",
+            Self::GraphHeuristic => "graph_heuristic",
+            Self::GraphHops => "graph_hops",
+        }
+    }
+
+    const fn direction(self) -> ScoreDirection {
+        match self {
+            Self::WithinChannelRank | Self::CosineDistance | Self::GraphHops => {
+                ScoreDirection::LowerIsBetter
+            }
+            Self::ExactMatchTier
+            | Self::LexicalHeuristic
+            | Self::Bm25Score
+            | Self::CosineSimilarity
+            | Self::ReciprocalRankFusion
+            | Self::CrossEncoderScore
+            | Self::PageRank
+            | Self::EdgeDegree
+            | Self::StructuralHeuristic
+            | Self::GraphHeuristic => ScoreDirection::HigherIsBetter,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScoreDirection {
+    HigherIsBetter,
+    LowerIsBetter,
+}
+
+/// One scorer observation before within-channel ranking.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RawCandidateScore {
+    pub(crate) stable_id: String,
+    pub(crate) raw_score: f64,
+}
+
+impl RawCandidateScore {
+    pub(crate) fn new(stable_id: impl Into<String>, raw_score: f64) -> Self {
+        Self {
+            stable_id: stable_id.into(),
+            raw_score,
+        }
+    }
+}
+
+/// A complete, single-kind scorer lane.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ChannelInput {
+    pub(crate) channel: EvidenceChannel,
+    pub(crate) score_kind: ScoreKind,
+    pub(crate) candidates: Vec<RawCandidateScore>,
+}
+
+impl ChannelInput {
+    pub(crate) fn new(
+        channel: EvidenceChannel,
+        score_kind: ScoreKind,
+        candidates: Vec<RawCandidateScore>,
+    ) -> Self {
+        Self {
+            channel,
+            score_kind,
+            candidates,
+        }
+    }
+}
+
+/// Stable names for the versioned fusion policies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// The strict policy is exercised as an isolation contract while the sealed
+// strict service path deliberately bypasses product fusion.
+#[allow(dead_code)]
+pub(crate) enum FusionPolicyName {
+    OrdinarySearchV1,
+    TaskSearchV1,
+    StrictSemanticIsolationV1,
+}
+
+impl FusionPolicyName {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::OrdinarySearchV1 => "ordinary_search_v1",
+            Self::TaskSearchV1 => "task_search_v1",
+            Self::StrictSemanticIsolationV1 => "strict_semantic_isolation_v1",
+        }
+    }
+}
+
+/// A channel's bounded influence in one named policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ChannelRule {
+    pub(crate) channel: EvidenceChannel,
+    pub(crate) weight: u32,
+    pub(crate) depth: u32,
+    pub(crate) required: bool,
+}
+
+impl ChannelRule {
+    const fn new(channel: EvidenceChannel, weight: u32, depth: u32, required: bool) -> Self {
+        Self {
+            channel,
+            weight,
+            depth,
+            required,
+        }
+    }
+}
+
+// Rule order is also the deterministic per-channel tie-break order.
+const ORDINARY_SEARCH_RULES: [ChannelRule; 7] = [
+    ChannelRule::new(EvidenceChannel::Rerank, 8, 20, false),
+    ChannelRule::new(EvidenceChannel::ExactLexical, 8, 20, false),
+    ChannelRule::new(EvidenceChannel::Vector, 6, 20, false),
+    ChannelRule::new(EvidenceChannel::FullText, 4, 20, false),
+    ChannelRule::new(EvidenceChannel::HybridRrf, 6, 20, false),
+    ChannelRule::new(EvidenceChannel::Graph, 2, 20, false),
+    ChannelRule::new(EvidenceChannel::Structural, 1, 20, false),
+];
+
+const TASK_SEARCH_RULES: [ChannelRule; 7] = [
+    ChannelRule::new(EvidenceChannel::ExactLexical, 10, 20, false),
+    ChannelRule::new(EvidenceChannel::Rerank, 6, 20, false),
+    ChannelRule::new(EvidenceChannel::Vector, 5, 20, false),
+    ChannelRule::new(EvidenceChannel::FullText, 3, 20, false),
+    ChannelRule::new(EvidenceChannel::HybridRrf, 5, 20, false),
+    ChannelRule::new(EvidenceChannel::Graph, 5, 20, false),
+    ChannelRule::new(EvidenceChannel::Structural, 1, 20, false),
+];
+
+// Hybrid RRF is qualification evidence only here.  Giving it zero weight
+// preserves the existing strict contract: the exact cross-encoder permutation
+// determines final order after hybrid retrieval succeeds.
+#[allow(dead_code)]
+const STRICT_SEMANTIC_RULES: [ChannelRule; 2] = [
+    ChannelRule::new(EvidenceChannel::Rerank, 1, 50, true),
+    ChannelRule::new(EvidenceChannel::HybridRrf, 0, 50, true),
+];
+
+/// Versioned, immutable fusion behavior selected by the shared service.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FusionPolicy {
+    pub(crate) name: FusionPolicyName,
+    rules: &'static [ChannelRule],
+    strict: bool,
+}
+
+impl FusionPolicy {
+    pub(crate) const fn ordinary_search() -> Self {
+        Self {
+            name: FusionPolicyName::OrdinarySearchV1,
+            rules: &ORDINARY_SEARCH_RULES,
+            strict: false,
+        }
+    }
+
+    pub(crate) const fn task_search() -> Self {
+        Self {
+            name: FusionPolicyName::TaskSearchV1,
+            rules: &TASK_SEARCH_RULES,
+            strict: false,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) const fn strict_semantic_isolation() -> Self {
+        Self {
+            name: FusionPolicyName::StrictSemanticIsolationV1,
+            rules: &STRICT_SEMANTIC_RULES,
+            strict: true,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) const fn rules(self) -> &'static [ChannelRule] {
+        self.rules
+    }
+
+    fn rule(self, channel: EvidenceChannel) -> Option<ChannelRule> {
+        self.rules
+            .iter()
+            .copied()
+            .find(|rule| rule.channel == channel)
+    }
+}
+
+/// Auditable evidence for one candidate in one channel.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ChannelEvidence {
+    pub(crate) channel: EvidenceChannel,
+    pub(crate) score_kind: ScoreKind,
+    pub(crate) raw_score: f64,
+    pub(crate) rank: u32,
+    pub(crate) depth: u32,
+    pub(crate) normalized_rank_micros: u64,
+    pub(crate) weight: u32,
+    pub(crate) contribution: u64,
+}
+
+/// Typed explanation from which the concise #810 ordering reason is rendered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FinalOrderingReason {
+    pub(crate) policy: FusionPolicyName,
+    pub(crate) leading_channel: EvidenceChannel,
+    pub(crate) contributing_channels: Vec<EvidenceChannel>,
+}
+
+impl FinalOrderingReason {
+    pub(crate) fn summary(&self) -> String {
+        let contributors = self
+            .contributing_channels
+            .iter()
+            .map(|channel| channel.label())
+            .collect::<Vec<_>>()
+            .join("+");
+        format!(
+            "{}: {} led normalized rank fusion ({})",
+            self.policy.label(),
+            self.leading_channel.label(),
+            contributors
+        )
+    }
+}
+
+/// One field in the deterministic rank-vector tie break.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChannelRankTieBreak {
+    pub(crate) channel: EvidenceChannel,
+    pub(crate) rank: Option<u32>,
+}
+
+/// The exact evidence used after equal fixed-point totals.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TieBreakEvidence {
+    pub(crate) channel_ranks: Vec<ChannelRankTieBreak>,
+    pub(crate) stable_id_utf8: String,
+}
+
+impl TieBreakEvidence {
+    fn compare(&self, other: &Self) -> Ordering {
+        for (left, right) in self.channel_ranks.iter().zip(&other.channel_ranks) {
+            debug_assert_eq!(left.channel, right.channel);
+            let ordering = left
+                .rank
+                .unwrap_or(u32::MAX)
+                .cmp(&right.rank.unwrap_or(u32::MAX));
+            if ordering != Ordering::Equal {
+                return ordering;
+            }
+        }
+        self.stable_id_utf8
+            .as_bytes()
+            .cmp(other.stable_id_utf8.as_bytes())
+    }
+}
+
+/// A fused result ready for projection or task-role selection.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct FusedCandidate {
+    pub(crate) stable_id: String,
+    pub(crate) channels: Vec<ChannelEvidence>,
+    pub(crate) final_score: u64,
+    pub(crate) final_reason: FinalOrderingReason,
+    pub(crate) tie_break: TieBreakEvidence,
+}
+
+/// Fail-closed contract violations at the fusion boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FusionError {
+    DuplicateChannel(EvidenceChannel),
+    UnexpectedChannel {
+        policy: FusionPolicyName,
+        channel: EvidenceChannel,
+    },
+    StrictFallbackForbidden(EvidenceChannel),
+    MissingRequiredChannel(EvidenceChannel),
+    EmptyRequiredChannel(EvidenceChannel),
+    StrictChannelDepthExceeded {
+        channel: EvidenceChannel,
+        candidates: usize,
+        depth: u32,
+    },
+    StrictCandidateSetMismatch {
+        expected: EvidenceChannel,
+        actual: EvidenceChannel,
+    },
+    CompositeAndComponentChannels,
+    ScoreKindMismatch {
+        channel: EvidenceChannel,
+        score_kind: ScoreKind,
+    },
+    DuplicateCandidate {
+        channel: EvidenceChannel,
+        stable_id: String,
+    },
+    NonFiniteScore {
+        channel: EvidenceChannel,
+        stable_id: String,
+    },
+    ContributionOverflow(String),
+}
+
+impl fmt::Display for FusionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateChannel(channel) => {
+                write!(formatter, "duplicate {} fusion channel", channel.label())
+            }
+            Self::UnexpectedChannel { policy, channel } => write!(
+                formatter,
+                "{} does not accept the {} channel",
+                policy.label(),
+                channel.label()
+            ),
+            Self::StrictFallbackForbidden(channel) => write!(
+                formatter,
+                "strict semantic isolation forbids {} fallback evidence",
+                channel.label()
+            ),
+            Self::MissingRequiredChannel(channel) => {
+                write!(formatter, "missing required {} channel", channel.label())
+            }
+            Self::EmptyRequiredChannel(channel) => {
+                write!(formatter, "required {} channel is empty", channel.label())
+            }
+            Self::StrictChannelDepthExceeded {
+                channel,
+                candidates,
+                depth,
+            } => write!(
+                formatter,
+                "strict {} channel has {} candidates, exceeding fixed depth {}",
+                channel.label(),
+                candidates,
+                depth
+            ),
+            Self::StrictCandidateSetMismatch { expected, actual } => write!(
+                formatter,
+                "strict {} candidate set is not an exact permutation of {}",
+                actual.label(),
+                expected.label()
+            ),
+            Self::CompositeAndComponentChannels => write!(
+                formatter,
+                "hybrid RRF cannot be fused alongside its FTS/vector components"
+            ),
+            Self::ScoreKindMismatch {
+                channel,
+                score_kind,
+            } => write!(
+                formatter,
+                "{} is not a valid raw score kind for the {} channel",
+                score_kind.label(),
+                channel.label()
+            ),
+            Self::DuplicateCandidate { channel, stable_id } => write!(
+                formatter,
+                "candidate {stable_id} appears twice in the {} channel",
+                channel.label()
+            ),
+            Self::NonFiniteScore { channel, stable_id } => write!(
+                formatter,
+                "candidate {stable_id} has a non-finite {} score",
+                channel.label()
+            ),
+            Self::ContributionOverflow(stable_id) => {
+                write!(formatter, "fusion contribution overflow for {stable_id}")
+            }
+        }
+    }
+}
+
+impl Error for FusionError {}
+
+/// Fuse independent scorer lanes using only their within-channel ranks.
+pub(crate) fn fuse_ranked_channels(
+    policy: FusionPolicy,
+    inputs: &[ChannelInput],
+) -> Result<Vec<FusedCandidate>, FusionError> {
+    validate_inputs(policy, inputs)?;
+
+    let mut ranked_by_channel: BTreeMap<EvidenceChannel, Vec<RankedObservation>> = BTreeMap::new();
+    for input in inputs {
+        let rule = policy
+            .rule(input.channel)
+            .expect("validated channel must have a policy rule");
+        ranked_by_channel.insert(input.channel, rank_channel(input, rule)?);
+    }
+
+    let mut by_candidate: BTreeMap<String, BTreeMap<EvidenceChannel, ChannelEvidence>> =
+        BTreeMap::new();
+    for (channel, ranked) in ranked_by_channel {
+        for observation in ranked {
+            by_candidate
+                .entry(observation.stable_id)
+                .or_default()
+                .insert(channel, observation.evidence);
+        }
+    }
+
+    let mut fused = Vec::with_capacity(by_candidate.len());
+    for (stable_id, evidence_by_channel) in by_candidate {
+        // Strict candidate-set equality was validated before ranking.  This
+        // defensive check keeps future policy edits fail-closed.
+        if policy.strict
+            && policy
+                .rules
+                .iter()
+                .filter(|rule| rule.required)
+                .any(|rule| !evidence_by_channel.contains_key(&rule.channel))
+        {
+            return Err(FusionError::ContributionOverflow(stable_id));
+        }
+
+        let channels: Vec<ChannelEvidence> = policy
+            .rules
+            .iter()
+            .filter_map(|rule| evidence_by_channel.get(&rule.channel).cloned())
+            .collect();
+        let final_score = channels.iter().try_fold(0_u64, |total, evidence| {
+            total
+                .checked_add(evidence.contribution)
+                .ok_or_else(|| FusionError::ContributionOverflow(stable_id.clone()))
+        })?;
+        // `channels` is already in policy-rule order. Preserve the first item
+        // on equal contribution so the explanation uses the same tie order as
+        // candidate ranking, independent of enum declaration order.
+        let leading_channel = channels
+            .iter()
+            .filter(|evidence| evidence.weight > 0)
+            .fold(None, |best, evidence| match best {
+                None => Some(evidence),
+                Some(current) if evidence.contribution > current.contribution => Some(evidence),
+                Some(current) => Some(current),
+            })
+            .map(|evidence| evidence.channel)
+            .expect("named policies always have a positive-weight channel");
+        let contributing_channels = channels
+            .iter()
+            .filter(|evidence| evidence.weight > 0)
+            .map(|evidence| evidence.channel)
+            .collect();
+        let channel_ranks = policy
+            .rules
+            .iter()
+            .map(|rule| ChannelRankTieBreak {
+                channel: rule.channel,
+                rank: evidence_by_channel
+                    .get(&rule.channel)
+                    .map(|evidence| evidence.rank),
+            })
+            .collect();
+
+        fused.push(FusedCandidate {
+            stable_id: stable_id.clone(),
+            channels,
+            final_score,
+            final_reason: FinalOrderingReason {
+                policy: policy.name,
+                leading_channel,
+                contributing_channels,
+            },
+            tie_break: TieBreakEvidence {
+                channel_ranks,
+                stable_id_utf8: stable_id,
+            },
+        });
+    }
+
+    fused.sort_by(|left, right| {
+        right
+            .final_score
+            .cmp(&left.final_score)
+            .then_with(|| left.tie_break.compare(&right.tie_break))
+    });
+    Ok(fused)
+}
+
+#[derive(Debug)]
+struct RankedObservation {
+    stable_id: String,
+    evidence: ChannelEvidence,
+}
+
+fn validate_inputs(policy: FusionPolicy, inputs: &[ChannelInput]) -> Result<(), FusionError> {
+    let mut seen_channels = BTreeSet::new();
+    for input in inputs {
+        if !seen_channels.insert(input.channel) {
+            return Err(FusionError::DuplicateChannel(input.channel));
+        }
+        let Some(rule) = policy.rule(input.channel) else {
+            return Err(if policy.strict {
+                FusionError::StrictFallbackForbidden(input.channel)
+            } else {
+                FusionError::UnexpectedChannel {
+                    policy: policy.name,
+                    channel: input.channel,
+                }
+            });
+        };
+        if !input.channel.accepts(input.score_kind) {
+            return Err(FusionError::ScoreKindMismatch {
+                channel: input.channel,
+                score_kind: input.score_kind,
+            });
+        }
+        validate_candidates(input)?;
+        if policy.strict && input.candidates.len() > rule.depth as usize {
+            return Err(FusionError::StrictChannelDepthExceeded {
+                channel: input.channel,
+                candidates: input.candidates.len(),
+                depth: rule.depth,
+            });
+        }
+    }
+
+    if seen_channels.contains(&EvidenceChannel::HybridRrf)
+        && (seen_channels.contains(&EvidenceChannel::FullText)
+            || seen_channels.contains(&EvidenceChannel::Vector))
+    {
+        return Err(FusionError::CompositeAndComponentChannels);
+    }
+
+    for rule in policy.rules.iter().filter(|rule| rule.required) {
+        let Some(input) = inputs.iter().find(|input| input.channel == rule.channel) else {
+            return Err(FusionError::MissingRequiredChannel(rule.channel));
+        };
+        if input.candidates.is_empty() {
+            return Err(FusionError::EmptyRequiredChannel(rule.channel));
+        }
+    }
+
+    if policy.strict {
+        validate_strict_candidate_sets(policy, inputs)?;
+    }
+    Ok(())
+}
+
+fn validate_candidates(input: &ChannelInput) -> Result<(), FusionError> {
+    let mut seen = BTreeSet::new();
+    for candidate in &input.candidates {
+        if !candidate.raw_score.is_finite() {
+            return Err(FusionError::NonFiniteScore {
+                channel: input.channel,
+                stable_id: candidate.stable_id.clone(),
+            });
+        }
+        if !seen.insert(candidate.stable_id.as_str()) {
+            return Err(FusionError::DuplicateCandidate {
+                channel: input.channel,
+                stable_id: candidate.stable_id.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_strict_candidate_sets(
+    policy: FusionPolicy,
+    inputs: &[ChannelInput],
+) -> Result<(), FusionError> {
+    let mut required = policy.rules.iter().filter(|rule| rule.required);
+    let first_rule = required
+        .next()
+        .expect("strict policy must require at least one channel");
+    let first_input = inputs
+        .iter()
+        .find(|input| input.channel == first_rule.channel)
+        .expect("required channels were validated");
+    let expected: BTreeSet<&str> = first_input
+        .candidates
+        .iter()
+        .map(|candidate| candidate.stable_id.as_str())
+        .collect();
+
+    for rule in required {
+        let input = inputs
+            .iter()
+            .find(|input| input.channel == rule.channel)
+            .expect("required channels were validated");
+        let actual: BTreeSet<&str> = input
+            .candidates
+            .iter()
+            .map(|candidate| candidate.stable_id.as_str())
+            .collect();
+        if actual != expected {
+            return Err(FusionError::StrictCandidateSetMismatch {
+                expected: first_rule.channel,
+                actual: rule.channel,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn rank_channel(
+    input: &ChannelInput,
+    rule: ChannelRule,
+) -> Result<Vec<RankedObservation>, FusionError> {
+    debug_assert!(rule.depth > 0);
+    let mut candidates = input.candidates.clone();
+    candidates.sort_by(|left, right| {
+        compare_raw_scores(
+            left.raw_score,
+            right.raw_score,
+            input.score_kind.direction(),
+        )
+        .then_with(|| left.stable_id.as_bytes().cmp(right.stable_id.as_bytes()))
+    });
+
+    let mut ranked = Vec::with_capacity(candidates.len().min(rule.depth as usize));
+    let mut previous_score = None;
+    let mut rank = 0_u32;
+    for (index, candidate) in candidates.into_iter().take(rule.depth as usize).enumerate() {
+        let canonical_score = canonical_score(candidate.raw_score);
+        if previous_score != Some(canonical_score) {
+            rank = index as u32 + 1;
+            previous_score = Some(canonical_score);
+        }
+        let normalized_rank_micros = normalized_rank(rank, rule.depth);
+        let contribution = normalized_rank_micros
+            .checked_mul(u64::from(rule.weight))
+            .ok_or_else(|| FusionError::ContributionOverflow(candidate.stable_id.clone()))?;
+        ranked.push(RankedObservation {
+            stable_id: candidate.stable_id,
+            evidence: ChannelEvidence {
+                channel: input.channel,
+                score_kind: input.score_kind,
+                raw_score: canonical_score,
+                rank,
+                depth: rule.depth,
+                normalized_rank_micros,
+                weight: rule.weight,
+                contribution,
+            },
+        });
+    }
+    Ok(ranked)
+}
+
+fn compare_raw_scores(left: f64, right: f64, direction: ScoreDirection) -> Ordering {
+    let left = canonical_score(left);
+    let right = canonical_score(right);
+    match direction {
+        ScoreDirection::HigherIsBetter => right.total_cmp(&left),
+        ScoreDirection::LowerIsBetter => left.total_cmp(&right),
+    }
+}
+
+fn canonical_score(score: f64) -> f64 {
+    // Treat IEEE -0.0 and 0.0 as the same score so platform-specific sign-zero
+    // details cannot alter channel ranks.
+    if score == 0.0 { 0.0 } else { score }
+}
+
+fn normalized_rank(rank: u32, depth: u32) -> u64 {
+    debug_assert!(rank >= 1 && rank <= depth);
+    NORMALIZED_RANK_SCALE * u64::from(depth - rank + 1) / u64::from(depth)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn channel(
+        evidence_channel: EvidenceChannel,
+        score_kind: ScoreKind,
+        candidates: &[(&str, f64)],
+    ) -> ChannelInput {
+        ChannelInput::new(
+            evidence_channel,
+            score_kind,
+            candidates
+                .iter()
+                .map(|(stable_id, raw_score)| RawCandidateScore::new(*stable_id, *raw_score))
+                .collect(),
+        )
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct InvariantCandidate {
+        stable_id: String,
+        final_score: u64,
+        channels: Vec<(EvidenceChannel, u32, u64, u64)>,
+        reason: FinalOrderingReason,
+        tie_break: TieBreakEvidence,
+    }
+
+    fn invariant_snapshot(results: &[FusedCandidate]) -> Vec<InvariantCandidate> {
+        results
+            .iter()
+            .map(|candidate| InvariantCandidate {
+                stable_id: candidate.stable_id.clone(),
+                final_score: candidate.final_score,
+                channels: candidate
+                    .channels
+                    .iter()
+                    .map(|evidence| {
+                        (
+                            evidence.channel,
+                            evidence.rank,
+                            evidence.normalized_rank_micros,
+                            evidence.contribution,
+                        )
+                    })
+                    .collect(),
+                reason: candidate.final_reason.clone(),
+                tie_break: candidate.tie_break.clone(),
+            })
+            .collect()
+    }
+
+    fn append_length_prefixed(bytes: &mut Vec<u8>, value: &[u8]) {
+        let length = u64::try_from(value.len()).expect("test evidence length fits in u64");
+        bytes.extend_from_slice(&length.to_be_bytes());
+        bytes.extend_from_slice(value);
+    }
+
+    /// Canonical, length-prefixed encoding of every ordering field the fusion
+    /// kernel hands to the projection layer. This deliberately avoids a
+    /// serializer's map/order defaults so the test asserts the exact byte
+    /// contract, including raw score bits and the complete final tie vector.
+    fn canonical_evidence_bytes(results: &[FusedCandidate]) -> Vec<u8> {
+        let mut bytes = b"fusion-evidence-v1\0".to_vec();
+        bytes.extend_from_slice(
+            &u64::try_from(results.len())
+                .expect("test result count fits in u64")
+                .to_be_bytes(),
+        );
+        for candidate in results {
+            append_length_prefixed(&mut bytes, candidate.stable_id.as_bytes());
+            bytes.extend_from_slice(&candidate.final_score.to_be_bytes());
+            append_length_prefixed(&mut bytes, candidate.final_reason.policy.label().as_bytes());
+            append_length_prefixed(
+                &mut bytes,
+                candidate.final_reason.leading_channel.label().as_bytes(),
+            );
+            bytes.extend_from_slice(
+                &u64::try_from(candidate.final_reason.contributing_channels.len())
+                    .expect("test channel count fits in u64")
+                    .to_be_bytes(),
+            );
+            for channel in &candidate.final_reason.contributing_channels {
+                append_length_prefixed(&mut bytes, channel.label().as_bytes());
+            }
+
+            bytes.extend_from_slice(
+                &u64::try_from(candidate.channels.len())
+                    .expect("test evidence count fits in u64")
+                    .to_be_bytes(),
+            );
+            for evidence in &candidate.channels {
+                append_length_prefixed(&mut bytes, evidence.channel.label().as_bytes());
+                append_length_prefixed(&mut bytes, evidence.score_kind.label().as_bytes());
+                bytes.extend_from_slice(&evidence.raw_score.to_bits().to_be_bytes());
+                bytes.extend_from_slice(&evidence.rank.to_be_bytes());
+                bytes.extend_from_slice(&evidence.depth.to_be_bytes());
+                bytes.extend_from_slice(&evidence.normalized_rank_micros.to_be_bytes());
+                bytes.extend_from_slice(&evidence.weight.to_be_bytes());
+                bytes.extend_from_slice(&evidence.contribution.to_be_bytes());
+            }
+
+            bytes.extend_from_slice(
+                &u64::try_from(candidate.tie_break.channel_ranks.len())
+                    .expect("test tie count fits in u64")
+                    .to_be_bytes(),
+            );
+            for tie in &candidate.tie_break.channel_ranks {
+                append_length_prefixed(&mut bytes, tie.channel.label().as_bytes());
+                match tie.rank {
+                    Some(rank) => {
+                        bytes.push(1);
+                        bytes.extend_from_slice(&rank.to_be_bytes());
+                    }
+                    None => bytes.push(0),
+                }
+            }
+            append_length_prefixed(&mut bytes, candidate.tie_break.stable_id_utf8.as_bytes());
+        }
+        bytes
+    }
+
+    fn assert_channel_scale_invariant(
+        inputs: &[ChannelInput],
+        target_channel: EvidenceChannel,
+        scale: f64,
+    ) {
+        assert!(scale.is_finite() && scale > 0.0);
+        let original = fuse_ranked_channels(FusionPolicy::ordinary_search(), inputs).unwrap();
+        let mut scaled = inputs.to_vec();
+        let target = scaled
+            .iter_mut()
+            .find(|input| input.channel == target_channel)
+            .expect("target channel should be present");
+        for candidate in &mut target.candidates {
+            candidate.raw_score *= scale;
+        }
+        let rescaled = fuse_ranked_channels(FusionPolicy::ordinary_search(), &scaled).unwrap();
+        assert_eq!(
+            invariant_snapshot(&original),
+            invariant_snapshot(&rescaled),
+            "channel {target_channel:?} changed under positive scale {scale}"
+        );
+    }
+
+    fn candidate<'a>(results: &'a [FusedCandidate], stable_id: &str) -> &'a FusedCandidate {
+        results
+            .iter()
+            .find(|candidate| candidate.stable_id == stable_id)
+            .expect("candidate should be present")
+    }
+
+    #[test]
+    fn multiplying_each_channel_alone_cannot_change_fusion() {
+        let component_inputs = vec![
+            channel(
+                EvidenceChannel::ExactLexical,
+                ScoreKind::LexicalHeuristic,
+                &[("alpha", 10_000.0), ("beta", 8_000.0), ("gamma", 100.0)],
+            ),
+            channel(
+                EvidenceChannel::FullText,
+                ScoreKind::Bm25Score,
+                &[("beta", 17.0), ("gamma", 3.0), ("alpha", 1.0)],
+            ),
+            channel(
+                EvidenceChannel::Vector,
+                ScoreKind::CosineDistance,
+                &[("gamma", 0.05), ("alpha", 0.2), ("beta", 0.8)],
+            ),
+            channel(
+                EvidenceChannel::Rerank,
+                ScoreKind::CrossEncoderScore,
+                &[("alpha", 0.9), ("gamma", 0.7), ("beta", 0.1)],
+            ),
+            channel(
+                EvidenceChannel::Structural,
+                ScoreKind::PageRank,
+                &[("beta", 0.8), ("alpha", 0.3), ("gamma", 0.1)],
+            ),
+            channel(
+                EvidenceChannel::Graph,
+                ScoreKind::GraphHeuristic,
+                &[("gamma", 90_000.0), ("beta", 100.0)],
+            ),
+        ];
+        for target_channel in [
+            EvidenceChannel::ExactLexical,
+            EvidenceChannel::FullText,
+            EvidenceChannel::Vector,
+            EvidenceChannel::Rerank,
+            EvidenceChannel::Structural,
+            EvidenceChannel::Graph,
+        ] {
+            for scale in [0.000_001, 7.0, 1_000_000.0] {
+                assert_channel_scale_invariant(&component_inputs, target_channel, scale);
+            }
+        }
+
+        // Hybrid RRF is intentionally exclusive with its FTS/vector
+        // components, so exercise it in the same multi-channel context with
+        // those two lanes absent rather than weakening the double-count guard.
+        let hybrid_inputs = vec![
+            channel(
+                EvidenceChannel::ExactLexical,
+                ScoreKind::ExactMatchTier,
+                &[("alpha", 3.0), ("beta", 2.0), ("gamma", 1.0)],
+            ),
+            channel(
+                EvidenceChannel::HybridRrf,
+                ScoreKind::ReciprocalRankFusion,
+                &[("gamma", 0.9), ("alpha", 0.6), ("beta", 0.1)],
+            ),
+            channel(
+                EvidenceChannel::Rerank,
+                ScoreKind::CrossEncoderScore,
+                &[("alpha", 0.8), ("gamma", 0.7), ("beta", 0.2)],
+            ),
+            channel(
+                EvidenceChannel::Structural,
+                ScoreKind::PageRank,
+                &[("beta", 0.8), ("alpha", 0.3), ("gamma", 0.1)],
+            ),
+            channel(
+                EvidenceChannel::Graph,
+                ScoreKind::GraphHeuristic,
+                &[("gamma", 9.0), ("beta", 1.0)],
+            ),
+        ];
+        for scale in [0.000_001, 7.0, 1_000_000.0] {
+            assert_channel_scale_invariant(&hybrid_inputs, EvidenceChannel::HybridRrf, scale);
+        }
+    }
+
+    #[test]
+    fn shuffled_channels_and_candidates_are_byte_stable() {
+        let inputs = vec![
+            channel(
+                EvidenceChannel::ExactLexical,
+                ScoreKind::ExactMatchTier,
+                &[("node:zeta", 3.0), ("node:alpha", 3.0), ("node:beta", 2.0)],
+            ),
+            channel(
+                EvidenceChannel::Vector,
+                ScoreKind::CosineDistance,
+                &[("node:beta", 0.1), ("node:zeta", 0.2), ("node:alpha", 0.2)],
+            ),
+            channel(
+                EvidenceChannel::Graph,
+                ScoreKind::GraphHeuristic,
+                &[("node:alpha", 5.0), ("node:beta", 4.0)],
+            ),
+        ];
+        let mut shuffled = inputs.clone();
+        shuffled.reverse();
+        for input in &mut shuffled {
+            input.candidates.reverse();
+        }
+
+        let expected = fuse_ranked_channels(FusionPolicy::task_search(), &inputs).unwrap();
+        let actual = fuse_ranked_channels(FusionPolicy::task_search(), &shuffled).unwrap();
+        assert_eq!(
+            canonical_evidence_bytes(&expected),
+            canonical_evidence_bytes(&actual)
+        );
+        assert!(expected.iter().all(|candidate| {
+            candidate.tie_break.stable_id_utf8 == candidate.stable_id
+                && candidate.tie_break.channel_ranks.len()
+                    == FusionPolicy::task_search().rules().len()
+        }));
+    }
+
+    #[test]
+    fn graph_only_evidence_promotes_while_weak_graph_does_not_overwhelm_semantic() {
+        let semantic_candidates: Vec<(String, f64)> = (1_u32..=20)
+            .map(|rank| (format!("semantic-{rank:02}"), f64::from(21_u32 - rank)))
+            .collect();
+        let semantic = ChannelInput::new(
+            EvidenceChannel::Vector,
+            ScoreKind::CosineSimilarity,
+            semantic_candidates
+                .iter()
+                .map(|(stable_id, score)| RawCandidateScore::new(stable_id, *score))
+                .collect(),
+        );
+        let graph_only = channel(
+            EvidenceChannel::Graph,
+            ScoreKind::GraphHeuristic,
+            &[("graph-only", 100.0)],
+        );
+        let promoted =
+            fuse_ranked_channels(FusionPolicy::ordinary_search(), &[semantic, graph_only]).unwrap();
+        let graph_only_candidate = candidate(&promoted, "graph-only");
+        assert_eq!(
+            graph_only_candidate
+                .channels
+                .iter()
+                .map(|evidence| evidence.channel)
+                .collect::<Vec<_>>(),
+            vec![EvidenceChannel::Graph]
+        );
+        assert_eq!(
+            graph_only_candidate.final_reason.leading_channel,
+            EvidenceChannel::Graph
+        );
+        assert!(
+            promoted
+                .iter()
+                .position(|candidate| candidate.stable_id == "graph-only")
+                < promoted
+                    .iter()
+                    .position(|candidate| candidate.stable_id == "semantic-15")
+        );
+
+        let mut weak_graph_candidates: Vec<(String, f64)> = (1..20)
+            .map(|rank| (format!("graph-{rank:02}"), f64::from(100 - rank)))
+            .collect();
+        weak_graph_candidates.push(("weakly-connected".to_string(), 0.0));
+        let weak_graph = ChannelInput::new(
+            EvidenceChannel::Graph,
+            ScoreKind::GraphHeuristic,
+            weak_graph_candidates
+                .iter()
+                .map(|(stable_id, score)| RawCandidateScore::new(stable_id, *score))
+                .collect(),
+        );
+        let weak_semantic = channel(
+            EvidenceChannel::Vector,
+            ScoreKind::CosineSimilarity,
+            &[("semantic-first", 0.9), ("weakly-connected", 0.8)],
+        );
+        let weak = fuse_ranked_channels(
+            FusionPolicy::ordinary_search(),
+            &[weak_semantic, weak_graph],
+        )
+        .unwrap();
+        assert!(
+            weak.iter()
+                .position(|candidate| candidate.stable_id == "semantic-first")
+                < weak
+                    .iter()
+                    .position(|candidate| candidate.stable_id == "weakly-connected")
+        );
+        assert_eq!(
+            candidate(&weak, "weakly-connected")
+                .channels
+                .iter()
+                .find(|evidence| evidence.channel == EvidenceChannel::Graph)
+                .expect("weak graph evidence should be retained")
+                .rank,
+            20
+        );
+    }
+
+    #[test]
+    fn giant_semantic_decoy_is_bounded_and_cannot_erase_exact_graph_evidence() {
+        let mut semantic_decoys = vec![RawCandidateScore::new("giant-decoy", 1.0e300)];
+        semantic_decoys.extend((0_u32..256).map(|rank| {
+            RawCandidateScore::new(
+                format!("semantic-decoy-{rank:03}"),
+                f64::from(256_u32 - rank),
+            )
+        }));
+        let inputs = vec![
+            channel(
+                EvidenceChannel::ExactLexical,
+                ScoreKind::ExactMatchTier,
+                &[("direct-relevant", 1.0)],
+            ),
+            ChannelInput::new(
+                EvidenceChannel::Vector,
+                ScoreKind::CosineSimilarity,
+                semantic_decoys,
+            ),
+            channel(
+                EvidenceChannel::Rerank,
+                ScoreKind::CrossEncoderScore,
+                &[("giant-decoy", 1.0e20), ("direct-relevant", 0.2)],
+            ),
+            channel(
+                EvidenceChannel::Graph,
+                ScoreKind::GraphHeuristic,
+                &[("direct-relevant", 1.0)],
+            ),
+        ];
+        let fused = fuse_ranked_channels(FusionPolicy::task_search(), &inputs).unwrap();
+
+        assert_eq!(fused[0].stable_id, "direct-relevant");
+        // The fusion kernel has no rendered-body cost input; its relevant
+        // boundedness guarantee is that each lane contributes at most its
+        // policy depth. Twenty semantic observations plus the exact/graph
+        // candidate therefore produce exactly twenty-one fused candidates.
+        assert_eq!(fused.len(), 21);
+        assert!(
+            candidate(&fused, "direct-relevant").final_score
+                > candidate(&fused, "giant-decoy").final_score
+        );
+        assert_eq!(
+            candidate(&fused, "giant-decoy")
+                .channels
+                .iter()
+                .find(|evidence| evidence.channel == EvidenceChannel::Vector)
+                .expect("giant semantic decoy should be retained")
+                .rank,
+            1
+        );
+    }
+
+    #[test]
+    fn equal_scores_close_with_stable_id_utf8_bytes() {
+        let forward = fuse_ranked_channels(
+            FusionPolicy::ordinary_search(),
+            &[channel(
+                EvidenceChannel::FullText,
+                ScoreKind::Bm25Score,
+                &[
+                    ("node:\u{e9}", 4.0),
+                    ("node:zeta", 4.0),
+                    ("node:alpha", 4.0),
+                ],
+            )],
+        )
+        .unwrap();
+        let reverse = fuse_ranked_channels(
+            FusionPolicy::ordinary_search(),
+            &[channel(
+                EvidenceChannel::FullText,
+                ScoreKind::Bm25Score,
+                &[
+                    ("node:alpha", 4.0),
+                    ("node:zeta", 4.0),
+                    ("node:\u{e9}", 4.0),
+                ],
+            )],
+        )
+        .unwrap();
+
+        assert_eq!(
+            forward
+                .iter()
+                .map(|candidate| candidate.stable_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["node:alpha", "node:zeta", "node:\u{e9}"]
+        );
+        assert!(
+            forward
+                .iter()
+                .all(|candidate| candidate.channels[0].rank == 1)
+        );
+        assert!(
+            forward
+                .iter()
+                .all(|candidate| candidate.final_score == forward[0].final_score)
+        );
+        assert!(
+            forward
+                .iter()
+                .all(|candidate| { candidate.tie_break.stable_id_utf8 == candidate.stable_id })
+        );
+        assert_eq!(
+            canonical_evidence_bytes(&forward),
+            canonical_evidence_bytes(&reverse)
+        );
+    }
+
+    #[test]
+    fn leading_channel_uses_policy_order_when_contributions_tie() {
+        let fused = fuse_ranked_channels(
+            FusionPolicy::ordinary_search(),
+            &[
+                channel(
+                    EvidenceChannel::Rerank,
+                    ScoreKind::WithinChannelRank,
+                    &[("node:a", 1.0)],
+                ),
+                channel(
+                    EvidenceChannel::ExactLexical,
+                    ScoreKind::WithinChannelRank,
+                    &[("node:a", 1.0)],
+                ),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            fused[0].final_reason.leading_channel,
+            EvidenceChannel::Rerank
+        );
+        assert_eq!(
+            fused[0]
+                .channels
+                .iter()
+                .map(|evidence| evidence.channel)
+                .collect::<Vec<_>>(),
+            vec![EvidenceChannel::Rerank, EvidenceChannel::ExactLexical]
+        );
+    }
+
+    #[test]
+    fn within_channel_rank_is_a_truthful_order_only_score_for_every_lane() {
+        let fused = fuse_ranked_channels(
+            FusionPolicy::ordinary_search(),
+            &[channel(
+                EvidenceChannel::Vector,
+                ScoreKind::WithinChannelRank,
+                &[("node:second", 2.0), ("node:first", 1.0)],
+            )],
+        )
+        .unwrap();
+
+        assert_eq!(fused[0].stable_id, "node:first");
+        assert_eq!(fused[0].channels[0].raw_score, 1.0);
+        assert_eq!(
+            fused[0].channels[0].score_kind,
+            ScoreKind::WithinChannelRank
+        );
+    }
+
+    #[test]
+    fn strict_semantic_isolation_forbids_fallback_and_requires_exact_permutation() {
+        let fallback = fuse_ranked_channels(
+            FusionPolicy::strict_semantic_isolation(),
+            &[channel(
+                EvidenceChannel::Vector,
+                ScoreKind::CosineDistance,
+                &[("node:a", 0.1)],
+            )],
+        );
+        assert_eq!(
+            fallback,
+            Err(FusionError::StrictFallbackForbidden(
+                EvidenceChannel::Vector
+            ))
+        );
+
+        let mismatch = fuse_ranked_channels(
+            FusionPolicy::strict_semantic_isolation(),
+            &[
+                channel(
+                    EvidenceChannel::HybridRrf,
+                    ScoreKind::ReciprocalRankFusion,
+                    &[("node:a", 0.9), ("node:b", 0.8)],
+                ),
+                channel(
+                    EvidenceChannel::Rerank,
+                    ScoreKind::CrossEncoderScore,
+                    &[("node:a", 0.7)],
+                ),
+            ],
+        );
+        assert_eq!(
+            mismatch,
+            Err(FusionError::StrictCandidateSetMismatch {
+                expected: EvidenceChannel::Rerank,
+                actual: EvidenceChannel::HybridRrf,
+            })
+        );
+    }
+
+    #[test]
+    fn strict_semantic_isolation_preserves_reranker_order() {
+        let fused = fuse_ranked_channels(
+            FusionPolicy::strict_semantic_isolation(),
+            &[
+                channel(
+                    EvidenceChannel::HybridRrf,
+                    ScoreKind::ReciprocalRankFusion,
+                    &[("node:a", 0.9), ("node:b", 0.8)],
+                ),
+                channel(
+                    EvidenceChannel::Rerank,
+                    ScoreKind::CrossEncoderScore,
+                    &[("node:b", 0.95), ("node:a", 0.5)],
+                ),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            fused
+                .iter()
+                .map(|candidate| candidate.stable_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["node:b", "node:a"]
+        );
+        assert!(
+            fused
+                .iter()
+                .all(|candidate| candidate.channels.iter().any(|evidence| {
+                    evidence.channel == EvidenceChannel::HybridRrf && evidence.weight == 0
+                }))
+        );
+    }
+}

--- a/src/service/search/graph_delta.rs
+++ b/src/service/search/graph_delta.rs
@@ -5,7 +5,7 @@
 //! a proposal never mutates that snapshot or the persisted RNA graph.
 
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, VecDeque};
 use std::error::Error;
 use std::fmt;
 
@@ -241,6 +241,7 @@ pub(crate) struct ImpactEvidence {
 #[serde(deny_unknown_fields)]
 pub(crate) struct GraphNode {
     pub(crate) id: String,
+    pub(crate) kind: ImpactKind,
     pub(crate) grounding: EvidenceGrounding,
 }
 
@@ -312,6 +313,40 @@ pub(crate) struct ChangedFileFact {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub(crate) enum InferredRelationshipKind {
+    Call,
+    Reference,
+    Registration,
+    AttributeOrStateReference,
+}
+
+impl InferredRelationshipKind {
+    pub(crate) fn edge_kind(self) -> &'static str {
+        match self {
+            Self::Call => "calls",
+            Self::Reference => "references",
+            Self::Registration => "registers",
+            Self::AttributeOrStateReference => "references_state",
+        }
+    }
+}
+
+/// A conservative proposal relationship awaiting live-graph endpoint
+/// resolution. The pure parser identifies syntax and a qualified target; the
+/// service adapter must corroborate exactly one current graph node before it
+/// materializes an overlay edge.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ChangedRelationshipFact {
+    pub(crate) change: ChangedLineKind,
+    pub(crate) kind: InferredRelationshipKind,
+    pub(crate) qualifier: Option<String>,
+    pub(crate) target: String,
+    pub(crate) grounding: ProposalLine,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub(crate) enum GraphDeltaCapability {
     ProposalParsing,
     LiveGraphInference,
@@ -341,6 +376,7 @@ pub(crate) struct CapabilityReport {
 pub(crate) enum BehavioralDeltaKind {
     BypassedCall,
     BranchBehavior,
+    Reconciliation,
     ErrorPath,
     Representation,
     StatePropagation,
@@ -395,6 +431,8 @@ pub(crate) struct StructuredProposal {
     #[serde(default)]
     pub(crate) edge_removals: Vec<EdgeKey>,
     #[serde(default)]
+    pub(crate) relationships: Vec<ChangedRelationshipFact>,
+    #[serde(default)]
     pub(crate) impacted: Vec<ImpactEvidence>,
     #[serde(default)]
     pub(crate) capabilities: Vec<CapabilityReport>,
@@ -413,6 +451,7 @@ impl Default for StructuredProposal {
             changed_files: Vec::new(),
             edge_additions: Vec::new(),
             edge_removals: Vec::new(),
+            relationships: Vec::new(),
             impacted: Vec::new(),
             capabilities: Vec::new(),
             behavioral_deltas: Vec::new(),
@@ -444,6 +483,7 @@ pub(crate) struct EphemeralOverlay {
     pub(crate) changed_files: Vec<ChangedFileFact>,
     pub(crate) edge_additions: Vec<WeightedEdge>,
     pub(crate) edge_removals: Vec<EdgeKey>,
+    pub(crate) relationships: Vec<ChangedRelationshipFact>,
     pub(crate) impacted: Vec<ImpactEvidence>,
     pub(crate) capabilities: Vec<CapabilityReport>,
     pub(crate) behavioral_deltas: Vec<BehavioralDelta>,
@@ -493,6 +533,7 @@ fn structured_overlay(proposal: StructuredProposal) -> Result<EphemeralOverlay, 
         changed_files: proposal.changed_files,
         edge_additions: proposal.edge_additions,
         edge_removals: proposal.edge_removals,
+        relationships: proposal.relationships,
         impacted: proposal.impacted,
         capabilities: proposal.capabilities,
         behavioral_deltas: proposal.behavioral_deltas,
@@ -773,11 +814,19 @@ fn parse_unified_diff(
         .iter()
         .next()
         .map(|evidence| evidence.grounding.clone());
+    let relationships = changed_files
+        .iter()
+        .flat_map(|file| &file.hunks)
+        .flat_map(|hunk| &hunk.changed_lines)
+        .flat_map(infer_changed_line_relationships)
+        .collect::<Vec<_>>();
+    let behavioral_deltas = infer_changed_behavioral_deltas(&changed_files);
 
     Ok(EphemeralOverlay {
         changed_files,
         edge_additions: Vec::new(),
         edge_removals: Vec::new(),
+        relationships,
         impacted: impacted.into_iter().collect(),
         capabilities: vec![
             CapabilityReport {
@@ -791,7 +840,7 @@ fn parse_unified_diff(
                 detail: "raw changed lines require the service adapter and live GraphState to infer relationships".to_owned(),
             },
         ],
-        behavioral_deltas: Vec::new(),
+        behavioral_deltas,
         analogues: Vec::new(),
         omissions: vec![GraphDeltaOmission {
             code: GraphDeltaOmissionCode::LiveGraphInferenceDeferred,
@@ -802,6 +851,275 @@ fn parse_unified_diff(
             grounding: first_grounding,
         }],
     })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IdentifierToken {
+    value: String,
+    start: usize,
+    end: usize,
+}
+
+/// Extract conservative syntax facts without claiming that a textual name is
+/// a graph endpoint. Live graph resolution remains mandatory and fail-closed.
+pub(crate) fn infer_changed_line_relationships(
+    line: &ChangedLineFact,
+) -> Vec<ChangedRelationshipFact> {
+    let tokens = identifier_tokens(&line.text);
+    let mut facts = BTreeSet::new();
+    let trimmed = line.text.trim_start();
+    let import_like = trimmed.starts_with("use ")
+        || trimmed.starts_with("import ")
+        || trimmed.starts_with("from ");
+
+    if import_like {
+        for token in &tokens {
+            if !is_syntax_word(&token.value) {
+                facts.insert(relationship_fact(
+                    line,
+                    InferredRelationshipKind::Reference,
+                    None,
+                    token.value.clone(),
+                ));
+            }
+        }
+    }
+
+    for (index, token) in tokens.iter().enumerate() {
+        let called = line.text[token.end..].trim_start().starts_with('(');
+        let qualifier = token_qualifier(&line.text, &tokens, index);
+        if called && is_registration_operation(&token.value) {
+            for (target_index, target) in tokens.iter().enumerate().skip(index + 1).take(8) {
+                if !is_syntax_word(&target.value)
+                    && !line.text[target.end..].trim_start().starts_with('=')
+                {
+                    facts.insert(relationship_fact(
+                        line,
+                        InferredRelationshipKind::Registration,
+                        token_qualifier(&line.text, &tokens, target_index),
+                        target.value.clone(),
+                    ));
+                }
+            }
+        } else if called && !is_syntax_word(&token.value) {
+            facts.insert(relationship_fact(
+                line,
+                InferredRelationshipKind::Call,
+                qualifier,
+                token.value.clone(),
+            ));
+        } else if let Some(qualifier) = qualifier
+            && !called
+        {
+            facts.insert(relationship_fact(
+                line,
+                InferredRelationshipKind::AttributeOrStateReference,
+                Some(qualifier),
+                token.value.clone(),
+            ));
+        }
+    }
+    facts.into_iter().collect()
+}
+
+fn relationship_fact(
+    line: &ChangedLineFact,
+    kind: InferredRelationshipKind,
+    qualifier: Option<String>,
+    target: String,
+) -> ChangedRelationshipFact {
+    ChangedRelationshipFact {
+        change: line.kind,
+        kind,
+        qualifier,
+        target,
+        grounding: line.grounding.clone(),
+    }
+}
+
+fn identifier_tokens(text: &str) -> Vec<IdentifierToken> {
+    let bytes = text.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    let mut quote = None;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if let Some(active) = quote {
+            if byte == b'\\' {
+                index = index.saturating_add(2);
+                continue;
+            }
+            if byte == active {
+                quote = None;
+            }
+            index += 1;
+            continue;
+        }
+        if matches!(byte, b'\'' | b'"' | b'`') {
+            quote = Some(byte);
+            index += 1;
+            continue;
+        }
+        if byte == b'/' && bytes.get(index + 1) == Some(&b'/') {
+            break;
+        }
+        if byte == b'_' || byte.is_ascii_alphabetic() {
+            let start = index;
+            index += 1;
+            while index < bytes.len()
+                && (bytes[index] == b'_' || bytes[index].is_ascii_alphanumeric())
+            {
+                index += 1;
+            }
+            tokens.push(IdentifierToken {
+                value: text[start..index].to_owned(),
+                start,
+                end: index,
+            });
+            continue;
+        }
+        index += 1;
+    }
+    tokens
+}
+
+fn token_qualifier(text: &str, tokens: &[IdentifierToken], index: usize) -> Option<String> {
+    let token = tokens.get(index)?;
+    let previous = index.checked_sub(1).and_then(|index| tokens.get(index))?;
+    (text[previous.end..token.start].trim() == ".").then(|| previous.value.clone())
+}
+
+fn is_registration_operation(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "register"
+            | "register_route"
+            | "add_route"
+            | "add_url_rule"
+            | "mount"
+            | "include_router"
+            | "register_blueprint"
+    )
+}
+
+fn is_syntax_word(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "as" | "async"
+            | "await"
+            | "case"
+            | "catch"
+            | "else"
+            | "except"
+            | "false"
+            | "for"
+            | "from"
+            | "if"
+            | "import"
+            | "in"
+            | "let"
+            | "match"
+            | "mod"
+            | "none"
+            | "null"
+            | "raise"
+            | "return"
+            | "self"
+            | "super"
+            | "switch"
+            | "throw"
+            | "true"
+            | "use"
+            | "while"
+    )
+}
+
+fn infer_changed_behavioral_deltas(files: &[ChangedFileFact]) -> Vec<BehavioralDelta> {
+    let mut deltas = BTreeSet::new();
+    for line in files
+        .iter()
+        .flat_map(|file| &file.hunks)
+        .flat_map(|hunk| &hunk.changed_lines)
+    {
+        let tokens = identifier_tokens(&line.text)
+            .into_iter()
+            .map(|token| token.value.to_ascii_lowercase())
+            .collect::<BTreeSet<_>>();
+        let mut classify = |kind, marker: &str| {
+            deltas.insert(BehavioralDelta {
+                kind,
+                label: format!(
+                    "{} proposal line contains `{marker}` behavior",
+                    match line.kind {
+                        ChangedLineKind::Added => "added",
+                        ChangedLineKind::Removed => "removed",
+                    }
+                ),
+                changed_locus: EvidenceGrounding::Proposal(line.grounding.clone()),
+                analogue_locus: None,
+            });
+        };
+        if let Some(marker) = first_marker(
+            &tokens,
+            &["case", "else", "elif", "guard", "if", "match", "switch"],
+        ) {
+            classify(BehavioralDeltaKind::BranchBehavior, marker);
+        }
+        if let Some(marker) = first_marker(
+            &tokens,
+            &[
+                "dedupe",
+                "deduplicate",
+                "merge",
+                "reconcile",
+                "reconciliation",
+                "sync",
+                "synchronize",
+            ],
+        ) {
+            classify(BehavioralDeltaKind::Reconciliation, marker);
+        }
+        if let Some(marker) = first_marker(
+            &tokens,
+            &[
+                "decode",
+                "deserialize",
+                "encode",
+                "format",
+                "render",
+                "representation",
+                "serialize",
+            ],
+        ) {
+            classify(BehavioralDeltaKind::Representation, marker);
+        }
+        if let Some(marker) = first_marker(
+            &tokens,
+            &[
+                "bail", "catch", "err", "error", "except", "panic", "raise", "throw",
+            ],
+        ) {
+            classify(BehavioralDeltaKind::ErrorPath, marker);
+        }
+        let has_state_reference = infer_changed_line_relationships(line)
+            .iter()
+            .any(|fact| fact.kind == InferredRelationshipKind::AttributeOrStateReference);
+        if let Some(marker) = first_marker(
+            &tokens,
+            &["cache", "context", "metadata", "state", "status"],
+        ) && (has_state_reference || line.text.contains('='))
+        {
+            classify(BehavioralDeltaKind::StatePropagation, marker);
+        }
+    }
+    deltas.into_iter().collect()
+}
+
+fn first_marker<'a>(tokens: &BTreeSet<String>, markers: &[&'a str]) -> Option<&'a str> {
+    markers
+        .iter()
+        .copied()
+        .find(|marker| tokens.contains(*marker))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1135,6 +1453,27 @@ fn validate_overlay(
     for key in &overlay.edge_removals {
         validate_edge_key(key)?;
     }
+    enforce_limit(
+        "relationship facts",
+        overlay.relationships.len(),
+        limits.changed_lines.saturating_mul(16),
+    )?;
+    for relationship in &overlay.relationships {
+        EvidenceGrounding::Proposal(relationship.grounding.clone()).validate()?;
+        if relationship.target.trim().is_empty()
+            || relationship.target.len() > 1_024
+            || relationship.target.chars().any(char::is_control)
+            || relationship.qualifier.as_ref().is_some_and(|qualifier| {
+                qualifier.trim().is_empty()
+                    || qualifier.len() > 1_024
+                    || qualifier.chars().any(char::is_control)
+            })
+        {
+            return Err(GraphDeltaError::InvalidGraph(
+                "relationship facts require bounded printable targets".to_owned(),
+            ));
+        }
+    }
     for evidence in &overlay.impacted {
         if evidence.label.trim().is_empty() {
             return Err(GraphDeltaError::InvalidGraph(
@@ -1229,6 +1568,8 @@ fn canonicalize_overlay(mut overlay: EphemeralOverlay) -> EphemeralOverlay {
     overlay.edge_additions.dedup_by(|left, right| left == right);
     overlay.edge_removals.sort();
     overlay.edge_removals.dedup();
+    overlay.relationships.sort();
+    overlay.relationships.dedup();
     overlay.impacted.sort();
     overlay.impacted.dedup();
     overlay.capabilities.sort();
@@ -1286,6 +1627,10 @@ fn validate_overlay_root(
         .changed_files
         .iter()
         .any(|file| file.root != expected_root)
+        || overlay
+            .relationships
+            .iter()
+            .any(|relationship| relationship.grounding.root != expected_root)
         || proposal_groundings.iter().any(|grounding| {
             matches!(grounding, EvidenceGrounding::Proposal(line) if line.root != expected_root)
         })
@@ -1515,6 +1860,23 @@ pub(crate) fn analyze_graph_delta(
     }
 
     let mut impacted = overlay.impacted.clone();
+    impacted.extend(changed_edges.iter().filter_map(|changed| {
+        nodes
+            .get(&changed.edge.key.to)
+            .map(|target| ImpactEvidence {
+                label: target.id.clone(),
+                kind: target.kind,
+                grounding: target.grounding.clone(),
+            })
+    }));
+    impacted.extend(nearest_route_tests(
+        &nodes,
+        &before_edges,
+        &after_edges,
+        &changed_edges,
+        &routes,
+        limits,
+    )?);
     impacted.sort();
     impacted.dedup();
     let impacted_tests = impacted
@@ -1931,6 +2293,77 @@ fn classify_route_change(before: &PathSet, after: &PathSet) -> RouteChange {
     }
 }
 
+fn nearest_route_tests(
+    nodes: &BTreeMap<String, GraphNode>,
+    before_edges: &BTreeMap<EdgeKey, WeightedEdge>,
+    after_edges: &BTreeMap<EdgeKey, WeightedEdge>,
+    changed_edges: &[ChangedEdge],
+    routes: &[RouteDelta],
+    limits: &GraphDeltaLimits,
+) -> Result<Vec<ImpactEvidence>, GraphDeltaError> {
+    let mut seeds = BTreeSet::new();
+    for changed in changed_edges {
+        seeds.insert(changed.edge.key.from.clone());
+        seeds.insert(changed.edge.key.to.clone());
+    }
+    for route in routes
+        .iter()
+        .filter(|route| route.change != RouteChange::Unchanged)
+    {
+        seeds.insert(route.endpoints.from.clone());
+        seeds.insert(route.endpoints.to.clone());
+    }
+    if seeds.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut adjacency = BTreeMap::<String, BTreeSet<String>>::new();
+    for edge in before_edges.values().chain(after_edges.values()) {
+        adjacency
+            .entry(edge.key.from.clone())
+            .or_default()
+            .insert(edge.key.to.clone());
+        adjacency
+            .entry(edge.key.to.clone())
+            .or_default()
+            .insert(edge.key.from.clone());
+    }
+    let mut queue = seeds
+        .iter()
+        .cloned()
+        .map(|seed| (seed, 0usize))
+        .collect::<VecDeque<_>>();
+    let mut visited = seeds;
+    let mut nearest_distance = None;
+    let mut tests = BTreeSet::new();
+    while let Some((node_id, distance)) = queue.pop_front() {
+        enforce_limit("visited nodes", visited.len(), limits.visited_nodes)?;
+        if nearest_distance.is_some_and(|nearest| distance > nearest) {
+            break;
+        }
+        if let Some(node) = nodes.get(&node_id)
+            && node.kind == ImpactKind::Test
+        {
+            nearest_distance.get_or_insert(distance);
+            tests.insert(ImpactEvidence {
+                label: node.id.clone(),
+                kind: ImpactKind::Test,
+                grounding: node.grounding.clone(),
+            });
+            continue;
+        }
+        if nearest_distance.is_some() {
+            continue;
+        }
+        for neighbor in adjacency.get(&node_id).into_iter().flatten() {
+            if visited.insert(neighbor.clone()) {
+                queue.push_back((neighbor.clone(), distance.saturating_add(1)));
+            }
+        }
+    }
+    Ok(tests.into_iter().collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1954,6 +2387,20 @@ mod tests {
         })
     }
 
+    fn changed(text: &str, line: u32) -> ChangedLineFact {
+        ChangedLineFact {
+            kind: ChangedLineKind::Added,
+            grounding: ProposalLine {
+                root: "workspace".to_owned(),
+                path: "src/lib.rs".to_owned(),
+                proposal_line: line,
+                old_line: None,
+                new_line: Some(line),
+            },
+            text: text.to_owned(),
+        }
+    }
+
     fn edge(from: &str, to: &str, cost: u32, priority: u32) -> WeightedEdge {
         WeightedEdge {
             key: EdgeKey {
@@ -1974,6 +2421,7 @@ mod tests {
                 .into_iter()
                 .map(|id| GraphNode {
                     id: id.to_owned(),
+                    kind: ImpactKind::EditableLocus,
                     grounding: current(&format!("src/{id}.rs"), 1),
                 })
                 .collect(),
@@ -2036,6 +2484,74 @@ mod tests {
         assert!(overlay.omissions.iter().any(|omission| {
             omission.code == GraphDeltaOmissionCode::LiveGraphInferenceDeferred
         }));
+    }
+
+    #[test]
+    fn changed_lines_infer_typed_registration_and_attribute_state_facts() {
+        let registration =
+            infer_changed_line_relationships(&changed("router.register(handler)", 8));
+        assert!(registration.iter().any(|fact| {
+            fact.kind == InferredRelationshipKind::Registration
+                && fact.target == "handler"
+                && fact.grounding.proposal_line == 8
+        }));
+        assert!(
+            registration
+                .iter()
+                .all(|fact| fact.kind != InferredRelationshipKind::Call)
+        );
+
+        let state =
+            infer_changed_line_relationships(&changed("endpoint.state = response.status", 9));
+        assert!(state.iter().any(|fact| {
+            fact.kind == InferredRelationshipKind::AttributeOrStateReference
+                && fact.qualifier.as_deref() == Some("endpoint")
+                && fact.target == "state"
+        }));
+        assert!(state.iter().any(|fact| {
+            fact.kind == InferredRelationshipKind::AttributeOrStateReference
+                && fact.qualifier.as_deref() == Some("response")
+                && fact.target == "status"
+        }));
+    }
+
+    #[test]
+    fn behavioral_classes_are_proposal_grounded_and_deterministic() {
+        let lines = vec![
+            changed("if endpoint.state == None {", 10),
+            changed("reconcile(value);", 11),
+            changed("decode(payload);", 12),
+            changed("raise(error);", 13),
+            changed("cache.status = value;", 14),
+        ];
+        let files = vec![ChangedFileFact {
+            root: "workspace".to_owned(),
+            path: "src/lib.rs".to_owned(),
+            hunks: vec![ChangedHunkFact {
+                proposal_header_line: 9,
+                old_start: 10,
+                old_count: 0,
+                new_start: 10,
+                new_count: 5,
+                changed_lines: lines.clone(),
+            }],
+        }];
+        let forward = infer_changed_behavioral_deltas(&files);
+        let mut reversed = files;
+        reversed[0].hunks[0].changed_lines.reverse();
+        let reverse = infer_changed_behavioral_deltas(&reversed);
+        assert_eq!(forward, reverse);
+        for kind in [
+            BehavioralDeltaKind::BranchBehavior,
+            BehavioralDeltaKind::Reconciliation,
+            BehavioralDeltaKind::Representation,
+            BehavioralDeltaKind::ErrorPath,
+            BehavioralDeltaKind::StatePropagation,
+        ] {
+            assert!(forward.iter().any(|delta| {
+                delta.kind == kind && matches!(delta.changed_locus, EvidenceGrounding::Proposal(_))
+            }));
+        }
     }
 
     #[test]
@@ -2103,6 +2619,61 @@ mod tests {
                 && matches!(delta.changed_locus, EvidenceGrounding::CurrentSource(_))
         }));
         assert_eq!(card.routes[0].after.alternatives[0].grounded_steps.len(), 1);
+    }
+
+    #[test]
+    fn nearest_route_test_is_discovered_without_returning_farther_tests() {
+        let mut base = graph();
+        base.nodes.extend([
+            GraphNode {
+                id: "near_test".to_owned(),
+                kind: ImpactKind::Test,
+                grounding: current("tests/near.rs", 4),
+            },
+            GraphNode {
+                id: "far_test".to_owned(),
+                kind: ImpactKind::Test,
+                grounding: current("tests/far.rs", 8),
+            },
+        ]);
+        base.edges
+            .extend([edge("near_test", "a", 1, 0), edge("far_test", "b", 1, 0)]);
+        let card = analyze_graph_delta(
+            &base,
+            &EphemeralOverlay {
+                edge_additions: vec![WeightedEdge {
+                    key: EdgeKey {
+                        from: "a".to_owned(),
+                        to: "d".to_owned(),
+                        kind: "registers".to_owned(),
+                    },
+                    cost: 1,
+                    priority: 0,
+                    registration_order: 0,
+                    grounding: proposed("src/lib.rs", 8),
+                }],
+                ..EphemeralOverlay::default()
+            },
+            &[EndpointPair {
+                from: "a".to_owned(),
+                to: "d".to_owned(),
+            }],
+            &GraphDeltaLimits::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            card.impacted_tests
+                .iter()
+                .map(|test| test.label.as_str())
+                .collect::<Vec<_>>(),
+            ["near_test"]
+        );
+        assert!(
+            card.affected_locus_checklist.iter().any(|item| {
+                item.label == "near_test" && item.kinds.contains(&ImpactKind::Test)
+            })
+        );
     }
 
     #[test]
@@ -2223,6 +2794,7 @@ mod tests {
                 .into_iter()
                 .map(|id| GraphNode {
                     id: id.to_owned(),
+                    kind: ImpactKind::EditableLocus,
                     grounding: current(&format!("src/{id}.rs"), 1),
                 })
                 .collect(),
@@ -2288,6 +2860,58 @@ mod tests {
             omission.code == GraphDeltaOmissionCode::CapabilityDegraded
                 && omission.detail.contains("ImpactTraversal")
         }));
+    }
+
+    #[test]
+    fn referenced_state_edge_surfaces_the_source_grounded_target_contract() {
+        let base = GraphSnapshot {
+            nodes: vec![
+                GraphNode {
+                    id: "handler".to_owned(),
+                    kind: ImpactKind::EditableLocus,
+                    grounding: current("src/handler.rs", 3),
+                },
+                GraphNode {
+                    id: "endpoint_state".to_owned(),
+                    kind: ImpactKind::StateOrApi,
+                    grounding: current("src/state.rs", 7),
+                },
+            ],
+            edges: Vec::new(),
+        };
+        let card = analyze_graph_delta(
+            &base,
+            &EphemeralOverlay {
+                edge_additions: vec![WeightedEdge {
+                    key: EdgeKey {
+                        from: "handler".to_owned(),
+                        to: "endpoint_state".to_owned(),
+                        kind: InferredRelationshipKind::AttributeOrStateReference
+                            .edge_kind()
+                            .to_owned(),
+                    },
+                    cost: 1,
+                    priority: 0,
+                    registration_order: 12,
+                    grounding: proposed("src/handler.rs", 12),
+                }],
+                ..EphemeralOverlay::default()
+            },
+            &[EndpointPair {
+                from: "handler".to_owned(),
+                to: "endpoint_state".to_owned(),
+            }],
+            &GraphDeltaLimits::default(),
+        )
+        .unwrap();
+
+        assert_eq!(card.routes[0].change, RouteChange::AddedReachability);
+        assert_eq!(card.impacted_state_or_api.len(), 1);
+        assert_eq!(card.impacted_state_or_api[0].label, "endpoint_state");
+        assert!(matches!(
+            card.impacted_state_or_api[0].grounding,
+            EvidenceGrounding::CurrentSource(_)
+        ));
     }
 
     #[test]

--- a/src/service/search/graph_delta.rs
+++ b/src/service/search/graph_delta.rs
@@ -1,0 +1,2324 @@
+//! Opt-in, bounded graph-delta analysis over an ephemeral proposal overlay.
+//!
+//! The types here are intentionally independent of persistence. A service
+//! adapter may project the repository graph into `GraphSnapshot`, but applying
+//! a proposal never mutates that snapshot or the persisted RNA graph.
+
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) const HARD_MAX_PROPOSAL_BYTES: usize = 256 * 1024;
+pub(crate) const HARD_MAX_PROPOSAL_FILES: usize = 32;
+pub(crate) const HARD_MAX_PROPOSAL_HUNKS: usize = 256;
+pub(crate) const HARD_MAX_CHANGED_LINES: usize = 4_096;
+pub(crate) const HARD_MAX_OVERLAY_EDGES: usize = 512;
+pub(crate) const HARD_MAX_ENDPOINT_PAIRS: usize = 64;
+pub(crate) const HARD_MAX_EQUAL_PATHS: usize = 16;
+pub(crate) const HARD_MAX_VISITED_NODES: usize = 10_000;
+pub(crate) const HARD_MAX_PATH_HOPS: usize = 128;
+pub(crate) const HARD_MAX_EDGE_COST: u32 = 1_000_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GraphDeltaError {
+    BetaOptInRequired,
+    InvalidLimits(&'static str),
+    LimitExceeded {
+        resource: &'static str,
+        actual: usize,
+        limit: usize,
+    },
+    UnsupportedProposal(&'static str),
+    MalformedProposal {
+        line: usize,
+        reason: &'static str,
+    },
+    MalformedStructuredProposal(String),
+    UnsafePath {
+        line: usize,
+        path: String,
+    },
+    InvalidGraph(String),
+}
+
+impl fmt::Display for GraphDeltaError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BetaOptInRequired => {
+                write!(formatter, "graph-delta beta was not explicitly enabled")
+            }
+            Self::InvalidLimits(reason) => {
+                write!(formatter, "invalid graph-delta limits: {reason}")
+            }
+            Self::LimitExceeded {
+                resource,
+                actual,
+                limit,
+            } => write!(formatter, "{resource} count {actual} exceeds limit {limit}"),
+            Self::UnsupportedProposal(reason) => {
+                write!(formatter, "unsupported proposal: {reason}")
+            }
+            Self::MalformedProposal { line, reason } => {
+                write!(formatter, "malformed proposal at line {line}: {reason}")
+            }
+            Self::MalformedStructuredProposal(reason) => {
+                write!(formatter, "malformed structured proposal: {reason}")
+            }
+            Self::UnsafePath { line, path } => {
+                write!(formatter, "unsafe proposal path at line {line}: {path:?}")
+            }
+            Self::InvalidGraph(reason) => write!(formatter, "invalid graph delta input: {reason}"),
+        }
+    }
+}
+
+impl Error for GraphDeltaError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GraphDeltaLimits {
+    pub(crate) proposal_bytes: usize,
+    pub(crate) proposal_files: usize,
+    pub(crate) proposal_hunks: usize,
+    pub(crate) changed_lines: usize,
+    pub(crate) overlay_edges: usize,
+    pub(crate) endpoint_pairs: usize,
+    pub(crate) equal_paths: usize,
+    pub(crate) visited_nodes: usize,
+    pub(crate) path_hops: usize,
+}
+
+impl Default for GraphDeltaLimits {
+    fn default() -> Self {
+        Self {
+            proposal_bytes: HARD_MAX_PROPOSAL_BYTES,
+            proposal_files: 20,
+            proposal_hunks: 200,
+            changed_lines: 2_000,
+            overlay_edges: 256,
+            endpoint_pairs: 32,
+            equal_paths: 8,
+            visited_nodes: 5_000,
+            path_hops: 64,
+        }
+    }
+}
+
+impl GraphDeltaLimits {
+    fn validate(&self) -> Result<(), GraphDeltaError> {
+        let checks = [
+            (
+                self.proposal_bytes,
+                HARD_MAX_PROPOSAL_BYTES,
+                "proposal_bytes",
+            ),
+            (
+                self.proposal_files,
+                HARD_MAX_PROPOSAL_FILES,
+                "proposal_files",
+            ),
+            (
+                self.proposal_hunks,
+                HARD_MAX_PROPOSAL_HUNKS,
+                "proposal_hunks",
+            ),
+            (self.changed_lines, HARD_MAX_CHANGED_LINES, "changed_lines"),
+            (self.overlay_edges, HARD_MAX_OVERLAY_EDGES, "overlay_edges"),
+            (
+                self.endpoint_pairs,
+                HARD_MAX_ENDPOINT_PAIRS,
+                "endpoint_pairs",
+            ),
+            (self.equal_paths, HARD_MAX_EQUAL_PATHS, "equal_paths"),
+            (self.visited_nodes, HARD_MAX_VISITED_NODES, "visited_nodes"),
+            (self.path_hops, HARD_MAX_PATH_HOPS, "path_hops"),
+        ];
+        if let Some((_, _, name)) = checks
+            .into_iter()
+            .find(|(value, hard_limit, _)| *value == 0 || value > hard_limit)
+        {
+            return Err(GraphDeltaError::InvalidLimits(name));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SourceSpan {
+    pub(crate) root: String,
+    pub(crate) path: String,
+    pub(crate) start_line: u32,
+    pub(crate) end_line: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ProposalLine {
+    pub(crate) root: String,
+    pub(crate) path: String,
+    pub(crate) proposal_line: u32,
+    pub(crate) old_line: Option<u32>,
+    pub(crate) new_line: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum EvidenceGrounding {
+    CurrentSource(SourceSpan),
+    Proposal(ProposalLine),
+}
+
+impl EvidenceGrounding {
+    fn validate(&self) -> Result<(), GraphDeltaError> {
+        match self {
+            Self::CurrentSource(span) => {
+                validate_root_qualifier(&span.root)?;
+                validate_relative_path(&span.path, 0)?;
+                if span.start_line == 0 || span.end_line < span.start_line {
+                    return Err(GraphDeltaError::InvalidGraph(
+                        "source grounding has an invalid line range".to_owned(),
+                    ));
+                }
+            }
+            Self::Proposal(line) => {
+                validate_root_qualifier(&line.root)?;
+                validate_relative_path(&line.path, line.proposal_line as usize)?;
+                if line.proposal_line == 0 {
+                    return Err(GraphDeltaError::InvalidGraph(
+                        "proposal grounding uses line zero".to_owned(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn stable_hydration_key(&self) -> String {
+        match self {
+            Self::CurrentSource(span) => format!(
+                "graph-delta:v1:source:{}:{}:{}:{}",
+                encode_key_component(&span.root),
+                encode_key_component(&span.path),
+                span.start_line,
+                span.end_line
+            ),
+            Self::Proposal(line) => format!(
+                "graph-delta:v1:proposal:{}:{}:{}:{}:{}",
+                encode_key_component(&line.root),
+                encode_key_component(&line.path),
+                line.proposal_line,
+                line.old_line
+                    .map_or_else(|| "-".to_owned(), |value| value.to_string()),
+                line.new_line
+                    .map_or_else(|| "-".to_owned(), |value| value.to_string())
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ImpactKind {
+    EditableLocus,
+    Test,
+    StateOrApi,
+    Caller,
+    BehavioralAnalogue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ImpactEvidence {
+    pub(crate) label: String,
+    pub(crate) kind: ImpactKind,
+    pub(crate) grounding: EvidenceGrounding,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GraphNode {
+    pub(crate) id: String,
+    pub(crate) grounding: EvidenceGrounding,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct EdgeKey {
+    pub(crate) from: String,
+    pub(crate) to: String,
+    pub(crate) kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct WeightedEdge {
+    pub(crate) key: EdgeKey,
+    /// Positive path cost. Zero is rejected to keep shortest-path enumeration
+    /// finite and deterministic.
+    pub(crate) cost: u32,
+    /// Lower values win only after total path cost ties.
+    pub(crate) priority: u32,
+    /// Lower values win after priority ties.
+    pub(crate) registration_order: u32,
+    pub(crate) grounding: EvidenceGrounding,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GraphSnapshot {
+    pub(crate) nodes: Vec<GraphNode>,
+    pub(crate) edges: Vec<WeightedEdge>,
+}
+
+pub(crate) const STRUCTURED_PROPOSAL_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ChangedLineKind {
+    Added,
+    Removed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ChangedLineFact {
+    pub(crate) kind: ChangedLineKind,
+    pub(crate) grounding: ProposalLine,
+    /// Line text without the unified-diff marker. It is evidence for a live
+    /// graph adapter, not a parser-level claim about graph relationships.
+    pub(crate) text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ChangedHunkFact {
+    pub(crate) proposal_header_line: u32,
+    pub(crate) old_start: u32,
+    pub(crate) old_count: u32,
+    pub(crate) new_start: u32,
+    pub(crate) new_count: u32,
+    pub(crate) changed_lines: Vec<ChangedLineFact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ChangedFileFact {
+    pub(crate) root: String,
+    pub(crate) path: String,
+    pub(crate) hunks: Vec<ChangedHunkFact>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GraphDeltaCapability {
+    ProposalParsing,
+    LiveGraphInference,
+    RouteAnalysis,
+    ImpactTraversal,
+    BehavioralAnalogueDiscovery,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CapabilityState {
+    Ready,
+    Degraded,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CapabilityReport {
+    pub(crate) capability: GraphDeltaCapability,
+    pub(crate) state: CapabilityState,
+    pub(crate) detail: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum BehavioralDeltaKind {
+    BypassedCall,
+    BranchBehavior,
+    ErrorPath,
+    Representation,
+    StatePropagation,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct BehavioralDelta {
+    pub(crate) kind: BehavioralDeltaKind,
+    pub(crate) label: String,
+    pub(crate) changed_locus: EvidenceGrounding,
+    pub(crate) analogue_locus: Option<EvidenceGrounding>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct BehavioralAnalogue {
+    pub(crate) label: String,
+    pub(crate) changed_locus: ImpactEvidence,
+    pub(crate) analogue_locus: ImpactEvidence,
+    pub(crate) similarity_basis: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GraphDeltaOmissionCode {
+    LiveGraphInferenceDeferred,
+    ImpactTraversalUnavailable,
+    BehavioralAnalogueUnavailable,
+    CapabilityDegraded,
+    TraversalLimited,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GraphDeltaOmission {
+    pub(crate) code: GraphDeltaOmissionCode,
+    pub(crate) detail: String,
+    pub(crate) grounding: Option<EvidenceGrounding>,
+    pub(crate) hydration_key: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct StructuredProposal {
+    pub(crate) schema_version: u16,
+    #[serde(default)]
+    pub(crate) changed_files: Vec<ChangedFileFact>,
+    #[serde(default)]
+    pub(crate) edge_additions: Vec<WeightedEdge>,
+    #[serde(default)]
+    pub(crate) edge_removals: Vec<EdgeKey>,
+    #[serde(default)]
+    pub(crate) impacted: Vec<ImpactEvidence>,
+    #[serde(default)]
+    pub(crate) capabilities: Vec<CapabilityReport>,
+    #[serde(default)]
+    pub(crate) behavioral_deltas: Vec<BehavioralDelta>,
+    #[serde(default)]
+    pub(crate) analogues: Vec<BehavioralAnalogue>,
+    #[serde(default)]
+    pub(crate) omissions: Vec<GraphDeltaOmission>,
+}
+
+impl Default for StructuredProposal {
+    fn default() -> Self {
+        Self {
+            schema_version: STRUCTURED_PROPOSAL_SCHEMA_VERSION,
+            changed_files: Vec::new(),
+            edge_additions: Vec::new(),
+            edge_removals: Vec::new(),
+            impacted: Vec::new(),
+            capabilities: Vec::new(),
+            behavioral_deltas: Vec::new(),
+            analogues: Vec::new(),
+            omissions: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProposalInput {
+    UnifiedDiff(String),
+    #[cfg(test)]
+    Structured(StructuredProposal),
+    StructuredJson(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BetaGraphDeltaRequest {
+    /// Must be true. Merely supplying proposal data never opts a caller in.
+    pub(crate) beta: bool,
+    /// Stable workspace-root name qualifying every proposal/source anchor.
+    pub(crate) root: String,
+    pub(crate) proposal: ProposalInput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct EphemeralOverlay {
+    pub(crate) changed_files: Vec<ChangedFileFact>,
+    pub(crate) edge_additions: Vec<WeightedEdge>,
+    pub(crate) edge_removals: Vec<EdgeKey>,
+    pub(crate) impacted: Vec<ImpactEvidence>,
+    pub(crate) capabilities: Vec<CapabilityReport>,
+    pub(crate) behavioral_deltas: Vec<BehavioralDelta>,
+    pub(crate) analogues: Vec<BehavioralAnalogue>,
+    pub(crate) omissions: Vec<GraphDeltaOmission>,
+}
+
+pub(crate) fn parse_beta_proposal(
+    request: BetaGraphDeltaRequest,
+    limits: &GraphDeltaLimits,
+) -> Result<EphemeralOverlay, GraphDeltaError> {
+    limits.validate()?;
+    if !request.beta {
+        return Err(GraphDeltaError::BetaOptInRequired);
+    }
+    validate_root_qualifier(&request.root)?;
+    let root = request.root;
+    let overlay = match request.proposal {
+        ProposalInput::UnifiedDiff(diff) => parse_unified_diff(&root, &diff, limits)?,
+        #[cfg(test)]
+        ProposalInput::Structured(proposal) => structured_overlay(proposal)?,
+        ProposalInput::StructuredJson(json) => {
+            enforce_limit("proposal bytes", json.len(), limits.proposal_bytes)?;
+            structured_overlay(deserialize_structured_proposal(&json)?)?
+        }
+    };
+    validate_overlay(&overlay, limits)?;
+    validate_overlay_root(&overlay, &root)?;
+    Ok(canonicalize_overlay(overlay))
+}
+
+pub(crate) fn deserialize_structured_proposal(
+    json: &str,
+) -> Result<StructuredProposal, GraphDeltaError> {
+    serde_json::from_str(json)
+        .map_err(|error| GraphDeltaError::MalformedStructuredProposal(error.to_string()))
+}
+
+fn structured_overlay(proposal: StructuredProposal) -> Result<EphemeralOverlay, GraphDeltaError> {
+    if proposal.schema_version != STRUCTURED_PROPOSAL_SCHEMA_VERSION {
+        return Err(GraphDeltaError::MalformedStructuredProposal(format!(
+            "unsupported schema_version {}; expected {STRUCTURED_PROPOSAL_SCHEMA_VERSION}",
+            proposal.schema_version
+        )));
+    }
+    Ok(EphemeralOverlay {
+        changed_files: proposal.changed_files,
+        edge_additions: proposal.edge_additions,
+        edge_removals: proposal.edge_removals,
+        impacted: proposal.impacted,
+        capabilities: proposal.capabilities,
+        behavioral_deltas: proposal.behavioral_deltas,
+        analogues: proposal.analogues,
+        omissions: proposal.omissions,
+    })
+}
+
+fn parse_unified_diff(
+    root: &str,
+    diff: &str,
+    limits: &GraphDeltaLimits,
+) -> Result<EphemeralOverlay, GraphDeltaError> {
+    enforce_limit("proposal bytes", diff.len(), limits.proposal_bytes)?;
+    validate_root_qualifier(root)?;
+    if diff.contains('\0')
+        || diff.lines().any(|line| {
+            line.starts_with("GIT binary patch")
+                || line.starts_with("Binary files ")
+                || line.starts_with("diff --cc ")
+                || line.starts_with("diff --combined ")
+        })
+    {
+        return Err(GraphDeltaError::UnsupportedProposal(
+            "binary and combined diffs are not accepted",
+        ));
+    }
+
+    let mut file_paths = BTreeSet::new();
+    let mut changed_files = Vec::new();
+    let mut current_file: Option<PendingFile> = None;
+    let mut current_hunk: Option<PendingHunk> = None;
+    let mut hunks = 0usize;
+    let mut changed = 0usize;
+    let mut impacted = BTreeSet::new();
+
+    for (index, line) in diff.lines().enumerate() {
+        let line_number = index + 1;
+        if let Some(header) = line.strip_prefix("diff --git ") {
+            finish_pending_hunk(&mut current_hunk, current_file.as_mut())?;
+            finish_pending_file(&mut current_file, &mut changed_files)?;
+            let fields = header.split_ascii_whitespace().collect::<Vec<_>>();
+            if fields.len() != 2 {
+                return Err(GraphDeltaError::MalformedProposal {
+                    line: line_number,
+                    reason: "diff header must contain exactly two unquoted paths",
+                });
+            }
+            let old = strip_diff_prefix(fields[0], "a/", line_number)?;
+            let new = strip_diff_prefix(fields[1], "b/", line_number)?;
+            if old != new {
+                return Err(GraphDeltaError::UnsupportedProposal(
+                    "renames require a structured proposal",
+                ));
+            }
+            validate_relative_path(new, line_number)?;
+            if !file_paths.insert(new.to_owned()) {
+                return Err(GraphDeltaError::MalformedProposal {
+                    line: line_number,
+                    reason: "a file may appear only once in a unified proposal",
+                });
+            }
+            enforce_limit("proposal files", file_paths.len(), limits.proposal_files)?;
+            current_file = Some(PendingFile {
+                root: root.to_owned(),
+                path: new.to_owned(),
+                header_line: line_number,
+                old_marker_seen: false,
+                new_marker_seen: false,
+                hunks: Vec::new(),
+            });
+            continue;
+        }
+
+        if line.starts_with("rename from ")
+            || line.starts_with("rename to ")
+            || line.starts_with("similarity index ")
+        {
+            return Err(GraphDeltaError::UnsupportedProposal(
+                "renames require a structured proposal",
+            ));
+        }
+        if line.starts_with("new file mode ") || line.starts_with("deleted file mode ") {
+            return Err(GraphDeltaError::UnsupportedProposal(
+                "file creation and deletion require a structured proposal",
+            ));
+        }
+
+        if line.starts_with("@@") {
+            finish_pending_hunk(&mut current_hunk, current_file.as_mut())?;
+            let file = current_file
+                .as_ref()
+                .ok_or(GraphDeltaError::MalformedProposal {
+                    line: line_number,
+                    reason: "hunk appears before a diff header",
+                })?;
+            if !file.old_marker_seen || !file.new_marker_seen {
+                return Err(GraphDeltaError::MalformedProposal {
+                    line: line_number,
+                    reason: "hunk appears before matching --- and +++ file markers",
+                });
+            }
+            let (old_range, new_range) = parse_hunk_header(line, line_number)?;
+            hunks += 1;
+            enforce_limit("proposal hunks", hunks, limits.proposal_hunks)?;
+            current_hunk = Some(PendingHunk {
+                proposal_header_line: line_number,
+                old_range,
+                new_range,
+                old_seen: 0,
+                new_seen: 0,
+                changed_lines: Vec::new(),
+                last_was_body: false,
+            });
+            continue;
+        }
+
+        if let Some(hunk) = current_hunk.as_mut() {
+            let file = current_file
+                .as_ref()
+                .expect("an active hunk always belongs to a file");
+            if let Some(text) = line.strip_prefix('+') {
+                if hunk.new_seen >= hunk.new_range.count {
+                    return Err(GraphDeltaError::MalformedProposal {
+                        line: line_number,
+                        reason: "hunk contains more new lines than its header declares",
+                    });
+                }
+                changed += 1;
+                enforce_limit("changed lines", changed, limits.changed_lines)?;
+                let proposal = ProposalLine {
+                    root: root.to_owned(),
+                    path: file.path.clone(),
+                    proposal_line: line_number as u32,
+                    old_line: None,
+                    new_line: Some(hunk.new_range.start.checked_add(hunk.new_seen).ok_or(
+                        GraphDeltaError::MalformedProposal {
+                            line: line_number,
+                            reason: "new hunk line number overflows",
+                        },
+                    )?),
+                };
+                hunk.changed_lines.push(ChangedLineFact {
+                    kind: ChangedLineKind::Added,
+                    grounding: proposal.clone(),
+                    text: text.to_owned(),
+                });
+                impacted.insert(ImpactEvidence {
+                    label: file.path.clone(),
+                    kind: ImpactKind::EditableLocus,
+                    grounding: EvidenceGrounding::Proposal(proposal),
+                });
+                hunk.new_seen += 1;
+                hunk.last_was_body = true;
+            } else if let Some(text) = line.strip_prefix('-') {
+                if hunk.old_seen >= hunk.old_range.count {
+                    return Err(GraphDeltaError::MalformedProposal {
+                        line: line_number,
+                        reason: "hunk contains more old lines than its header declares",
+                    });
+                }
+                changed += 1;
+                enforce_limit("changed lines", changed, limits.changed_lines)?;
+                let proposal = ProposalLine {
+                    root: root.to_owned(),
+                    path: file.path.clone(),
+                    proposal_line: line_number as u32,
+                    old_line: Some(hunk.old_range.start.checked_add(hunk.old_seen).ok_or(
+                        GraphDeltaError::MalformedProposal {
+                            line: line_number,
+                            reason: "old hunk line number overflows",
+                        },
+                    )?),
+                    new_line: None,
+                };
+                hunk.changed_lines.push(ChangedLineFact {
+                    kind: ChangedLineKind::Removed,
+                    grounding: proposal.clone(),
+                    text: text.to_owned(),
+                });
+                impacted.insert(ImpactEvidence {
+                    label: file.path.clone(),
+                    kind: ImpactKind::EditableLocus,
+                    grounding: EvidenceGrounding::Proposal(proposal),
+                });
+                hunk.old_seen += 1;
+                hunk.last_was_body = true;
+            } else if line.strip_prefix(' ').is_some() {
+                if hunk.old_seen >= hunk.old_range.count || hunk.new_seen >= hunk.new_range.count {
+                    return Err(GraphDeltaError::MalformedProposal {
+                        line: line_number,
+                        reason: "hunk context exceeds a declared range",
+                    });
+                }
+                hunk.old_seen += 1;
+                hunk.new_seen += 1;
+                hunk.last_was_body = true;
+            } else if line == "\\ No newline at end of file" {
+                if !hunk.last_was_body {
+                    return Err(GraphDeltaError::MalformedProposal {
+                        line: line_number,
+                        reason: "no-newline marker must follow a hunk body line",
+                    });
+                }
+                hunk.last_was_body = false;
+            } else {
+                return Err(GraphDeltaError::MalformedProposal {
+                    line: line_number,
+                    reason: "unexpected line inside hunk body",
+                });
+            }
+            continue;
+        }
+
+        let file = current_file
+            .as_mut()
+            .ok_or(GraphDeltaError::MalformedProposal {
+                line: line_number,
+                reason: "content appears before a diff header",
+            })?;
+        if let Some(marker) = line.strip_prefix("--- ") {
+            if file.old_marker_seen || file.new_marker_seen {
+                return Err(GraphDeltaError::MalformedProposal {
+                    line: line_number,
+                    reason: "duplicate or out-of-order --- file marker",
+                });
+            }
+            let marker_path = strip_diff_prefix(marker, "a/", line_number)?;
+            if marker_path != file.path {
+                return Err(GraphDeltaError::MalformedProposal {
+                    line: line_number,
+                    reason: "--- marker does not match diff header path",
+                });
+            }
+            file.old_marker_seen = true;
+        } else if let Some(marker) = line.strip_prefix("+++ ") {
+            if !file.old_marker_seen || file.new_marker_seen {
+                return Err(GraphDeltaError::MalformedProposal {
+                    line: line_number,
+                    reason: "duplicate or out-of-order +++ file marker",
+                });
+            }
+            let marker_path = strip_diff_prefix(marker, "b/", line_number)?;
+            if marker_path != file.path {
+                return Err(GraphDeltaError::MalformedProposal {
+                    line: line_number,
+                    reason: "+++ marker does not match diff header path",
+                });
+            }
+            file.new_marker_seen = true;
+        } else if line.starts_with("index ")
+            || line.starts_with("old mode ")
+            || line.starts_with("new mode ")
+        {
+            if file.old_marker_seen {
+                return Err(GraphDeltaError::MalformedProposal {
+                    line: line_number,
+                    reason: "diff metadata must precede file markers",
+                });
+            }
+        } else {
+            return Err(GraphDeltaError::MalformedProposal {
+                line: line_number,
+                reason: "unexpected content outside a hunk",
+            });
+        }
+    }
+
+    finish_pending_hunk(&mut current_hunk, current_file.as_mut())?;
+    finish_pending_file(&mut current_file, &mut changed_files)?;
+    if changed_files.is_empty() || hunks == 0 || changed == 0 {
+        return Err(GraphDeltaError::UnsupportedProposal(
+            "a unified proposal must contain a complete changed hunk",
+        ));
+    }
+
+    let first_grounding = impacted
+        .iter()
+        .next()
+        .map(|evidence| evidence.grounding.clone());
+
+    Ok(EphemeralOverlay {
+        changed_files,
+        edge_additions: Vec::new(),
+        edge_removals: Vec::new(),
+        impacted: impacted.into_iter().collect(),
+        capabilities: vec![
+            CapabilityReport {
+                capability: GraphDeltaCapability::ProposalParsing,
+                state: CapabilityState::Ready,
+                detail: "unified diff validated and materialized as changed-line facts".to_owned(),
+            },
+            CapabilityReport {
+                capability: GraphDeltaCapability::LiveGraphInference,
+                state: CapabilityState::Degraded,
+                detail: "raw changed lines require the service adapter and live GraphState to infer relationships".to_owned(),
+            },
+        ],
+        behavioral_deltas: Vec::new(),
+        analogues: Vec::new(),
+        omissions: vec![GraphDeltaOmission {
+            code: GraphDeltaOmissionCode::LiveGraphInferenceDeferred,
+            detail: "no graph edges were inferred by the pure unified-diff parser; hydrate these changed-line facts against the live graph".to_owned(),
+            hydration_key: first_grounding
+                .as_ref()
+                .map(EvidenceGrounding::stable_hydration_key),
+            grounding: first_grounding,
+        }],
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HunkRange {
+    start: u32,
+    count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingHunk {
+    proposal_header_line: usize,
+    old_range: HunkRange,
+    new_range: HunkRange,
+    old_seen: u32,
+    new_seen: u32,
+    changed_lines: Vec<ChangedLineFact>,
+    last_was_body: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingFile {
+    root: String,
+    path: String,
+    header_line: usize,
+    old_marker_seen: bool,
+    new_marker_seen: bool,
+    hunks: Vec<ChangedHunkFact>,
+}
+
+fn finish_pending_hunk(
+    pending: &mut Option<PendingHunk>,
+    file: Option<&mut PendingFile>,
+) -> Result<(), GraphDeltaError> {
+    let Some(hunk) = pending.take() else {
+        return Ok(());
+    };
+    if hunk.old_seen != hunk.old_range.count || hunk.new_seen != hunk.new_range.count {
+        return Err(GraphDeltaError::MalformedProposal {
+            line: hunk.proposal_header_line,
+            reason: "hunk body line counts do not match its header",
+        });
+    }
+    if hunk.changed_lines.is_empty() {
+        return Err(GraphDeltaError::MalformedProposal {
+            line: hunk.proposal_header_line,
+            reason: "hunk contains no added or removed lines",
+        });
+    }
+    let file = file.ok_or(GraphDeltaError::MalformedProposal {
+        line: hunk.proposal_header_line,
+        reason: "hunk has no owning file",
+    })?;
+    file.hunks.push(ChangedHunkFact {
+        proposal_header_line: hunk.proposal_header_line as u32,
+        old_start: hunk.old_range.start,
+        old_count: hunk.old_range.count,
+        new_start: hunk.new_range.start,
+        new_count: hunk.new_range.count,
+        changed_lines: hunk.changed_lines,
+    });
+    Ok(())
+}
+
+fn finish_pending_file(
+    pending: &mut Option<PendingFile>,
+    output: &mut Vec<ChangedFileFact>,
+) -> Result<(), GraphDeltaError> {
+    let Some(file) = pending.take() else {
+        return Ok(());
+    };
+    if !file.old_marker_seen || !file.new_marker_seen || file.hunks.is_empty() {
+        return Err(GraphDeltaError::MalformedProposal {
+            line: file.header_line,
+            reason: "file diff is missing markers or complete hunks",
+        });
+    }
+    output.push(ChangedFileFact {
+        root: file.root,
+        path: file.path,
+        hunks: file.hunks,
+    });
+    Ok(())
+}
+
+fn strip_diff_prefix<'a>(
+    path: &'a str,
+    prefix: &str,
+    line: usize,
+) -> Result<&'a str, GraphDeltaError> {
+    path.strip_prefix(prefix)
+        .ok_or(GraphDeltaError::MalformedProposal {
+            line,
+            reason: "diff paths must use a/ and b/ prefixes",
+        })
+}
+
+fn parse_hunk_header(
+    line: &str,
+    line_number: usize,
+) -> Result<(HunkRange, HunkRange), GraphDeltaError> {
+    let end =
+        line[2..]
+            .find("@@")
+            .map(|index| index + 2)
+            .ok_or(GraphDeltaError::MalformedProposal {
+                line: line_number,
+                reason: "unterminated hunk header",
+            })?;
+    let ranges = line[2..end].split_ascii_whitespace().collect::<Vec<_>>();
+    if ranges.len() != 2 {
+        return Err(GraphDeltaError::MalformedProposal {
+            line: line_number,
+            reason: "hunk header must contain old and new ranges",
+        });
+    }
+    Ok((
+        parse_hunk_range(ranges[0], '-', line_number)?,
+        parse_hunk_range(ranges[1], '+', line_number)?,
+    ))
+}
+
+fn parse_hunk_range(range: &str, prefix: char, line: usize) -> Result<HunkRange, GraphDeltaError> {
+    let raw = range
+        .strip_prefix(prefix)
+        .ok_or(GraphDeltaError::MalformedProposal {
+            line,
+            reason: "invalid hunk range prefix",
+        })?;
+    let fields = raw.split(',').collect::<Vec<_>>();
+    if fields.is_empty() || fields.len() > 2 {
+        return Err(GraphDeltaError::MalformedProposal {
+            line,
+            reason: "invalid hunk range",
+        });
+    }
+    let start = fields[0]
+        .parse::<u32>()
+        .map_err(|_| GraphDeltaError::MalformedProposal {
+            line,
+            reason: "invalid hunk range start",
+        })?;
+    let count = match fields.get(1) {
+        Some(value) => value
+            .parse::<u32>()
+            .map_err(|_| GraphDeltaError::MalformedProposal {
+                line,
+                reason: "invalid hunk range count",
+            })?,
+        None => 1,
+    };
+    if (start == 0 && count != 0) || (count > 0 && start.checked_add(count - 1).is_none()) {
+        return Err(GraphDeltaError::MalformedProposal {
+            line,
+            reason: "hunk range is inconsistent or overflows",
+        });
+    }
+    Ok(HunkRange { start, count })
+}
+
+fn validate_relative_path(path: &str, line: usize) -> Result<(), GraphDeltaError> {
+    if path.is_empty()
+        || path.starts_with('/')
+        || path.starts_with('~')
+        || path.contains('\\')
+        || path
+            .split('/')
+            .any(|segment| segment.is_empty() || segment == "..")
+    {
+        return Err(GraphDeltaError::UnsafePath {
+            line,
+            path: path.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_root_qualifier(root: &str) -> Result<(), GraphDeltaError> {
+    if root.trim().is_empty()
+        || root.len() > 1_024
+        || root.contains('\0')
+        || root.chars().any(char::is_control)
+    {
+        return Err(GraphDeltaError::InvalidGraph(
+            "root qualifier must be non-empty, bounded, and printable".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn encode_key_component(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('%');
+            encoded.push(char::from(HEX[(byte >> 4) as usize]));
+            encoded.push(char::from(HEX[(byte & 0x0f) as usize]));
+        }
+    }
+    encoded
+}
+
+fn enforce_limit(
+    resource: &'static str,
+    actual: usize,
+    limit: usize,
+) -> Result<(), GraphDeltaError> {
+    if actual > limit {
+        return Err(GraphDeltaError::LimitExceeded {
+            resource,
+            actual,
+            limit,
+        });
+    }
+    Ok(())
+}
+
+fn validate_overlay(
+    overlay: &EphemeralOverlay,
+    limits: &GraphDeltaLimits,
+) -> Result<(), GraphDeltaError> {
+    enforce_limit(
+        "proposal files",
+        overlay.changed_files.len(),
+        limits.proposal_files,
+    )?;
+    let hunk_count = overlay
+        .changed_files
+        .iter()
+        .map(|file| file.hunks.len())
+        .sum::<usize>();
+    enforce_limit("proposal hunks", hunk_count, limits.proposal_hunks)?;
+    let changed_line_count = overlay
+        .changed_files
+        .iter()
+        .flat_map(|file| &file.hunks)
+        .map(|hunk| hunk.changed_lines.len())
+        .sum::<usize>();
+    enforce_limit("changed lines", changed_line_count, limits.changed_lines)?;
+    let changed_text_bytes = overlay
+        .changed_files
+        .iter()
+        .flat_map(|file| &file.hunks)
+        .flat_map(|hunk| &hunk.changed_lines)
+        .map(|line| line.text.len())
+        .sum::<usize>();
+    enforce_limit("proposal bytes", changed_text_bytes, limits.proposal_bytes)?;
+    for file in &overlay.changed_files {
+        validate_root_qualifier(&file.root)?;
+        validate_relative_path(&file.path, 0)?;
+        if file.hunks.is_empty() {
+            return Err(GraphDeltaError::InvalidGraph(
+                "changed file facts must contain at least one hunk".to_owned(),
+            ));
+        }
+        for hunk in &file.hunks {
+            if hunk.proposal_header_line == 0 || hunk.changed_lines.is_empty() {
+                return Err(GraphDeltaError::InvalidGraph(
+                    "changed hunk facts require a header line and changed lines".to_owned(),
+                ));
+            }
+            if (hunk.old_start == 0 && hunk.old_count != 0)
+                || (hunk.new_start == 0 && hunk.new_count != 0)
+            {
+                return Err(GraphDeltaError::InvalidGraph(
+                    "changed hunk ranges are inconsistent".to_owned(),
+                ));
+            }
+            let added_count = hunk
+                .changed_lines
+                .iter()
+                .filter(|line| line.kind == ChangedLineKind::Added)
+                .count();
+            let removed_count = hunk.changed_lines.len() - added_count;
+            if added_count > hunk.new_count as usize || removed_count > hunk.old_count as usize {
+                return Err(GraphDeltaError::InvalidGraph(
+                    "changed-line facts exceed their declared hunk ranges".to_owned(),
+                ));
+            }
+            for line in &hunk.changed_lines {
+                EvidenceGrounding::Proposal(line.grounding.clone()).validate()?;
+                if line.grounding.root != file.root || line.grounding.path != file.path {
+                    return Err(GraphDeltaError::InvalidGraph(
+                        "changed-line grounding must match its owning root and file".to_owned(),
+                    ));
+                }
+                let shape_is_valid = match line.kind {
+                    ChangedLineKind::Added => {
+                        line.grounding.old_line.is_none() && line.grounding.new_line.is_some()
+                    }
+                    ChangedLineKind::Removed => {
+                        line.grounding.old_line.is_some() && line.grounding.new_line.is_none()
+                    }
+                };
+                if !shape_is_valid {
+                    return Err(GraphDeltaError::InvalidGraph(
+                        "changed-line kind disagrees with old/new line grounding".to_owned(),
+                    ));
+                }
+                let coordinate_is_valid = match line.kind {
+                    ChangedLineKind::Added => line.grounding.new_line.is_some_and(|line| {
+                        line_in_declared_range(line, hunk.new_start, hunk.new_count)
+                    }),
+                    ChangedLineKind::Removed => line.grounding.old_line.is_some_and(|line| {
+                        line_in_declared_range(line, hunk.old_start, hunk.old_count)
+                    }),
+                };
+                if !coordinate_is_valid {
+                    return Err(GraphDeltaError::InvalidGraph(
+                        "changed-line coordinate is outside its declared hunk range".to_owned(),
+                    ));
+                }
+            }
+        }
+    }
+    enforce_limit(
+        "overlay edges",
+        overlay.edge_additions.len() + overlay.edge_removals.len(),
+        limits.overlay_edges,
+    )?;
+    for edge in &overlay.edge_additions {
+        validate_edge(edge)?;
+        if !matches!(edge.grounding, EvidenceGrounding::Proposal(_)) {
+            return Err(GraphDeltaError::InvalidGraph(
+                "overlay edge additions must be grounded in proposal lines".to_owned(),
+            ));
+        }
+    }
+    for key in &overlay.edge_removals {
+        validate_edge_key(key)?;
+    }
+    for evidence in &overlay.impacted {
+        if evidence.label.trim().is_empty() {
+            return Err(GraphDeltaError::InvalidGraph(
+                "impact evidence label must not be empty".to_owned(),
+            ));
+        }
+        evidence.grounding.validate()?;
+    }
+    let mut capability_states = BTreeSet::new();
+    for capability in &overlay.capabilities {
+        if capability.detail.trim().is_empty() {
+            return Err(GraphDeltaError::InvalidGraph(
+                "capability reports require a detail".to_owned(),
+            ));
+        }
+        if !capability_states.insert(capability.capability) {
+            return Err(GraphDeltaError::InvalidGraph(
+                "one capability may be reported only once".to_owned(),
+            ));
+        }
+    }
+    for delta in &overlay.behavioral_deltas {
+        if delta.label.trim().is_empty() {
+            return Err(GraphDeltaError::InvalidGraph(
+                "behavioral deltas require a label".to_owned(),
+            ));
+        }
+        delta.changed_locus.validate()?;
+        if let Some(analogue) = &delta.analogue_locus {
+            analogue.validate()?;
+        }
+    }
+    for analogue in &overlay.analogues {
+        if analogue.label.trim().is_empty() || analogue.similarity_basis.trim().is_empty() {
+            return Err(GraphDeltaError::InvalidGraph(
+                "behavioral analogues require labels and a similarity basis".to_owned(),
+            ));
+        }
+        analogue.changed_locus.grounding.validate()?;
+        analogue.analogue_locus.grounding.validate()?;
+    }
+    for omission in &overlay.omissions {
+        if omission.detail.trim().is_empty() {
+            return Err(GraphDeltaError::InvalidGraph(
+                "graph-delta omissions require a detail".to_owned(),
+            ));
+        }
+        if let Some(grounding) = &omission.grounding {
+            grounding.validate()?;
+            if omission
+                .hydration_key
+                .as_ref()
+                .is_some_and(|key| key != &grounding.stable_hydration_key())
+            {
+                return Err(GraphDeltaError::InvalidGraph(
+                    "omission hydration key does not match its grounding".to_owned(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn line_in_declared_range(line: u32, start: u32, count: u32) -> bool {
+    count > 0
+        && line >= start
+        && start
+            .checked_add(count)
+            .is_some_and(|exclusive_end| line < exclusive_end)
+}
+
+fn canonicalize_overlay(mut overlay: EphemeralOverlay) -> EphemeralOverlay {
+    for file in &mut overlay.changed_files {
+        for hunk in &mut file.hunks {
+            hunk.changed_lines.sort_by(|left, right| {
+                left.grounding
+                    .proposal_line
+                    .cmp(&right.grounding.proposal_line)
+                    .then_with(|| left.kind.cmp(&right.kind))
+                    .then_with(|| left.text.cmp(&right.text))
+            });
+            hunk.changed_lines.dedup();
+        }
+        file.hunks.sort();
+        file.hunks.dedup();
+    }
+    overlay.changed_files.sort();
+    overlay.changed_files.dedup();
+    overlay
+        .edge_additions
+        .sort_by(|left, right| left.key.cmp(&right.key));
+    overlay.edge_additions.dedup_by(|left, right| left == right);
+    overlay.edge_removals.sort();
+    overlay.edge_removals.dedup();
+    overlay.impacted.sort();
+    overlay.impacted.dedup();
+    overlay.capabilities.sort();
+    overlay.capabilities.dedup();
+    overlay.behavioral_deltas.sort();
+    overlay.behavioral_deltas.dedup();
+    overlay.analogues.sort();
+    overlay.analogues.dedup();
+    for omission in &mut overlay.omissions {
+        if omission.hydration_key.is_none() {
+            omission.hydration_key = omission
+                .grounding
+                .as_ref()
+                .map(EvidenceGrounding::stable_hydration_key);
+        }
+    }
+    overlay.omissions.sort();
+    overlay.omissions.dedup();
+    overlay
+}
+
+fn validate_overlay_root(
+    overlay: &EphemeralOverlay,
+    expected_root: &str,
+) -> Result<(), GraphDeltaError> {
+    let mut proposal_groundings = Vec::new();
+    proposal_groundings.extend(overlay.edge_additions.iter().map(|edge| &edge.grounding));
+    proposal_groundings.extend(overlay.impacted.iter().map(|impact| &impact.grounding));
+    proposal_groundings.extend(
+        overlay
+            .behavioral_deltas
+            .iter()
+            .map(|delta| &delta.changed_locus),
+    );
+    proposal_groundings.extend(
+        overlay
+            .behavioral_deltas
+            .iter()
+            .filter_map(|delta| delta.analogue_locus.as_ref()),
+    );
+    proposal_groundings.extend(overlay.analogues.iter().flat_map(|analogue| {
+        [
+            &analogue.changed_locus.grounding,
+            &analogue.analogue_locus.grounding,
+        ]
+    }));
+    proposal_groundings.extend(
+        overlay
+            .omissions
+            .iter()
+            .filter_map(|omission| omission.grounding.as_ref()),
+    );
+
+    if overlay
+        .changed_files
+        .iter()
+        .any(|file| file.root != expected_root)
+        || proposal_groundings.iter().any(|grounding| {
+            matches!(grounding, EvidenceGrounding::Proposal(line) if line.root != expected_root)
+        })
+    {
+        return Err(GraphDeltaError::InvalidGraph(
+            "proposal grounding root does not match the requested workspace root".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_edge_key(key: &EdgeKey) -> Result<(), GraphDeltaError> {
+    if key.from.trim().is_empty() || key.to.trim().is_empty() || key.kind.trim().is_empty() {
+        return Err(GraphDeltaError::InvalidGraph(
+            "edge identifiers and kind must not be empty".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_edge(edge: &WeightedEdge) -> Result<(), GraphDeltaError> {
+    validate_edge_key(&edge.key)?;
+    if edge.cost == 0 || edge.cost > HARD_MAX_EDGE_COST {
+        return Err(GraphDeltaError::InvalidGraph(format!(
+            "edge {:?} cost must be within 1..={HARD_MAX_EDGE_COST}",
+            edge.key
+        )));
+    }
+    edge.grounding.validate()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct EndpointPair {
+    pub(crate) from: String,
+    pub(crate) to: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GroundedRouteStep {
+    pub(crate) edge: EdgeKey,
+    pub(crate) cost: u32,
+    pub(crate) priority: u32,
+    pub(crate) registration_order: u32,
+    pub(crate) grounding: EvidenceGrounding,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WeightedPath {
+    pub(crate) total_cost: u64,
+    pub(crate) nodes: Vec<String>,
+    pub(crate) edges: Vec<EdgeKey>,
+    pub(crate) grounded_steps: Vec<GroundedRouteStep>,
+    pub(crate) priority_registration_key: Vec<(u32, u32, String)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PathSet {
+    /// All equal-minimum-cost alternatives, deterministically ordered. The
+    /// first path is preferred by priority then registration order.
+    pub(crate) alternatives: Vec<WeightedPath>,
+}
+
+impl PathSet {
+    fn cost(&self) -> Option<u64> {
+        self.alternatives.first().map(|path| path.total_cost)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum RouteChange {
+    Unchanged,
+    AddedReachability,
+    RemovedReachability,
+    Shortened,
+    Lengthened,
+    EqualCostAlternativesChanged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RouteDelta {
+    pub(crate) endpoints: EndpointPair,
+    pub(crate) change: RouteChange,
+    pub(crate) before: PathSet,
+    pub(crate) after: PathSet,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum EdgeChange {
+    Added,
+    Removed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChangedEdge {
+    pub(crate) change: EdgeChange,
+    pub(crate) edge: WeightedEdge,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct HydrationTarget {
+    pub(crate) stable_key: String,
+    pub(crate) grounding: EvidenceGrounding,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum ChecklistRequirement {
+    EditOrEvidenceBackedNoEdit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AffectedLocusChecklistItem {
+    pub(crate) stable_id: String,
+    pub(crate) label: String,
+    pub(crate) kinds: BTreeSet<ImpactKind>,
+    pub(crate) grounding: EvidenceGrounding,
+    pub(crate) hydration: HydrationTarget,
+    pub(crate) requirement: ChecklistRequirement,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GraphDeltaCard {
+    pub(crate) beta: bool,
+    pub(crate) capabilities: Vec<CapabilityReport>,
+    pub(crate) changed_files: Vec<ChangedFileFact>,
+    pub(crate) routes: Vec<RouteDelta>,
+    pub(crate) changed_edges: Vec<ChangedEdge>,
+    pub(crate) impacted_loci: Vec<ImpactEvidence>,
+    pub(crate) impacted_tests: Vec<ImpactEvidence>,
+    pub(crate) impacted_state_or_api: Vec<ImpactEvidence>,
+    pub(crate) bypassed_loci: Vec<GraphNode>,
+    pub(crate) behavioral_deltas: Vec<BehavioralDelta>,
+    pub(crate) behavioral_analogues: Vec<BehavioralAnalogue>,
+    pub(crate) affected_locus_checklist: Vec<AffectedLocusChecklistItem>,
+    pub(crate) omissions: Vec<GraphDeltaOmission>,
+}
+
+pub(crate) fn analyze_graph_delta(
+    base: &GraphSnapshot,
+    overlay: &EphemeralOverlay,
+    endpoint_pairs: &[EndpointPair],
+    limits: &GraphDeltaLimits,
+) -> Result<GraphDeltaCard, GraphDeltaError> {
+    limits.validate()?;
+    validate_overlay(overlay, limits)?;
+    let overlay = canonicalize_overlay(overlay.clone());
+    enforce_limit(
+        "endpoint pairs",
+        endpoint_pairs.len(),
+        limits.endpoint_pairs,
+    )?;
+
+    let (nodes, before_edges) = canonical_graph(base)?;
+    let mut after_edges = before_edges.clone();
+    let mut changed_edges = Vec::new();
+
+    for key in &overlay.edge_removals {
+        let removed = after_edges.remove(key).ok_or_else(|| {
+            GraphDeltaError::InvalidGraph(format!(
+                "proposal removes absent edge {} -> {} ({})",
+                key.from, key.to, key.kind
+            ))
+        })?;
+        changed_edges.push(ChangedEdge {
+            change: EdgeChange::Removed,
+            edge: removed,
+        });
+    }
+    for edge in &overlay.edge_additions {
+        if !nodes.contains_key(&edge.key.from) || !nodes.contains_key(&edge.key.to) {
+            return Err(GraphDeltaError::InvalidGraph(format!(
+                "proposal edge references unknown endpoint: {:?}",
+                edge.key
+            )));
+        }
+        match after_edges.get(&edge.key) {
+            Some(existing) if existing != edge => {
+                return Err(GraphDeltaError::InvalidGraph(format!(
+                    "proposal conflicts with existing edge {:?}",
+                    edge.key
+                )));
+            }
+            Some(_) => {}
+            None => {
+                after_edges.insert(edge.key.clone(), edge.clone());
+                changed_edges.push(ChangedEdge {
+                    change: EdgeChange::Added,
+                    edge: edge.clone(),
+                });
+            }
+        }
+    }
+    changed_edges.sort_by(|left, right| {
+        left.edge
+            .key
+            .cmp(&right.edge.key)
+            .then_with(|| left.change.cmp(&right.change))
+    });
+
+    let mut pairs = endpoint_pairs.to_vec();
+    pairs.sort();
+    pairs.dedup();
+    let mut routes = Vec::new();
+    let mut before_route_nodes = BTreeSet::new();
+    let mut after_route_nodes = BTreeSet::new();
+    for endpoints in pairs {
+        if !nodes.contains_key(&endpoints.from) || !nodes.contains_key(&endpoints.to) {
+            return Err(GraphDeltaError::InvalidGraph(format!(
+                "path endpoint is absent: {} -> {}",
+                endpoints.from, endpoints.to
+            )));
+        }
+        let before = shortest_paths(&nodes, &before_edges, &endpoints, limits)?;
+        let after = shortest_paths(&nodes, &after_edges, &endpoints, limits)?;
+        for path in &before.alternatives {
+            before_route_nodes.extend(path.nodes.iter().cloned());
+        }
+        for path in &after.alternatives {
+            after_route_nodes.extend(path.nodes.iter().cloned());
+        }
+        let change = classify_route_change(&before, &after);
+        routes.push(RouteDelta {
+            endpoints,
+            change,
+            before,
+            after,
+        });
+    }
+
+    let mut impacted = overlay.impacted.clone();
+    impacted.sort();
+    impacted.dedup();
+    let impacted_tests = impacted
+        .iter()
+        .filter(|evidence| evidence.kind == ImpactKind::Test)
+        .cloned()
+        .collect();
+    let impacted_state_or_api = impacted
+        .iter()
+        .filter(|evidence| evidence.kind == ImpactKind::StateOrApi)
+        .cloned()
+        .collect();
+    let bypassed_loci = before_route_nodes
+        .difference(&after_route_nodes)
+        .filter_map(|id| nodes.get(id).cloned())
+        .collect::<Vec<_>>();
+
+    let mut behavioral_deltas = overlay.behavioral_deltas.clone();
+    behavioral_deltas.extend(bypassed_loci.iter().map(|node| BehavioralDelta {
+        kind: BehavioralDeltaKind::BypassedCall,
+        label: format!("route no longer traverses {}", node.id),
+        changed_locus: node.grounding.clone(),
+        analogue_locus: None,
+    }));
+    behavioral_deltas.sort();
+    behavioral_deltas.dedup();
+
+    let mut capabilities = overlay.capabilities.clone();
+    ensure_capability(
+        &mut capabilities,
+        GraphDeltaCapability::ProposalParsing,
+        CapabilityState::Ready,
+        "proposal overlay is validated and canonical",
+    );
+    ensure_capability(
+        &mut capabilities,
+        GraphDeltaCapability::RouteAnalysis,
+        CapabilityState::Ready,
+        "bounded equal-cost route analysis completed",
+    );
+    ensure_capability(
+        &mut capabilities,
+        GraphDeltaCapability::LiveGraphInference,
+        CapabilityState::Degraded,
+        "the overlay did not declare complete live-graph relationship inference",
+    );
+    ensure_capability(
+        &mut capabilities,
+        GraphDeltaCapability::ImpactTraversal,
+        CapabilityState::Degraded,
+        "the overlay did not declare complete transitive impact traversal",
+    );
+    ensure_capability(
+        &mut capabilities,
+        GraphDeltaCapability::BehavioralAnalogueDiscovery,
+        if overlay.analogues.is_empty() {
+            CapabilityState::Degraded
+        } else {
+            CapabilityState::Ready
+        },
+        if overlay.analogues.is_empty() {
+            "the overlay supplied no grounded behavioral analogues"
+        } else {
+            "grounded behavioral analogues were supplied by the service adapter"
+        },
+    );
+    capabilities.sort();
+    capabilities.dedup();
+
+    let affected_locus_checklist =
+        build_affected_locus_checklist(&impacted, &bypassed_loci, &behavioral_deltas);
+    let mut omissions = overlay.omissions.clone();
+    for capability in capabilities
+        .iter()
+        .filter(|capability| capability.state != CapabilityState::Ready)
+    {
+        omissions.push(GraphDeltaOmission {
+            code: GraphDeltaOmissionCode::CapabilityDegraded,
+            detail: format!("{:?}: {}", capability.capability, capability.detail),
+            grounding: None,
+            hydration_key: None,
+        });
+    }
+    omissions.sort();
+    omissions.dedup();
+
+    Ok(GraphDeltaCard {
+        beta: true,
+        capabilities,
+        changed_files: overlay.changed_files.clone(),
+        routes,
+        changed_edges,
+        impacted_loci: impacted,
+        impacted_tests,
+        impacted_state_or_api,
+        bypassed_loci,
+        behavioral_deltas,
+        behavioral_analogues: overlay.analogues.clone(),
+        affected_locus_checklist,
+        omissions,
+    })
+}
+
+fn ensure_capability(
+    capabilities: &mut Vec<CapabilityReport>,
+    capability: GraphDeltaCapability,
+    state: CapabilityState,
+    detail: &str,
+) {
+    if capabilities
+        .iter()
+        .all(|report| report.capability != capability)
+    {
+        capabilities.push(CapabilityReport {
+            capability,
+            state,
+            detail: detail.to_owned(),
+        });
+    }
+}
+
+fn build_affected_locus_checklist(
+    impacted: &[ImpactEvidence],
+    bypassed: &[GraphNode],
+    behavioral_deltas: &[BehavioralDelta],
+) -> Vec<AffectedLocusChecklistItem> {
+    let mut entries = BTreeMap::<String, AffectedLocusChecklistItem>::new();
+    let mut add = |label: String, kind: ImpactKind, grounding: EvidenceGrounding| {
+        let stable_id = grounding.stable_hydration_key();
+        let entry =
+            entries
+                .entry(stable_id.clone())
+                .or_insert_with(|| AffectedLocusChecklistItem {
+                    stable_id: stable_id.clone(),
+                    label: label.clone(),
+                    kinds: BTreeSet::new(),
+                    grounding: grounding.clone(),
+                    hydration: HydrationTarget {
+                        stable_key: stable_id,
+                        grounding,
+                    },
+                    requirement: ChecklistRequirement::EditOrEvidenceBackedNoEdit,
+                });
+        entry.kinds.insert(kind);
+        if label < entry.label {
+            entry.label = label;
+        }
+    };
+
+    for evidence in impacted {
+        add(
+            evidence.label.clone(),
+            evidence.kind,
+            evidence.grounding.clone(),
+        );
+    }
+    for node in bypassed {
+        add(
+            format!("bypassed {}", node.id),
+            ImpactKind::Caller,
+            node.grounding.clone(),
+        );
+    }
+    for delta in behavioral_deltas {
+        add(
+            delta.label.clone(),
+            ImpactKind::Caller,
+            delta.changed_locus.clone(),
+        );
+    }
+    entries.into_values().collect()
+}
+
+type CanonicalGraph = (BTreeMap<String, GraphNode>, BTreeMap<EdgeKey, WeightedEdge>);
+
+fn canonical_graph(graph: &GraphSnapshot) -> Result<CanonicalGraph, GraphDeltaError> {
+    let mut nodes = BTreeMap::new();
+    for node in &graph.nodes {
+        if node.id.trim().is_empty() {
+            return Err(GraphDeltaError::InvalidGraph(
+                "node id must not be empty".to_owned(),
+            ));
+        }
+        node.grounding.validate()?;
+        match nodes.insert(node.id.clone(), node.clone()) {
+            Some(existing) if existing != *node => {
+                return Err(GraphDeltaError::InvalidGraph(format!(
+                    "conflicting duplicate node {:?}",
+                    node.id
+                )));
+            }
+            _ => {}
+        }
+    }
+    let mut edges = BTreeMap::new();
+    for edge in &graph.edges {
+        validate_edge(edge)?;
+        if !nodes.contains_key(&edge.key.from) || !nodes.contains_key(&edge.key.to) {
+            return Err(GraphDeltaError::InvalidGraph(format!(
+                "edge references unknown node: {:?}",
+                edge.key
+            )));
+        }
+        match edges.insert(edge.key.clone(), edge.clone()) {
+            Some(existing) if existing != *edge => {
+                return Err(GraphDeltaError::InvalidGraph(format!(
+                    "conflicting duplicate edge {:?}",
+                    edge.key
+                )));
+            }
+            _ => {}
+        }
+    }
+    Ok((nodes, edges))
+}
+
+fn shortest_paths(
+    _nodes: &BTreeMap<String, GraphNode>,
+    edges: &BTreeMap<EdgeKey, WeightedEdge>,
+    endpoints: &EndpointPair,
+    limits: &GraphDeltaLimits,
+) -> Result<PathSet, GraphDeltaError> {
+    if endpoints.from == endpoints.to {
+        return Ok(PathSet {
+            alternatives: vec![WeightedPath {
+                total_cost: 0,
+                nodes: vec![endpoints.from.clone()],
+                edges: Vec::new(),
+                grounded_steps: Vec::new(),
+                priority_registration_key: Vec::new(),
+            }],
+        });
+    }
+
+    let mut adjacency = BTreeMap::<String, Vec<&WeightedEdge>>::new();
+    for edge in edges.values() {
+        adjacency
+            .entry(edge.key.from.clone())
+            .or_default()
+            .push(edge);
+    }
+    for outgoing in adjacency.values_mut() {
+        outgoing.sort_by(|left, right| {
+            left.key
+                .to
+                .cmp(&right.key.to)
+                .then_with(|| left.key.kind.cmp(&right.key.kind))
+                .then_with(|| left.priority.cmp(&right.priority))
+                .then_with(|| left.registration_order.cmp(&right.registration_order))
+        });
+    }
+
+    let mut distances = BTreeMap::<String, u64>::new();
+    let mut predecessors = BTreeMap::<String, Vec<EdgeKey>>::new();
+    let mut queue = BinaryHeap::new();
+    distances.insert(endpoints.from.clone(), 0);
+    queue.push(Reverse((0u64, endpoints.from.clone())));
+    let mut visited = 0usize;
+
+    while let Some(Reverse((distance, node))) = queue.pop() {
+        if distances.get(&node).copied() != Some(distance) {
+            continue;
+        }
+        visited += 1;
+        enforce_limit("visited nodes", visited, limits.visited_nodes)?;
+        if let Some(target_distance) = distances.get(&endpoints.to)
+            && distance > *target_distance
+        {
+            break;
+        }
+        for edge in adjacency.get(&node).into_iter().flatten() {
+            let candidate = distance + u64::from(edge.cost);
+            match distances.get(&edge.key.to).copied() {
+                None => {
+                    distances.insert(edge.key.to.clone(), candidate);
+                    predecessors.insert(edge.key.to.clone(), vec![edge.key.clone()]);
+                    queue.push(Reverse((candidate, edge.key.to.clone())));
+                }
+                Some(existing) if candidate < existing => {
+                    distances.insert(edge.key.to.clone(), candidate);
+                    predecessors.insert(edge.key.to.clone(), vec![edge.key.clone()]);
+                    queue.push(Reverse((candidate, edge.key.to.clone())));
+                }
+                Some(existing) if candidate == existing => {
+                    predecessors
+                        .entry(edge.key.to.clone())
+                        .or_default()
+                        .push(edge.key.clone());
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let Some(total_cost) = distances.get(&endpoints.to).copied() else {
+        return Ok(PathSet {
+            alternatives: Vec::new(),
+        });
+    };
+    for incoming in predecessors.values_mut() {
+        incoming.sort();
+        incoming.dedup();
+    }
+
+    let mut reversed_edges = Vec::new();
+    let mut alternatives = Vec::new();
+    collect_shortest_paths(
+        &endpoints.to,
+        &endpoints.from,
+        total_cost,
+        &predecessors,
+        edges,
+        limits,
+        &mut reversed_edges,
+        &mut alternatives,
+    )?;
+    alternatives.sort_by(|left, right| {
+        left.priority_registration_key
+            .cmp(&right.priority_registration_key)
+            .then_with(|| left.nodes.cmp(&right.nodes))
+            .then_with(|| left.edges.cmp(&right.edges))
+    });
+    Ok(PathSet { alternatives })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_shortest_paths(
+    current: &str,
+    source: &str,
+    total_cost: u64,
+    predecessors: &BTreeMap<String, Vec<EdgeKey>>,
+    edge_map: &BTreeMap<EdgeKey, WeightedEdge>,
+    limits: &GraphDeltaLimits,
+    reversed_edges: &mut Vec<EdgeKey>,
+    output: &mut Vec<WeightedPath>,
+) -> Result<(), GraphDeltaError> {
+    if reversed_edges.len() > limits.path_hops {
+        return Err(GraphDeltaError::LimitExceeded {
+            resource: "path hops",
+            actual: reversed_edges.len(),
+            limit: limits.path_hops,
+        });
+    }
+    if current == source {
+        if output.len() >= limits.equal_paths {
+            return Err(GraphDeltaError::LimitExceeded {
+                resource: "equal-cost paths",
+                actual: output.len() + 1,
+                limit: limits.equal_paths,
+            });
+        }
+        let path_edges = reversed_edges.iter().rev().cloned().collect::<Vec<_>>();
+        let mut path_nodes = vec![source.to_owned()];
+        let mut tie_break = Vec::new();
+        let mut grounded_steps = Vec::new();
+        for key in &path_edges {
+            let edge = edge_map.get(key).ok_or_else(|| {
+                GraphDeltaError::InvalidGraph("shortest-path edge disappeared".to_owned())
+            })?;
+            path_nodes.push(key.to.clone());
+            tie_break.push((
+                edge.priority,
+                edge.registration_order,
+                format!("{}:{}:{}", key.from, key.kind, key.to),
+            ));
+            grounded_steps.push(GroundedRouteStep {
+                edge: key.clone(),
+                cost: edge.cost,
+                priority: edge.priority,
+                registration_order: edge.registration_order,
+                grounding: edge.grounding.clone(),
+            });
+        }
+        output.push(WeightedPath {
+            total_cost,
+            nodes: path_nodes,
+            edges: path_edges,
+            grounded_steps,
+            priority_registration_key: tie_break,
+        });
+        return Ok(());
+    }
+
+    for edge in predecessors.get(current).into_iter().flatten() {
+        reversed_edges.push(edge.clone());
+        collect_shortest_paths(
+            &edge.from,
+            source,
+            total_cost,
+            predecessors,
+            edge_map,
+            limits,
+            reversed_edges,
+            output,
+        )?;
+        reversed_edges.pop();
+    }
+    Ok(())
+}
+
+fn classify_route_change(before: &PathSet, after: &PathSet) -> RouteChange {
+    match (before.cost(), after.cost()) {
+        (None, None) => RouteChange::Unchanged,
+        (None, Some(_)) => RouteChange::AddedReachability,
+        (Some(_), None) => RouteChange::RemovedReachability,
+        (Some(before_cost), Some(after_cost)) if after_cost < before_cost => RouteChange::Shortened,
+        (Some(before_cost), Some(after_cost)) if after_cost > before_cost => {
+            RouteChange::Lengthened
+        }
+        (Some(_), Some(_)) if before.alternatives != after.alternatives => {
+            RouteChange::EqualCostAlternativesChanged
+        }
+        _ => RouteChange::Unchanged,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn current(path: &str, line: u32) -> EvidenceGrounding {
+        EvidenceGrounding::CurrentSource(SourceSpan {
+            root: "workspace".to_owned(),
+            path: path.to_owned(),
+            start_line: line,
+            end_line: line,
+        })
+    }
+
+    fn proposed(path: &str, line: u32) -> EvidenceGrounding {
+        EvidenceGrounding::Proposal(ProposalLine {
+            root: "workspace".to_owned(),
+            path: path.to_owned(),
+            proposal_line: line,
+            old_line: None,
+            new_line: Some(line),
+        })
+    }
+
+    fn edge(from: &str, to: &str, cost: u32, priority: u32) -> WeightedEdge {
+        WeightedEdge {
+            key: EdgeKey {
+                from: from.to_owned(),
+                to: to.to_owned(),
+                kind: "calls".to_owned(),
+            },
+            cost,
+            priority,
+            registration_order: priority,
+            grounding: current("src/lib.rs", 1),
+        }
+    }
+
+    fn graph() -> GraphSnapshot {
+        GraphSnapshot {
+            nodes: ["a", "b", "c", "d"]
+                .into_iter()
+                .map(|id| GraphNode {
+                    id: id.to_owned(),
+                    grounding: current(&format!("src/{id}.rs"), 1),
+                })
+                .collect(),
+            edges: vec![
+                edge("a", "b", 1, 2),
+                edge("b", "d", 2, 2),
+                edge("a", "c", 1, 1),
+                edge("c", "d", 2, 1),
+            ],
+        }
+    }
+
+    #[test]
+    fn beta_requires_explicit_opt_in() {
+        let result = parse_beta_proposal(
+            BetaGraphDeltaRequest {
+                beta: false,
+                root: "workspace".to_owned(),
+                proposal: ProposalInput::Structured(StructuredProposal {
+                    edge_additions: Vec::new(),
+                    edge_removals: Vec::new(),
+                    impacted: Vec::new(),
+                    ..StructuredProposal::default()
+                }),
+            },
+            &GraphDeltaLimits::default(),
+        );
+        assert_eq!(result, Err(GraphDeltaError::BetaOptInRequired));
+    }
+
+    #[test]
+    fn unified_diff_is_bounded_and_source_grounded() {
+        let overlay = parse_beta_proposal(
+            BetaGraphDeltaRequest {
+                beta: true,
+                root: "workspace".to_owned(),
+                proposal: ProposalInput::UnifiedDiff(
+                    "diff --git a/src/state.rs b/src/state.rs\n\
+                     --- a/src/state.rs\n\
+                     +++ b/src/state.rs\n\
+                     @@ -1,1 +1,1 @@\n\
+                     -old\n\
+                     +new\n"
+                        .to_owned(),
+                ),
+            },
+            &GraphDeltaLimits::default(),
+        )
+        .unwrap();
+        assert_eq!(overlay.impacted.len(), 2);
+        assert_eq!(overlay.changed_files.len(), 1);
+        assert_eq!(overlay.changed_files[0].root, "workspace");
+        assert_eq!(overlay.changed_files[0].hunks[0].changed_lines.len(), 2);
+        assert!(overlay.edge_additions.is_empty());
+        assert!(overlay.edge_removals.is_empty());
+        assert!(overlay.impacted.iter().all(|evidence| matches!(
+            &evidence.grounding,
+            EvidenceGrounding::Proposal(line) if line.root == "workspace"
+        )));
+        assert!(overlay.omissions.iter().any(|omission| {
+            omission.code == GraphDeltaOmissionCode::LiveGraphInferenceDeferred
+        }));
+    }
+
+    #[test]
+    fn equal_cost_paths_are_complete_and_priority_ordered() {
+        let card = analyze_graph_delta(
+            &graph(),
+            &EphemeralOverlay {
+                edge_additions: Vec::new(),
+                edge_removals: Vec::new(),
+                impacted: Vec::new(),
+                ..EphemeralOverlay::default()
+            },
+            &[EndpointPair {
+                from: "a".to_owned(),
+                to: "d".to_owned(),
+            }],
+            &GraphDeltaLimits::default(),
+        )
+        .unwrap();
+        assert_eq!(card.routes[0].before.alternatives.len(), 2);
+        assert_eq!(card.routes[0].before.alternatives[0].nodes, ["a", "c", "d"]);
+    }
+
+    #[test]
+    fn overlay_shortens_path_without_mutating_base() {
+        let base = graph();
+        let untouched = base.clone();
+        let addition = WeightedEdge {
+            key: EdgeKey {
+                from: "a".to_owned(),
+                to: "d".to_owned(),
+                kind: "registers".to_owned(),
+            },
+            cost: 1,
+            priority: 0,
+            registration_order: 0,
+            grounding: proposed("src/lib.rs", 8),
+        };
+        let card = analyze_graph_delta(
+            &base,
+            &EphemeralOverlay {
+                edge_additions: vec![addition],
+                edge_removals: Vec::new(),
+                impacted: vec![ImpactEvidence {
+                    label: "src/lib.rs".to_owned(),
+                    kind: ImpactKind::EditableLocus,
+                    grounding: proposed("src/lib.rs", 8),
+                }],
+                ..EphemeralOverlay::default()
+            },
+            &[EndpointPair {
+                from: "a".to_owned(),
+                to: "d".to_owned(),
+            }],
+            &GraphDeltaLimits::default(),
+        )
+        .unwrap();
+
+        assert_eq!(card.routes[0].change, RouteChange::Shortened);
+        assert_eq!(base, untouched);
+        assert!(card.beta);
+        assert!(!card.bypassed_loci.is_empty());
+        assert!(card.behavioral_deltas.iter().any(|delta| {
+            delta.kind == BehavioralDeltaKind::BypassedCall
+                && matches!(delta.changed_locus, EvidenceGrounding::CurrentSource(_))
+        }));
+        assert_eq!(card.routes[0].after.alternatives[0].grounded_steps.len(), 1);
+    }
+
+    #[test]
+    fn incomplete_hunk_is_rejected_instead_of_partially_parsed() {
+        let result = parse_beta_proposal(
+            BetaGraphDeltaRequest {
+                beta: true,
+                root: "workspace".to_owned(),
+                proposal: ProposalInput::UnifiedDiff(
+                    "diff --git a/src/lib.rs b/src/lib.rs\n\
+                     --- a/src/lib.rs\n\
+                     +++ b/src/lib.rs\n\
+                     @@ -1,2 +1,1 @@\n\
+                     -old\n\
+                     +new\n"
+                        .to_owned(),
+                ),
+            },
+            &GraphDeltaLimits::default(),
+        );
+
+        assert!(matches!(
+            result,
+            Err(GraphDeltaError::MalformedProposal {
+                reason: "hunk body line counts do not match its header",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn structured_proposal_rejects_unknown_fields_and_wrong_roots() {
+        let unknown = parse_beta_proposal(
+            BetaGraphDeltaRequest {
+                beta: true,
+                root: "workspace".to_owned(),
+                proposal: ProposalInput::StructuredJson(
+                    r#"{"schema_version":1,"unexpected":true}"#.to_owned(),
+                ),
+            },
+            &GraphDeltaLimits::default(),
+        );
+        assert!(matches!(
+            unknown,
+            Err(GraphDeltaError::MalformedStructuredProposal(_))
+        ));
+
+        let wrong_root = parse_beta_proposal(
+            BetaGraphDeltaRequest {
+                beta: true,
+                root: "workspace".to_owned(),
+                proposal: ProposalInput::Structured(StructuredProposal {
+                    impacted: vec![ImpactEvidence {
+                        label: "changed".to_owned(),
+                        kind: ImpactKind::EditableLocus,
+                        grounding: EvidenceGrounding::Proposal(ProposalLine {
+                            root: "other-root".to_owned(),
+                            path: "src/lib.rs".to_owned(),
+                            proposal_line: 1,
+                            old_line: None,
+                            new_line: Some(1),
+                        }),
+                    }],
+                    ..StructuredProposal::default()
+                }),
+            },
+            &GraphDeltaLimits::default(),
+        );
+        assert!(matches!(
+            wrong_root,
+            Err(GraphDeltaError::InvalidGraph(reason))
+                if reason.contains("root does not match")
+        ));
+    }
+
+    #[test]
+    fn worse_priority_equal_cost_edge_does_not_displace_preferred_route() {
+        let card = analyze_graph_delta(
+            &graph(),
+            &EphemeralOverlay {
+                edge_additions: vec![WeightedEdge {
+                    key: EdgeKey {
+                        from: "a".to_owned(),
+                        to: "d".to_owned(),
+                        kind: "fallback".to_owned(),
+                    },
+                    cost: 3,
+                    priority: 99,
+                    registration_order: 99,
+                    grounding: proposed("src/lib.rs", 9),
+                }],
+                ..EphemeralOverlay::default()
+            },
+            &[EndpointPair {
+                from: "a".to_owned(),
+                to: "d".to_owned(),
+            }],
+            &GraphDeltaLimits::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            card.routes[0].change,
+            RouteChange::EqualCostAlternativesChanged
+        );
+        assert_eq!(
+            card.routes[0].before.alternatives[0].nodes,
+            card.routes[0].after.alternatives[0].nodes
+        );
+        assert_eq!(card.routes[0].after.alternatives[0].nodes, ["a", "c", "d"]);
+    }
+
+    #[test]
+    fn removing_the_only_edge_reports_lost_reachability() {
+        let only_edge = edge("a", "b", 1, 0);
+        let base = GraphSnapshot {
+            nodes: ["a", "b"]
+                .into_iter()
+                .map(|id| GraphNode {
+                    id: id.to_owned(),
+                    grounding: current(&format!("src/{id}.rs"), 1),
+                })
+                .collect(),
+            edges: vec![only_edge.clone()],
+        };
+        let card = analyze_graph_delta(
+            &base,
+            &EphemeralOverlay {
+                edge_removals: vec![only_edge.key],
+                ..EphemeralOverlay::default()
+            },
+            &[EndpointPair {
+                from: "a".to_owned(),
+                to: "b".to_owned(),
+            }],
+            &GraphDeltaLimits::default(),
+        )
+        .unwrap();
+
+        assert_eq!(card.routes[0].change, RouteChange::RemovedReachability);
+        assert!(card.routes[0].after.alternatives.is_empty());
+        assert_eq!(card.changed_edges[0].change, EdgeChange::Removed);
+    }
+
+    #[test]
+    fn cross_file_state_and_incomplete_capability_are_explicit() {
+        let state_grounding = EvidenceGrounding::CurrentSource(SourceSpan {
+            root: "dependency-root".to_owned(),
+            path: "src/state.rs".to_owned(),
+            start_line: 12,
+            end_line: 14,
+        });
+        let card = analyze_graph_delta(
+            &graph(),
+            &EphemeralOverlay {
+                impacted: vec![ImpactEvidence {
+                    label: "shared state".to_owned(),
+                    kind: ImpactKind::StateOrApi,
+                    grounding: state_grounding.clone(),
+                }],
+                capabilities: vec![CapabilityReport {
+                    capability: GraphDeltaCapability::ImpactTraversal,
+                    state: CapabilityState::Unavailable,
+                    detail: "live graph traversal was unavailable".to_owned(),
+                }],
+                ..EphemeralOverlay::default()
+            },
+            &[],
+            &GraphDeltaLimits::default(),
+        )
+        .unwrap();
+
+        assert_eq!(card.impacted_state_or_api.len(), 1);
+        assert_eq!(
+            card.affected_locus_checklist[0].hydration.stable_key,
+            state_grounding.stable_hydration_key()
+        );
+        assert!(card.capabilities.iter().any(|capability| {
+            capability.capability == GraphDeltaCapability::ImpactTraversal
+                && capability.state == CapabilityState::Unavailable
+        }));
+        assert!(card.omissions.iter().any(|omission| {
+            omission.code == GraphDeltaOmissionCode::CapabilityDegraded
+                && omission.detail.contains("ImpactTraversal")
+        }));
+    }
+
+    #[test]
+    fn candidate_order_does_not_change_card() {
+        let mut reversed = graph();
+        reversed.nodes.reverse();
+        reversed.edges.reverse();
+        let overlay = EphemeralOverlay {
+            edge_additions: Vec::new(),
+            edge_removals: Vec::new(),
+            impacted: Vec::new(),
+            ..EphemeralOverlay::default()
+        };
+        let endpoints = [EndpointPair {
+            from: "a".to_owned(),
+            to: "d".to_owned(),
+        }];
+        let forward =
+            analyze_graph_delta(&graph(), &overlay, &endpoints, &GraphDeltaLimits::default())
+                .unwrap();
+        let reverse = analyze_graph_delta(
+            &reversed,
+            &overlay,
+            &endpoints,
+            &GraphDeltaLimits::default(),
+        )
+        .unwrap();
+        assert_eq!(forward, reverse);
+        assert_eq!(
+            format!("{forward:#?}").as_bytes(),
+            format!("{reverse:#?}").as_bytes()
+        );
+    }
+}

--- a/src/service/search/model.rs
+++ b/src/service/search/model.rs
@@ -286,6 +286,8 @@ pub(crate) struct SymbolSummary {
     pub(crate) kind: String,
     pub(crate) language: String,
     pub(crate) signature: String,
+    pub(crate) extraction_source: Option<String>,
+    pub(crate) declared_metadata: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/service/search/model.rs
+++ b/src/service/search/model.rs
@@ -1,0 +1,522 @@
+//! Typed contracts for search selection, projection, hydration, and accounting.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+macro_rules! string_enum {
+    ($name:ident { $($variant:ident => $label:literal),+ $(,)? }) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub(crate) enum $name { $($variant),+ }
+
+        impl $name {
+            pub(crate) const fn as_str(self) -> &'static str {
+                match self { $(Self::$variant => $label),+ }
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+    };
+}
+
+string_enum!(SearchIntent {
+    Discover => "discover",
+    Implement => "implement",
+    Debug => "debug",
+    Review => "review",
+    Hydrate => "hydrate",
+});
+string_enum!(SearchProjection { Agent => "agent", Evidence => "evidence" });
+string_enum!(BodyPolicy {
+    Complete => "complete",
+    FocusedSpan => "focused_span",
+    SignatureOnly => "signature_only",
+    Minified => "minified",
+    NoBody => "none",
+});
+string_enum!(BodyRepresentation {
+    Complete => "complete",
+    FocusedSpan => "focused_span",
+    SignatureOnly => "signature_only",
+    Minified => "minified",
+    Truncated => "truncated",
+});
+string_enum!(ContextRole {
+    EditableSource => "editable_source",
+    DefinitionOrApiState => "definition_or_api_state",
+    Test => "test",
+    BehavioralAnalogue => "behavioral_analogue",
+    DirectDependency => "direct_dependency",
+    CallerOrImpact => "caller_or_impact",
+    ProposalDelta => "proposal_delta",
+});
+string_enum!(RetrievalLane {
+    ExactReference => "exact_reference",
+    EditableSource => "editable_source",
+    DefinitionOrState => "definition_or_state",
+    Tests => "tests",
+    Analogues => "analogues",
+    Dependencies => "dependencies",
+    GraphImpact => "graph_impact",
+    ProposalDelta => "proposal_delta",
+});
+string_enum!(SelectionChannel {
+    Exact => "exact",
+    Lexical => "lexical",
+    Semantic => "semantic",
+    Graph => "graph",
+    Artifact => "artifact",
+    Markdown => "markdown",
+});
+string_enum!(CandidateDisposition {
+    Selected => "selected",
+    Omitted => "omitted",
+});
+string_enum!(SpanCoverage { Complete => "complete", Partial => "partial" });
+string_enum!(HydrationKind { Source => "source", Evidence => "evidence" });
+string_enum!(CapabilityState {
+    Ready => "ready",
+    Degraded => "degraded",
+    Unavailable => "unavailable",
+});
+string_enum!(OmissionCode {
+    NoBodyPolicy => "no_body_policy",
+    MissingSource => "missing_source",
+    InvalidFocusedSpan => "invalid_focused_span",
+    SourceUnavailable => "source_unavailable",
+    PerRecordBodyCap => "per_record_body_cap",
+    TotalBodyCap => "total_body_cap",
+    RenderBudget => "render_budget",
+    MinificationFailed => "minification_failed",
+});
+string_enum!(CostSection {
+    Headers => "headers",
+    Bodies => "bodies",
+    Relationships => "relationships",
+    Metadata => "metadata",
+    Footer => "footer",
+});
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub(crate) struct SourceSpan {
+    pub(crate) root: String,
+    pub(crate) path: String,
+    pub(crate) start_line: u32,
+    pub(crate) end_line: u32,
+}
+
+impl SourceSpan {
+    pub(crate) fn is_valid(&self) -> bool {
+        self.start_line > 0 && self.end_line >= self.start_line
+    }
+
+    pub(crate) fn contains(&self, other: &Self) -> bool {
+        self.root == other.root
+            && self.path == other.path
+            && self.start_line <= other.start_line
+            && self.end_line >= other.end_line
+    }
+
+    pub(crate) fn stable_id(&self) -> String {
+        format!(
+            "source:v1:{}:{}:{}:{}",
+            hex(self.root.as_bytes()),
+            hex(self.path.as_bytes()),
+            self.start_line,
+            self.end_line
+        )
+    }
+
+    /// Recover the authoritative source span bound into a coalesced hydration
+    /// identity. All variable-width fields are hex encoded, so the shape is
+    /// unambiguous and malformed identities fail closed.
+    pub(crate) fn from_stable_id(value: &str) -> Result<Self, String> {
+        let parts: Vec<_> = value.split(':').collect();
+        if parts.len() != 6 || parts[0] != "source" || parts[1] != "v1" {
+            return Err("invalid source span identity shape".to_string());
+        }
+        let span = Self {
+            root: unhex(parts[2])?,
+            path: unhex(parts[3])?,
+            start_line: parts[4]
+                .parse()
+                .map_err(|_| "invalid source span start line")?,
+            end_line: parts[5]
+                .parse()
+                .map_err(|_| "invalid source span end line")?,
+        };
+        if !span.is_valid() || span.stable_id() != value {
+            return Err("invalid source span identity".to_string());
+        }
+        Ok(span)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct HydrationHandle {
+    pub(crate) kind: HydrationKind,
+    pub(crate) record_id: String,
+    pub(crate) source: Option<SourceSpan>,
+}
+
+impl HydrationHandle {
+    pub(crate) fn source(record_id: impl Into<String>, source: SourceSpan) -> Self {
+        Self {
+            kind: HydrationKind::Source,
+            record_id: record_id.into(),
+            source: Some(source),
+        }
+    }
+
+    pub(crate) fn evidence(record_id: impl Into<String>) -> Self {
+        Self {
+            kind: HydrationKind::Evidence,
+            record_id: record_id.into(),
+            source: None,
+        }
+    }
+
+    /// A self-describing handle; no process-local lookup table is required to hydrate it.
+    pub(crate) fn encode(&self) -> String {
+        let (root, path, start, end) = self.source.as_ref().map_or_else(
+            || (String::new(), String::new(), 0, 0),
+            |span| {
+                (
+                    hex(span.root.as_bytes()),
+                    hex(span.path.as_bytes()),
+                    span.start_line,
+                    span.end_line,
+                )
+            },
+        );
+        let payload = format!(
+            "rna-hydrate-v1:{}:{}:{root}:{path}:{start}:{end}",
+            self.kind,
+            hex(self.record_id.as_bytes())
+        );
+        let checksum = blake3::hash(payload.as_bytes()).to_hex();
+        format!("{payload}:{}", &checksum.as_str()[..16])
+    }
+
+    pub(crate) fn decode(value: &str) -> Result<Self, String> {
+        let parts: Vec<_> = value.split(':').collect();
+        if parts.len() != 8 || parts[0] != "rna-hydrate-v1" {
+            return Err("invalid hydration handle shape".to_string());
+        }
+        let payload = parts[..7].join(":");
+        let expected = blake3::hash(payload.as_bytes()).to_hex();
+        if parts[7] != &expected.as_str()[..16] {
+            return Err("hydration handle checksum mismatch".to_string());
+        }
+        let kind = match parts[1] {
+            "source" => HydrationKind::Source,
+            "evidence" => HydrationKind::Evidence,
+            _ => return Err("invalid hydration handle kind".to_string()),
+        };
+        let record_id = unhex(parts[2])?;
+        let start_line = parts[5]
+            .parse()
+            .map_err(|_| "invalid hydration start line")?;
+        let end_line = parts[6].parse().map_err(|_| "invalid hydration end line")?;
+        let source = if kind == HydrationKind::Source {
+            let span = SourceSpan {
+                root: unhex(parts[3])?,
+                path: unhex(parts[4])?,
+                start_line,
+                end_line,
+            };
+            if !span.is_valid() {
+                return Err("invalid hydration source span".to_string());
+            }
+            Some(span)
+        } else if parts[3].is_empty() && parts[4].is_empty() && start_line == 0 && end_line == 0 {
+            None
+        } else {
+            return Err("evidence handle unexpectedly contains a source span".to_string());
+        };
+        Ok(Self {
+            kind,
+            record_id,
+            source,
+        })
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(DIGITS[(byte >> 4) as usize] as char);
+        output.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+fn unhex(value: &str) -> Result<String, String> {
+    if !value.len().is_multiple_of(2) {
+        return Err("invalid hydration hex".to_string());
+    }
+    let mut bytes = Vec::with_capacity(value.len() / 2);
+    for pair in value.as_bytes().chunks_exact(2) {
+        let digit = |byte| match byte {
+            b'0'..=b'9' => Ok(byte - b'0'),
+            b'a'..=b'f' => Ok(byte - b'a' + 10),
+            _ => Err("invalid hydration hex".to_string()),
+        };
+        bytes.push((digit(pair[0])? << 4) | digit(pair[1])?);
+    }
+    String::from_utf8(bytes).map_err(|_| "hydration handle is not UTF-8".to_string())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct RecordIdentity {
+    pub(crate) node_id: String,
+    pub(crate) source: Option<SourceSpan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SymbolSummary {
+    pub(crate) name: String,
+    pub(crate) kind: String,
+    pub(crate) language: String,
+    pub(crate) signature: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SelectionSummary {
+    pub(crate) channel: SelectionChannel,
+    pub(crate) reason: String,
+    pub(crate) role: Option<ContextRole>,
+    pub(crate) lane: Option<RetrievalLane>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub(crate) struct EvidenceProvenance {
+    pub(crate) source: String,
+    pub(crate) detail: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SelectionEvidence {
+    pub(crate) raw_scores: BTreeMap<String, String>,
+    pub(crate) content_hash: Option<String>,
+    pub(crate) candidate_rank: Option<usize>,
+    pub(crate) provenance: Vec<EvidenceProvenance>,
+    pub(crate) diagnostics: BTreeMap<String, String>,
+}
+
+/// One member of the complete, bounded candidate set considered for a query.
+///
+/// Candidate audit is intentionally separate from [`SelectedRecord`]: the
+/// default agent projection renders only selected context, while the evidence
+/// projection retains both selected and omitted candidates with the exact
+/// disposition reason and retrieval observations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CandidateAudit {
+    pub(crate) candidate_rank: usize,
+    pub(crate) identity: RecordIdentity,
+    pub(crate) disposition: CandidateDisposition,
+    pub(crate) reason: String,
+    pub(crate) evidence: SelectionEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SelectedRecord {
+    pub(crate) selection_rank: usize,
+    pub(crate) identity: RecordIdentity,
+    pub(crate) symbol: SymbolSummary,
+    pub(crate) selection: SelectionSummary,
+    pub(crate) evidence: SelectionEvidence,
+    /// Present only when the service can resolve this exact selection evidence
+    /// without fabricating a graph identity for a non-graph result.
+    pub(crate) evidence_hydration: Option<HydrationHandle>,
+    pub(crate) focused_span: Option<SourceSpan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ProjectedRecord {
+    pub(crate) selection_rank: usize,
+    pub(crate) identity: RecordIdentity,
+    pub(crate) symbol: SymbolSummary,
+    pub(crate) selection: SelectionSummary,
+    pub(crate) evidence: SelectionEvidence,
+    pub(crate) body: BodyRepresentation,
+    pub(crate) span_ids: Vec<String>,
+    pub(crate) source_handle: Option<HydrationHandle>,
+    pub(crate) evidence_handle: Option<HydrationHandle>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SpanMapping {
+    pub(crate) record_id: String,
+    pub(crate) selection_rank: usize,
+    pub(crate) selection: SelectionSummary,
+    pub(crate) requested: SourceSpan,
+    pub(crate) coverage: SpanCoverage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ProjectedSpan {
+    pub(crate) source: SourceSpan,
+    pub(crate) text: String,
+    pub(crate) representation: BodyRepresentation,
+    pub(crate) mappings: Vec<SpanMapping>,
+    pub(crate) hydration: HydrationHandle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub(crate) struct ProjectedRelationship {
+    pub(crate) from: String,
+    pub(crate) kind: String,
+    pub(crate) to: String,
+    pub(crate) reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ProjectionOmission {
+    pub(crate) record_id: Option<String>,
+    pub(crate) source: Option<SourceSpan>,
+    pub(crate) code: OmissionCode,
+    pub(crate) detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub(crate) struct CapabilityStatus {
+    pub(crate) capability: String,
+    pub(crate) state: CapabilityState,
+    pub(crate) detail: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ProjectionBudget {
+    pub(crate) max_rendered_bytes: Option<usize>,
+    pub(crate) max_estimated_tokens: Option<usize>,
+    pub(crate) per_record_body_bytes: Option<usize>,
+    pub(crate) total_body_bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ProjectionRequest {
+    pub(crate) intent: SearchIntent,
+    pub(crate) projection: SearchProjection,
+    pub(crate) body_policy: BodyPolicy,
+    pub(crate) budget: ProjectionBudget,
+}
+
+impl Default for ProjectionRequest {
+    fn default() -> Self {
+        Self {
+            intent: SearchIntent::Discover,
+            projection: SearchProjection::Agent,
+            body_policy: BodyPolicy::SignatureOnly,
+            budget: ProjectionBudget::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ProjectionInput {
+    pub(crate) records: Vec<SelectedRecord>,
+    pub(crate) candidate_audit: Vec<CandidateAudit>,
+    pub(crate) relationships: Vec<ProjectedRelationship>,
+    pub(crate) omissions: Vec<ProjectionOmission>,
+    pub(crate) capabilities: Vec<CapabilityStatus>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ProjectionPlan {
+    pub(crate) request: ProjectionRequest,
+    pub(crate) records: Vec<ProjectedRecord>,
+    pub(crate) candidate_audit: Vec<CandidateAudit>,
+    pub(crate) spans: Vec<ProjectedSpan>,
+    pub(crate) relationships: Vec<ProjectedRelationship>,
+    pub(crate) omissions: Vec<ProjectionOmission>,
+    pub(crate) capabilities: Vec<CapabilityStatus>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct RenderCost {
+    pub(crate) utf8_bytes: usize,
+    pub(crate) unicode_chars: usize,
+    pub(crate) estimated_tokens: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct RenderAccounting {
+    pub(crate) total: RenderCost,
+    pub(crate) sections: BTreeMap<CostSection, RenderCost>,
+    pub(crate) estimate_name: String,
+    pub(crate) provider_usage: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct RenderedResponse {
+    pub(crate) text: String,
+    pub(crate) accounting: RenderAccounting,
+    pub(crate) plan: ProjectionPlan,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hydration_handles_are_stable_and_self_describing() {
+        let handle = HydrationHandle::source(
+            "node:β",
+            SourceSpan {
+                root: "repo".into(),
+                path: "src/ü.rs".into(),
+                start_line: 2,
+                end_line: 7,
+            },
+        );
+        assert_eq!(HydrationHandle::decode(&handle.encode()).unwrap(), handle);
+        assert_eq!(handle.encode(), handle.encode());
+    }
+
+    #[test]
+    fn source_span_identity_roundtrips_for_coalesced_hydration() {
+        let span = SourceSpan {
+            root: "repo:β".into(),
+            path: "src/ü.rs".into(),
+            start_line: 2,
+            end_line: 300,
+        };
+
+        assert_eq!(SourceSpan::from_stable_id(&span.stable_id()).unwrap(), span);
+        assert!(SourceSpan::from_stable_id("source:v1:00:00:0:1").is_err());
+    }
+
+    #[test]
+    fn evidence_handles_cannot_smuggle_a_source() {
+        let handle = HydrationHandle::evidence("node");
+        assert_eq!(HydrationHandle::decode(&handle.encode()).unwrap(), handle);
+    }
+
+    #[test]
+    fn hydration_handle_tampering_fails_closed() {
+        let handle = HydrationHandle::evidence("node").encode();
+        let (payload, checksum) = handle
+            .rsplit_once(':')
+            .expect("encoded handle has a checksum segment");
+        let mut checksum = checksum.as_bytes().to_vec();
+        checksum[0] = if checksum[0] == b'0' { b'1' } else { b'0' };
+        let tampered = format!(
+            "{payload}:{}",
+            String::from_utf8(checksum).expect("checksum remains valid UTF-8")
+        );
+
+        assert_eq!(tampered.split(':').count(), 8);
+        assert_eq!(
+            HydrationHandle::decode(&tampered),
+            Err("hydration handle checksum mismatch".to_string())
+        );
+    }
+}

--- a/src/service/search/projection.rs
+++ b/src/service/search/projection.rs
@@ -210,6 +210,7 @@ pub(crate) fn plan_projection(
 
     spans.sort_by(span_order);
     enforce_total_body_cap(&request, &mut records, &mut omissions, &mut spans);
+    annotate_projected_span_costs(&mut records, &spans);
     omissions.sort_by(omission_order);
 
     ProjectionPlan {
@@ -220,6 +221,41 @@ pub(crate) fn plan_projection(
         relationships: input.relationships,
         omissions,
         capabilities: input.capabilities,
+    }
+}
+
+/// Bind each selected record to the deterministic body-span cost it receives.
+/// The values live in evidence diagnostics, so the agent projection stays
+/// concise while evidence projection can audit admission against the exact
+/// coalesced span rather than an unprojected record body.
+fn annotate_projected_span_costs(records: &mut [ProjectedRecord], spans: &[ProjectedSpan]) {
+    for span in spans {
+        let unicode_chars = span.text.chars().count();
+        let estimated_tokens = unicode_chars.saturating_add(3) / 4;
+        let span_id = span.source.stable_id();
+        for mapping in &span.mappings {
+            for record in records.iter_mut().filter(|record| {
+                record.selection_rank == mapping.selection_rank
+                    && record.identity.node_id == mapping.record_id
+            }) {
+                record
+                    .evidence
+                    .diagnostics
+                    .insert("projected_span_id".into(), span_id.clone());
+                record.evidence.diagnostics.insert(
+                    "projected_span_utf8_bytes".into(),
+                    span.text.len().to_string(),
+                );
+                record.evidence.diagnostics.insert(
+                    "projected_span_unicode_chars".into(),
+                    unicode_chars.to_string(),
+                );
+                record.evidence.diagnostics.insert(
+                    "projected_span_estimated_tokens".into(),
+                    estimated_tokens.to_string(),
+                );
+            }
+        }
     }
 }
 
@@ -706,6 +742,24 @@ mod tests {
         assert_eq!(first.spans.len(), 1);
         assert_eq!(first.spans[0].text, "a\nb\nc\n");
         assert_eq!(first.spans[0].mappings.len(), 2);
+        for record in &first.records {
+            assert_eq!(
+                record
+                    .evidence
+                    .diagnostics
+                    .get("projected_span_utf8_bytes")
+                    .map(String::as_str),
+                Some("6")
+            );
+            assert_eq!(
+                record
+                    .evidence
+                    .diagnostics
+                    .get("projected_span_estimated_tokens")
+                    .map(String::as_str),
+                Some("2")
+            );
+        }
     }
 
     #[test]

--- a/src/service/search/projection.rs
+++ b/src/service/search/projection.rs
@@ -707,6 +707,8 @@ mod tests {
                 kind: "function".into(),
                 language: "text".into(),
                 signature: format!("fn {id}()"),
+                extraction_source: None,
+                declared_metadata: BTreeMap::new(),
             },
             selection: SelectionSummary {
                 channel: SelectionChannel::Exact,

--- a/src/service/search/projection.rs
+++ b/src/service/search/projection.rs
@@ -1,0 +1,1155 @@
+//! Deterministic source projection: select bodies, coalesce overlap, and enforce body caps.
+
+use std::collections::{BTreeMap, btree_map::Entry};
+
+use super::model::*;
+use super::source::{SourceError, SourceReader, SourceSlice};
+
+#[derive(Debug, Clone)]
+struct Candidate {
+    record_id: String,
+    selection_rank: usize,
+    selection: SelectionSummary,
+    language: String,
+    slice: SourceSlice,
+    representation: BodyRepresentation,
+}
+
+pub(crate) fn plan_projection(
+    request: ProjectionRequest,
+    mut input: ProjectionInput,
+    source: &SourceReader,
+) -> ProjectionPlan {
+    input.records.sort_by(record_order);
+    input.candidate_audit.sort_by(candidate_audit_order);
+    input.relationships.sort();
+    input.capabilities.sort();
+
+    let mut omissions = input.omissions;
+    let mut records: Vec<_> = input
+        .records
+        .iter()
+        .map(|selected| projected_record(&request, selected, source, &mut omissions))
+        .collect();
+    let mut candidates = Vec::new();
+
+    for selected in &input.records {
+        if matches!(
+            request.body_policy,
+            BodyPolicy::SignatureOnly | BodyPolicy::NoBody
+        ) {
+            if request.body_policy == BodyPolicy::NoBody {
+                omit(
+                    &mut omissions,
+                    selected,
+                    None,
+                    OmissionCode::NoBodyPolicy,
+                    "body policy requested no source body",
+                );
+            }
+            continue;
+        }
+        let Some(full) = selected.identity.source.as_ref() else {
+            omit(
+                &mut omissions,
+                selected,
+                None,
+                OmissionCode::MissingSource,
+                "record has no source span",
+            );
+            continue;
+        };
+        if !full.is_valid() {
+            omit(
+                &mut omissions,
+                selected,
+                Some(full.clone()),
+                OmissionCode::SourceUnavailable,
+                "record source span is invalid",
+            );
+            continue;
+        }
+        let focused = selected
+            .focused_span
+            .as_ref()
+            .filter(|span| full.contains(span));
+        if selected.focused_span.is_some() && focused.is_none() {
+            omit(
+                &mut omissions,
+                selected,
+                selected.focused_span.clone(),
+                OmissionCode::InvalidFocusedSpan,
+                "focused span is not contained by the record source span",
+            );
+        }
+        let preferred = if request.body_policy == BodyPolicy::FocusedSpan {
+            focused.unwrap_or(full)
+        } else {
+            full
+        };
+        let mut choices = vec![preferred];
+        if preferred == full
+            && let Some(focus) = focused
+            && focus != full
+        {
+            choices.push(focus);
+        }
+
+        let mut admitted = None;
+        let mut used_focused_fallback = false;
+        let mut last_error = String::new();
+        for choice in choices {
+            match source.read(choice) {
+                Ok(slice) => {
+                    if request
+                        .budget
+                        .per_record_body_bytes
+                        .is_none_or(|cap| slice.text.len() <= cap)
+                    {
+                        used_focused_fallback =
+                            choice != full && request.body_policy != BodyPolicy::FocusedSpan;
+                        admitted = Some((choice.clone(), slice));
+                        break;
+                    }
+                    last_error = format!(
+                        "source body exceeds the per-record cap of {} bytes",
+                        request.budget.per_record_body_bytes.unwrap()
+                    );
+                }
+                Err(error) => last_error = error.to_string(),
+            }
+        }
+        let Some((chosen, slice)) = admitted else {
+            let code = if last_error.contains("per-record cap") {
+                OmissionCode::PerRecordBodyCap
+            } else {
+                OmissionCode::SourceUnavailable
+            };
+            omit(
+                &mut omissions,
+                selected,
+                Some(preferred.clone()),
+                code,
+                &last_error,
+            );
+            continue;
+        };
+        let representation = if chosen != *full {
+            BodyRepresentation::FocusedSpan
+        } else {
+            BodyRepresentation::Complete
+        };
+        if used_focused_fallback {
+            omit(
+                &mut omissions,
+                selected,
+                Some(full.clone()),
+                OmissionCode::PerRecordBodyCap,
+                "complete body exceeded the per-record cap; selected the bounded focused span",
+            );
+        }
+        candidates.push(Candidate {
+            record_id: selected.identity.node_id.clone(),
+            selection_rank: selected.selection_rank,
+            selection: selected.selection.clone(),
+            language: selected.symbol.language.clone(),
+            slice,
+            representation,
+        });
+    }
+
+    let mut groups: BTreeMap<(String, String), Vec<Candidate>> = BTreeMap::new();
+    for candidate in candidates {
+        groups
+            .entry((
+                candidate.slice.span.root.clone(),
+                candidate.slice.span.path.clone(),
+            ))
+            .or_default()
+            .push(candidate);
+    }
+    let mut spans = Vec::new();
+    for (_, mut group) in groups {
+        group.sort_by(|a, b| {
+            a.slice
+                .span
+                .start_line
+                .cmp(&b.slice.span.start_line)
+                .then_with(|| a.slice.span.end_line.cmp(&b.slice.span.end_line))
+                .then_with(|| a.selection_rank.cmp(&b.selection_rank))
+                .then_with(|| a.record_id.cmp(&b.record_id))
+        });
+        let mut component = Vec::new();
+        let mut component_end = 0;
+        for candidate in group {
+            if !component.is_empty() && candidate.slice.span.start_line > component_end {
+                flush_component(
+                    &request,
+                    &mut records,
+                    &mut omissions,
+                    &mut spans,
+                    std::mem::take(&mut component),
+                    source,
+                );
+                component_end = 0;
+            }
+            component_end = component_end.max(candidate.slice.span.end_line);
+            component.push(candidate);
+        }
+        if !component.is_empty() {
+            flush_component(
+                &request,
+                &mut records,
+                &mut omissions,
+                &mut spans,
+                component,
+                source,
+            );
+        }
+    }
+
+    spans.sort_by(span_order);
+    enforce_total_body_cap(&request, &mut records, &mut omissions, &mut spans);
+    omissions.sort_by(omission_order);
+
+    ProjectionPlan {
+        request,
+        records,
+        candidate_audit: input.candidate_audit,
+        spans,
+        relationships: input.relationships,
+        omissions,
+        capabilities: input.capabilities,
+    }
+}
+
+fn candidate_audit_order(a: &CandidateAudit, b: &CandidateAudit) -> std::cmp::Ordering {
+    a.candidate_rank
+        .cmp(&b.candidate_rank)
+        .then_with(|| a.identity.node_id.cmp(&b.identity.node_id))
+        .then_with(|| a.identity.source.cmp(&b.identity.source))
+        .then_with(|| a.disposition.cmp(&b.disposition))
+        .then_with(|| a.reason.cmp(&b.reason))
+        .then_with(|| evidence_order(&a.evidence, &b.evidence))
+}
+
+fn record_order(a: &SelectedRecord, b: &SelectedRecord) -> std::cmp::Ordering {
+    a.selection_rank
+        .cmp(&b.selection_rank)
+        .then_with(|| a.identity.node_id.cmp(&b.identity.node_id))
+        .then_with(|| a.selection.role.cmp(&b.selection.role))
+        .then_with(|| a.selection.lane.cmp(&b.selection.lane))
+        .then_with(|| a.selection.channel.cmp(&b.selection.channel))
+        .then_with(|| a.selection.reason.cmp(&b.selection.reason))
+        .then_with(|| a.symbol.name.cmp(&b.symbol.name))
+        .then_with(|| a.symbol.kind.cmp(&b.symbol.kind))
+        .then_with(|| a.symbol.language.cmp(&b.symbol.language))
+        .then_with(|| a.symbol.signature.cmp(&b.symbol.signature))
+        .then_with(|| a.focused_span.cmp(&b.focused_span))
+        .then_with(|| evidence_order(&a.evidence, &b.evidence))
+        .then_with(|| {
+            a.evidence_hydration
+                .as_ref()
+                .map(HydrationHandle::encode)
+                .cmp(&b.evidence_hydration.as_ref().map(HydrationHandle::encode))
+        })
+}
+
+fn evidence_order(a: &SelectionEvidence, b: &SelectionEvidence) -> std::cmp::Ordering {
+    a.raw_scores
+        .cmp(&b.raw_scores)
+        .then_with(|| a.content_hash.cmp(&b.content_hash))
+        .then_with(|| a.candidate_rank.cmp(&b.candidate_rank))
+        .then_with(|| a.provenance.cmp(&b.provenance))
+        .then_with(|| a.diagnostics.cmp(&b.diagnostics))
+}
+
+fn projected_record(
+    request: &ProjectionRequest,
+    selected: &SelectedRecord,
+    source: &SourceReader,
+    omissions: &mut Vec<ProjectionOmission>,
+) -> ProjectedRecord {
+    let source_handle = selected.identity.source.as_ref().and_then(|full| {
+        let hydrated_page = (request.intent == SearchIntent::Hydrate)
+            .then_some(selected.focused_span.as_ref())
+            .flatten();
+        match next_hydration_span(source, full, hydrated_page) {
+            Ok(Some(span)) => Some(HydrationHandle::source(
+                selected.identity.node_id.clone(),
+                span,
+            )),
+            Ok(None) => None,
+            Err(error) => {
+                omit(
+                    omissions,
+                    selected,
+                    Some(full.clone()),
+                    OmissionCode::SourceUnavailable,
+                    &format!("source hydration handle unavailable: {error}"),
+                );
+                None
+            }
+        }
+    });
+    ProjectedRecord {
+        selection_rank: selected.selection_rank,
+        identity: selected.identity.clone(),
+        symbol: selected.symbol.clone(),
+        selection: selected.selection.clone(),
+        evidence: selected.evidence.clone(),
+        body: BodyRepresentation::SignatureOnly,
+        span_ids: Vec::new(),
+        source_handle,
+        evidence_handle: selected.evidence_hydration.clone(),
+    }
+}
+
+/// Return the next deterministic, readable page of an authoritative source
+/// span. Hydration requests advance strictly past the page they just rendered,
+/// so each emitted handle is consumed exactly once in source order.
+fn next_hydration_span(
+    source: &SourceReader,
+    full: &SourceSpan,
+    hydrated_page: Option<&SourceSpan>,
+) -> Result<Option<SourceSpan>, SourceError> {
+    let start_line = match hydrated_page {
+        Some(page) if full.contains(page) && page.end_line < full.end_line => {
+            page.end_line.saturating_add(1)
+        }
+        Some(page) if full.contains(page) => return Ok(None),
+        Some(_) => return Err(SourceError::InvalidRange),
+        None => full.start_line,
+    };
+    let remaining = SourceSpan {
+        start_line,
+        ..full.clone()
+    };
+    bounded_hydration_span(source, &remaining).map(Some)
+}
+
+/// Return the largest readable first page of the supplied remaining span.
+fn bounded_hydration_span(
+    source: &SourceReader,
+    remaining: &SourceSpan,
+) -> Result<SourceSpan, SourceError> {
+    let limits = source.limits();
+    let line_count = u64::from(remaining.end_line)
+        .saturating_sub(u64::from(remaining.start_line))
+        .saturating_add(1);
+    if line_count <= u64::from(limits.max_lines) {
+        match source.read(remaining) {
+            Ok(_) => return Ok(remaining.clone()),
+            Err(SourceError::SpanLimit(_)) => {}
+            Err(error) => return Err(error),
+        }
+    }
+
+    let mut low = remaining.start_line;
+    let mut high = remaining
+        .start_line
+        .saturating_add(limits.max_lines.saturating_sub(1))
+        .min(remaining.end_line);
+    let mut best = None;
+    while low <= high {
+        let middle = low + (high - low) / 2;
+        let page = SourceSpan {
+            end_line: middle,
+            ..remaining.clone()
+        };
+        match source.read(&page) {
+            Ok(_) => {
+                best = Some(page);
+                if middle == u32::MAX {
+                    break;
+                }
+                low = middle + 1;
+            }
+            Err(SourceError::SpanLimit(_)) => {
+                if middle == remaining.start_line {
+                    break;
+                }
+                high = middle - 1;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    best.ok_or(SourceError::SpanLimit(limits.max_span_bytes))
+}
+
+fn flush_component(
+    request: &ProjectionRequest,
+    records: &mut [ProjectedRecord],
+    omissions: &mut Vec<ProjectionOmission>,
+    spans: &mut Vec<ProjectedSpan>,
+    mut component: Vec<Candidate>,
+    source: &SourceReader,
+) {
+    component.sort_by(|a, b| {
+        a.selection_rank
+            .cmp(&b.selection_rank)
+            .then_with(|| a.record_id.cmp(&b.record_id))
+            .then_with(|| a.selection.role.cmp(&b.selection.role))
+            .then_with(|| a.selection.lane.cmp(&b.selection.lane))
+            .then_with(|| a.selection.channel.cmp(&b.selection.channel))
+            .then_with(|| a.selection.reason.cmp(&b.selection.reason))
+            .then_with(|| a.language.cmp(&b.language))
+            .then_with(|| a.slice.span.cmp(&b.slice.span))
+            .then_with(|| a.slice.text.cmp(&b.slice.text))
+            .then_with(|| a.representation.cmp(&b.representation))
+    });
+    let first = &component[0].slice.span;
+    let start = component
+        .iter()
+        .map(|c| c.slice.span.start_line)
+        .min()
+        .unwrap();
+    let end = component
+        .iter()
+        .map(|c| c.slice.span.end_line)
+        .max()
+        .unwrap();
+    let source_span = SourceSpan {
+        root: first.root.clone(),
+        path: first.path.clone(),
+        start_line: start,
+        end_line: end,
+    };
+    let mut lines = BTreeMap::<u32, String>::new();
+    for candidate in &component {
+        for (offset, line) in exact_lines(&candidate.slice.text).into_iter().enumerate() {
+            let number = candidate.slice.span.start_line + offset as u32;
+            match lines.entry(number) {
+                Entry::Vacant(entry) => {
+                    entry.insert(line.to_string());
+                }
+                Entry::Occupied(entry) if entry.get() == line => {}
+                Entry::Occupied(_) => {
+                    for candidate in &component {
+                        omissions.push(ProjectionOmission {
+                            record_id: Some(candidate.record_id.clone()),
+                            source: Some(candidate.slice.span.clone()),
+                            code: OmissionCode::SourceUnavailable,
+                            detail: "overlapping source reads disagreed".into(),
+                        });
+                    }
+                    return;
+                }
+            }
+        }
+    }
+    let mut text = String::new();
+    for number in start..=end {
+        let Some(line) = lines.get(&number) else {
+            return;
+        };
+        text.push_str(line);
+    }
+    let mut representation = if component
+        .iter()
+        .any(|c| c.representation == BodyRepresentation::FocusedSpan)
+    {
+        BodyRepresentation::FocusedSpan
+    } else {
+        BodyRepresentation::Complete
+    };
+    if request.body_policy == BodyPolicy::Minified {
+        match crate::code::minify::minify_body(&text, &component[0].language) {
+            Ok(minified) => {
+                text = minified.body;
+                representation = BodyRepresentation::Minified;
+            }
+            Err(error) => {
+                for candidate in &component {
+                    omissions.push(ProjectionOmission {
+                        record_id: Some(candidate.record_id.clone()),
+                        source: Some(candidate.slice.span.clone()),
+                        code: OmissionCode::MinificationFailed,
+                        detail: error.to_string(),
+                    });
+                }
+                return;
+            }
+        }
+    }
+    let mappings: Vec<_> = component
+        .iter()
+        .map(|candidate| SpanMapping {
+            record_id: candidate.record_id.clone(),
+            selection_rank: candidate.selection_rank,
+            selection: candidate.selection.clone(),
+            requested: candidate.slice.span.clone(),
+            coverage: if representation == BodyRepresentation::Truncated {
+                SpanCoverage::Partial
+            } else {
+                SpanCoverage::Complete
+            },
+        })
+        .collect();
+    let hydration_span = bounded_hydration_span(source, &source_span).unwrap_or_else(|_| {
+        // Every component member was read successfully above, so its first
+        // slice is a verified, consumable fallback even if the coalesced
+        // union exceeds the reader's line or byte ceiling.
+        component[0].slice.span.clone()
+    });
+    let span_id = source_span.stable_id();
+    for mapping in &mappings {
+        for record in records.iter_mut().filter(|r| {
+            r.selection_rank == mapping.selection_rank && r.identity.node_id == mapping.record_id
+        }) {
+            record.body = representation;
+            record.span_ids.push(span_id.clone());
+        }
+    }
+    spans.push(ProjectedSpan {
+        hydration: HydrationHandle::source(
+            format!("span:{}", source_span.stable_id()),
+            hydration_span,
+        ),
+        source: source_span,
+        text,
+        representation,
+        mappings,
+    });
+}
+
+fn exact_lines(text: &str) -> Vec<&str> {
+    if text.is_empty() {
+        vec![""]
+    } else {
+        text.split_inclusive('\n').collect()
+    }
+}
+
+fn span_order(a: &ProjectedSpan, b: &ProjectedSpan) -> std::cmp::Ordering {
+    let rank = |span: &ProjectedSpan| {
+        span.mappings
+            .iter()
+            .map(|m| m.selection_rank)
+            .min()
+            .unwrap_or(usize::MAX)
+    };
+    rank(a).cmp(&rank(b)).then_with(|| a.source.cmp(&b.source))
+}
+
+fn enforce_total_body_cap(
+    request: &ProjectionRequest,
+    records: &mut [ProjectedRecord],
+    omissions: &mut Vec<ProjectionOmission>,
+    spans: &mut Vec<ProjectedSpan>,
+) {
+    let Some(cap) = request.budget.total_body_bytes else {
+        return;
+    };
+    let mut used = 0_usize;
+    let mut admitted = Vec::new();
+    for mut span in std::mem::take(spans) {
+        let remaining = cap.saturating_sub(used);
+        if span.text.len() <= remaining {
+            used += span.text.len();
+            admitted.push(span);
+            continue;
+        }
+        if remaining > 0 {
+            span.text = utf8_prefix(&span.text, remaining).to_string();
+            used += span.text.len();
+            span.representation = BodyRepresentation::Truncated;
+            for mapping in &mut span.mappings {
+                mapping.coverage = SpanCoverage::Partial;
+            }
+            update_records(records, &span, BodyRepresentation::Truncated, false);
+            for mapping in &span.mappings {
+                omissions.push(ProjectionOmission {
+                    record_id: Some(mapping.record_id.clone()),
+                    source: Some(mapping.requested.clone()),
+                    code: OmissionCode::TotalBodyCap,
+                    detail: format!("body truncated at the total {cap}-byte cap"),
+                });
+            }
+            admitted.push(span);
+        } else {
+            update_records(records, &span, BodyRepresentation::SignatureOnly, true);
+            for mapping in span.mappings {
+                omissions.push(ProjectionOmission {
+                    record_id: Some(mapping.record_id),
+                    source: Some(mapping.requested),
+                    code: OmissionCode::TotalBodyCap,
+                    detail: format!("body omitted by the total {cap}-byte cap"),
+                });
+            }
+        }
+    }
+    *spans = admitted;
+}
+
+fn update_records(
+    records: &mut [ProjectedRecord],
+    span: &ProjectedSpan,
+    body: BodyRepresentation,
+    remove_span: bool,
+) {
+    let span_id = span.source.stable_id();
+    for mapping in &span.mappings {
+        for record in records.iter_mut().filter(|r| {
+            r.selection_rank == mapping.selection_rank && r.identity.node_id == mapping.record_id
+        }) {
+            record.body = body;
+            if remove_span {
+                record.span_ids.retain(|id| id != &span_id);
+            }
+        }
+    }
+}
+
+pub(crate) fn utf8_prefix(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
+}
+
+fn omit(
+    omissions: &mut Vec<ProjectionOmission>,
+    selected: &SelectedRecord,
+    source: Option<SourceSpan>,
+    code: OmissionCode,
+    detail: &str,
+) {
+    omissions.push(ProjectionOmission {
+        record_id: Some(selected.identity.node_id.clone()),
+        source,
+        code,
+        detail: detail.to_string(),
+    });
+}
+
+fn omission_order(a: &ProjectionOmission, b: &ProjectionOmission) -> std::cmp::Ordering {
+    a.record_id
+        .cmp(&b.record_id)
+        .then_with(|| a.source.cmp(&b.source))
+        .then_with(|| a.code.cmp(&b.code))
+        .then_with(|| a.detail.cmp(&b.detail))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn record(rank: usize, id: &str, start: u32, end: u32, role: ContextRole) -> SelectedRecord {
+        record_at(rank, id, "repo", "src/lib.rs", start, end, role)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn record_at(
+        rank: usize,
+        id: &str,
+        root: &str,
+        path: &str,
+        start: u32,
+        end: u32,
+        role: ContextRole,
+    ) -> SelectedRecord {
+        let source = SourceSpan {
+            root: root.into(),
+            path: path.into(),
+            start_line: start,
+            end_line: end,
+        };
+        SelectedRecord {
+            selection_rank: rank,
+            identity: RecordIdentity {
+                node_id: id.into(),
+                source: Some(source),
+            },
+            symbol: SymbolSummary {
+                name: id.into(),
+                kind: "function".into(),
+                language: "text".into(),
+                signature: format!("fn {id}()"),
+            },
+            selection: SelectionSummary {
+                channel: SelectionChannel::Exact,
+                reason: "matched".into(),
+                role: Some(role),
+                lane: Some(RetrievalLane::ExactReference),
+            },
+            evidence: SelectionEvidence::default(),
+            evidence_hydration: Some(HydrationHandle::evidence(id)),
+            focused_span: None,
+        }
+    }
+
+    #[test]
+    fn coalesces_overlap_and_preserves_every_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/lib.rs"), "a\nb\nc\nd\n").unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+        let mut input = ProjectionInput::default();
+        input.records = vec![
+            record(1, "child", 2, 3, ContextRole::EditableSource),
+            record(0, "parent", 1, 3, ContextRole::DefinitionOrApiState),
+        ];
+        let request = ProjectionRequest {
+            body_policy: BodyPolicy::Complete,
+            ..Default::default()
+        };
+        let first = plan_projection(request.clone(), input.clone(), &reader);
+        input.records.reverse();
+        let second = plan_projection(request, input, &reader);
+        assert_eq!(first, second);
+        assert_eq!(first.spans.len(), 1);
+        assert_eq!(first.spans[0].text, "a\nb\nc\n");
+        assert_eq!(first.spans[0].mappings.len(), 2);
+    }
+
+    #[test]
+    fn candidate_audit_is_byte_ordered_independently_of_input_iteration() {
+        let dir = tempfile::tempdir().unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+        let audit = |rank: usize, id: &str, reason: &str| CandidateAudit {
+            candidate_rank: rank,
+            identity: RecordIdentity {
+                node_id: id.into(),
+                source: None,
+            },
+            disposition: CandidateDisposition::Omitted,
+            reason: reason.into(),
+            evidence: SelectionEvidence::default(),
+        };
+        let mut input = ProjectionInput {
+            candidate_audit: vec![audit(2, "z", "later"), audit(1, "b", "same")],
+            ..Default::default()
+        };
+        let request = ProjectionRequest::default();
+        let first = plan_projection(request.clone(), input.clone(), &reader);
+        input.candidate_audit.reverse();
+        let second = plan_projection(request, input, &reader);
+
+        assert_eq!(first, second);
+        assert_eq!(first.candidate_audit[0].candidate_rank, 1);
+        assert_eq!(first.candidate_audit[0].identity.node_id, "b");
+        assert_eq!(first.candidate_audit[1].identity.node_id, "z");
+    }
+
+    #[test]
+    fn total_cap_truncates_on_a_utf8_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/lib.rs"), "αβγ\n").unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+        let input = ProjectionInput {
+            records: vec![record(
+                0,
+                "unicode",
+                1,
+                1,
+                ContextRole::DefinitionOrApiState,
+            )],
+            ..Default::default()
+        };
+        let request = ProjectionRequest {
+            body_policy: BodyPolicy::Complete,
+            budget: ProjectionBudget {
+                total_body_bytes: Some(3),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let plan = plan_projection(request, input, &reader);
+        assert_eq!(plan.spans[0].text, "α");
+        assert_eq!(plan.spans[0].representation, BodyRepresentation::Truncated);
+    }
+
+    #[test]
+    fn partially_overlapping_and_identical_role_spans_emit_source_once() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/lib.rs"), "one\ntwo\nthree\nfour\n").unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+        let input = ProjectionInput {
+            records: vec![
+                record(2, "same-test", 2, 3, ContextRole::Test),
+                record(0, "left", 1, 3, ContextRole::EditableSource),
+                record(1, "right", 2, 4, ContextRole::DefinitionOrApiState),
+                record(3, "same-impact", 2, 3, ContextRole::CallerOrImpact),
+            ],
+            ..Default::default()
+        };
+
+        let plan = plan_projection(
+            ProjectionRequest {
+                body_policy: BodyPolicy::Complete,
+                ..Default::default()
+            },
+            input,
+            &reader,
+        );
+
+        assert_eq!(plan.spans.len(), 1);
+        assert_eq!(plan.spans[0].text, "one\ntwo\nthree\nfour\n");
+        assert_eq!(plan.spans[0].mappings.len(), 4);
+        assert_eq!(plan.spans[0].text.matches("two\n").count(), 1);
+    }
+
+    #[test]
+    fn one_identity_with_multiple_roles_updates_every_projected_record() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/lib.rs"), "body\n").unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+        let plan = plan_projection(
+            ProjectionRequest {
+                body_policy: BodyPolicy::Complete,
+                ..Default::default()
+            },
+            ProjectionInput {
+                records: vec![
+                    record(0, "shared", 1, 1, ContextRole::EditableSource),
+                    record(0, "shared", 1, 1, ContextRole::Test),
+                ],
+                ..Default::default()
+            },
+            &reader,
+        );
+
+        assert_eq!(plan.records.len(), 2);
+        assert!(
+            plan.records
+                .iter()
+                .all(|record| record.body == BodyRepresentation::Complete)
+        );
+        assert_eq!(plan.spans.len(), 1);
+        assert_eq!(plan.spans[0].mappings.len(), 2);
+    }
+
+    #[test]
+    fn multi_root_plan_is_stable_and_root_qualified() {
+        let left = tempfile::tempdir().unwrap();
+        let right = tempfile::tempdir().unwrap();
+        fs::write(left.path().join("same.rs"), "left\n").unwrap();
+        fs::write(right.path().join("same.rs"), "right\n").unwrap();
+        let reader = SourceReader::new(
+            [
+                ("z-root".to_string(), right.path().to_path_buf()),
+                ("a-root".to_string(), left.path().to_path_buf()),
+            ],
+            Default::default(),
+        )
+        .unwrap();
+        let mut input = ProjectionInput {
+            records: vec![
+                record_at(
+                    0,
+                    "z",
+                    "z-root",
+                    "same.rs",
+                    1,
+                    1,
+                    ContextRole::EditableSource,
+                ),
+                record_at(
+                    0,
+                    "a",
+                    "a-root",
+                    "same.rs",
+                    1,
+                    1,
+                    ContextRole::EditableSource,
+                ),
+            ],
+            ..Default::default()
+        };
+        let request = ProjectionRequest {
+            body_policy: BodyPolicy::Complete,
+            ..Default::default()
+        };
+        let first = plan_projection(request.clone(), input.clone(), &reader);
+        input.records.reverse();
+        let second = plan_projection(request, input, &reader);
+
+        assert_eq!(first, second);
+        assert_eq!(first.spans.len(), 2);
+        assert_eq!(first.spans[0].source.root, "a-root");
+        assert_eq!(first.spans[1].source.root, "z-root");
+    }
+
+    #[test]
+    fn oversized_body_degrades_explicitly_and_keeps_hydration() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/lib.rs"), "0123456789\n").unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+        let plan = plan_projection(
+            ProjectionRequest {
+                body_policy: BodyPolicy::Complete,
+                budget: ProjectionBudget {
+                    per_record_body_bytes: Some(4),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ProjectionInput {
+                records: vec![record(0, "large", 1, 1, ContextRole::EditableSource)],
+                ..Default::default()
+            },
+            &reader,
+        );
+
+        assert!(plan.spans.is_empty());
+        assert_eq!(plan.records[0].body, BodyRepresentation::SignatureOnly);
+        assert!(plan.records[0].source_handle.is_some());
+        assert!(
+            plan.omissions
+                .iter()
+                .any(|item| item.code == OmissionCode::PerRecordBodyCap)
+        );
+    }
+
+    #[test]
+    fn large_record_hydration_pages_roundtrip_authoritative_span_once_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        let text = (1..=300)
+            .map(|line| format!("line {line}\n"))
+            .collect::<String>();
+        fs::write(dir.path().join("src/lib.rs"), &text).unwrap();
+        let reader = SourceReader::new(
+            [("repo".to_string(), dir.path().to_path_buf())],
+            super::super::source::SourceReadLimits {
+                max_lines: 200,
+                max_span_bytes: 512,
+                max_scanned_bytes: 16 * 1024 * 1024,
+            },
+        )
+        .unwrap();
+        let authoritative = record(0, "large", 1, 300, ContextRole::EditableSource);
+
+        let initial = plan_projection(
+            ProjectionRequest::default(),
+            ProjectionInput {
+                records: vec![authoritative.clone()],
+                ..Default::default()
+            },
+            &reader,
+        );
+        let mut next = initial.records[0].source_handle.clone();
+        let mut pages = Vec::new();
+        let mut hydrated = String::new();
+        while let Some(handle) = next.take() {
+            let handle = HydrationHandle::decode(&handle.encode()).unwrap();
+            let page = handle
+                .source
+                .clone()
+                .expect("source hydration handles contain a page");
+            pages.push((page.start_line, page.end_line));
+
+            let mut selected = authoritative.clone();
+            selected.focused_span = Some(page.clone());
+            let response = plan_projection(
+                ProjectionRequest {
+                    intent: SearchIntent::Hydrate,
+                    body_policy: BodyPolicy::FocusedSpan,
+                    ..Default::default()
+                },
+                ProjectionInput {
+                    records: vec![selected],
+                    ..Default::default()
+                },
+                &reader,
+            );
+            assert_eq!(response.spans.len(), 1);
+            assert_eq!(response.spans[0].source, page);
+            assert!(response.spans[0].text.len() <= 512);
+            hydrated.push_str(&response.spans[0].text);
+            next = response.records[0].source_handle.clone();
+        }
+
+        assert!(pages.len() > 2, "the byte cap must force multiple pages");
+        assert_eq!(pages.first().map(|page| page.0), Some(1));
+        assert_eq!(pages.last().map(|page| page.1), Some(300));
+        for pair in pages.windows(2) {
+            assert_eq!(pair[0].1 + 1, pair[1].0);
+        }
+        assert!(
+            pages
+                .iter()
+                .all(|(start, end)| end.saturating_sub(*start) < 200)
+        );
+        assert_eq!(hydrated, text);
+    }
+
+    #[test]
+    fn coalesced_hydration_binds_each_page_to_the_authoritative_union() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        let text = (1..=300)
+            .map(|line| format!("line {line}\n"))
+            .collect::<String>();
+        fs::write(dir.path().join("src/lib.rs"), text).unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+
+        let coalesced = plan_projection(
+            ProjectionRequest {
+                body_policy: BodyPolicy::Complete,
+                ..Default::default()
+            },
+            ProjectionInput {
+                records: vec![
+                    record(0, "first", 1, 200, ContextRole::EditableSource),
+                    record(1, "second", 101, 300, ContextRole::DirectDependency),
+                ],
+                ..Default::default()
+            },
+            &reader,
+        );
+        assert_eq!(coalesced.spans.len(), 1);
+        assert_eq!(coalesced.spans[0].source.end_line, 300);
+        let coalesced_page = coalesced.spans[0]
+            .hydration
+            .source
+            .as_ref()
+            .expect("coalesced spans retain a bounded hydration page");
+        assert_eq!(
+            (coalesced_page.start_line, coalesced_page.end_line),
+            (1, 200)
+        );
+        assert!(reader.read(coalesced_page).is_ok());
+        assert_eq!(
+            coalesced.spans[0].hydration.record_id,
+            format!("span:{}", coalesced.spans[0].source.stable_id())
+        );
+    }
+
+    #[test]
+    fn coalesced_union_does_not_reapply_each_members_body_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/lib.rs"), "aaaa\nbbbb\ncccc\n").unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+
+        let plan = plan_projection(
+            ProjectionRequest {
+                body_policy: BodyPolicy::Complete,
+                budget: ProjectionBudget {
+                    per_record_body_bytes: Some(10),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ProjectionInput {
+                records: vec![
+                    record(0, "left", 1, 2, ContextRole::EditableSource),
+                    record(1, "right", 2, 3, ContextRole::DirectDependency),
+                ],
+                ..Default::default()
+            },
+            &reader,
+        );
+
+        assert_eq!(plan.spans.len(), 1);
+        assert_eq!(plan.spans[0].text, "aaaa\nbbbb\ncccc\n");
+        assert_eq!(plan.spans[0].representation, BodyRepresentation::Complete);
+        assert!(
+            plan.spans[0]
+                .mappings
+                .iter()
+                .all(|mapping| mapping.coverage == SpanCoverage::Complete)
+        );
+        assert!(
+            plan.omissions
+                .iter()
+                .all(|omission| omission.code != OmissionCode::PerRecordBodyCap)
+        );
+    }
+
+    #[test]
+    fn oversized_complete_body_uses_and_records_the_focused_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(
+            dir.path().join("src/lib.rs"),
+            "large prefix\nrequired line\nlarge suffix\n",
+        )
+        .unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+        let mut selected = record(0, "large", 1, 3, ContextRole::EditableSource);
+        selected.focused_span = Some(SourceSpan {
+            root: "repo".into(),
+            path: "src/lib.rs".into(),
+            start_line: 2,
+            end_line: 2,
+        });
+        let plan = plan_projection(
+            ProjectionRequest {
+                body_policy: BodyPolicy::Complete,
+                budget: ProjectionBudget {
+                    per_record_body_bytes: Some(20),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ProjectionInput {
+                records: vec![selected],
+                ..Default::default()
+            },
+            &reader,
+        );
+
+        assert_eq!(plan.spans[0].text, "required line\n");
+        assert_eq!(
+            plan.spans[0].representation,
+            BodyRepresentation::FocusedSpan
+        );
+        assert_eq!(plan.records[0].body, BodyRepresentation::FocusedSpan);
+        assert!(plan.omissions.iter().any(|item| {
+            item.code == OmissionCode::PerRecordBodyCap && item.detail.contains("focused span")
+        }));
+    }
+
+    #[test]
+    fn signature_and_no_body_policies_are_explicit_and_hydratable() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/lib.rs"), "body\n").unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+        let input = ProjectionInput {
+            records: vec![record(0, "bounded", 1, 1, ContextRole::EditableSource)],
+            ..Default::default()
+        };
+
+        let signature = plan_projection(
+            ProjectionRequest {
+                body_policy: BodyPolicy::SignatureOnly,
+                ..Default::default()
+            },
+            input.clone(),
+            &reader,
+        );
+        let none = plan_projection(
+            ProjectionRequest {
+                body_policy: BodyPolicy::NoBody,
+                ..Default::default()
+            },
+            input,
+            &reader,
+        );
+
+        assert!(signature.spans.is_empty());
+        assert_eq!(signature.records[0].body, BodyRepresentation::SignatureOnly);
+        assert!(signature.records[0].source_handle.is_some());
+        assert!(none.spans.is_empty());
+        assert_eq!(none.records[0].body, BodyRepresentation::SignatureOnly);
+        assert!(none.records[0].source_handle.is_some());
+        assert!(
+            none.omissions
+                .iter()
+                .any(|item| item.code == OmissionCode::NoBodyPolicy)
+        );
+    }
+}

--- a/src/service/search/render.rs
+++ b/src/service/search/render.rs
@@ -98,7 +98,9 @@ fn shrink_last_record_evidence(plan: &mut ProjectionPlan) -> bool {
         .records
         .iter_mut()
         .rev()
-        .find(|record| record.evidence != SelectionEvidence::default())
+        .find(|record| {
+            record.evidence != SelectionEvidence::default() && record.evidence_handle.is_some()
+        })
     else {
         return false;
     };

--- a/src/service/search/render.rs
+++ b/src/service/search/render.rs
@@ -38,6 +38,7 @@ pub(crate) fn render_projection(plan: &ProjectionPlan) -> Result<RenderedRespons
         .len()
         .saturating_mul(2)
         .saturating_add(plan.candidate_audit.len())
+        .saturating_add(plan.records.len())
         .saturating_add(1);
     for _ in 0..attempts {
         let (text, accounting) = render_once(&plan)?;
@@ -50,6 +51,7 @@ pub(crate) fn render_projection(plan: &ProjectionPlan) -> Result<RenderedRespons
         }
         if !shrink_last_body(&mut plan, &accounting.total)
             && !shrink_last_candidate_audit(&mut plan)
+            && !shrink_last_record_evidence(&mut plan)
         {
             return Err(RenderError::BudgetTooSmall {
                 minimum: accounting.total,
@@ -60,10 +62,10 @@ pub(crate) fn render_projection(plan: &ProjectionPlan) -> Result<RenderedRespons
 }
 
 fn shrink_last_candidate_audit(plan: &mut ProjectionPlan) -> bool {
-    if plan.request.projection != SearchProjection::Evidence || plan.candidate_audit.pop().is_none()
-    {
+    if plan.request.projection != SearchProjection::Evidence || plan.candidate_audit.len() <= 1 {
         return false;
     }
+    plan.candidate_audit.pop();
     let detail = "candidate audit truncated to satisfy the final rendered budget; retry with a larger budget for the complete audit";
     if !plan.omissions.iter().any(|omission| {
         omission.record_id.is_none()
@@ -73,6 +75,43 @@ fn shrink_last_candidate_audit(plan: &mut ProjectionPlan) -> bool {
     }) {
         plan.omissions.push(ProjectionOmission {
             record_id: None,
+            source: None,
+            code: OmissionCode::RenderBudget,
+            detail: detail.to_string(),
+        });
+        plan.omissions.sort_by(|a, b| {
+            a.record_id
+                .cmp(&b.record_id)
+                .then_with(|| a.source.cmp(&b.source))
+                .then_with(|| a.code.cmp(&b.code))
+                .then_with(|| a.detail.cmp(&b.detail))
+        });
+    }
+    true
+}
+
+fn shrink_last_record_evidence(plan: &mut ProjectionPlan) -> bool {
+    if plan.request.projection != SearchProjection::Evidence {
+        return false;
+    }
+    let Some(record) = plan
+        .records
+        .iter_mut()
+        .rev()
+        .find(|record| record.evidence != SelectionEvidence::default())
+    else {
+        return false;
+    };
+    let record_id = record.identity.node_id.clone();
+    record.evidence = SelectionEvidence::default();
+    let detail = "selected record audit detail omitted to satisfy the final rendered budget; hydrate evidence for the complete audit";
+    if !plan.omissions.iter().any(|omission| {
+        omission.record_id.as_deref() == Some(record_id.as_str())
+            && omission.code == OmissionCode::RenderBudget
+            && omission.detail == detail
+    }) {
+        plan.omissions.push(ProjectionOmission {
+            record_id: Some(record_id),
             source: None,
             code: OmissionCode::RenderBudget,
             detail: detail.to_string(),
@@ -843,6 +882,44 @@ mod tests {
         assert!(rendered.text.contains("candidate audit truncated"));
         assert!(!rendered.plan.candidate_audit.is_empty());
         assert!(rendered.plan.candidate_audit.len() < 100);
+        assert_eq!(rendered, render_projection(&input).unwrap());
+    }
+
+    #[test]
+    fn evidence_budget_preserves_selected_identities_while_omitting_duplicate_audit_detail() {
+        let mut input = plan(SearchProjection::Evidence);
+        input.request.budget.max_rendered_bytes = Some(6_000);
+        input.spans.clear();
+        input.records = (0..8)
+            .map(|rank| {
+                let mut record = input.records[0].clone();
+                record.selection_rank = rank;
+                record.identity.node_id = format!("selected-{rank}");
+                record.evidence.diagnostics.insert(
+                    "complete_audit".into(),
+                    format!("record-{rank}-").repeat(120),
+                );
+                record
+            })
+            .collect();
+
+        let rendered = render_projection(&input).unwrap();
+
+        assert!(rendered.text.len() <= 6_000);
+        assert_eq!(rendered.plan.records.len(), 8);
+        assert_eq!(rendered.plan.candidate_audit.len(), 1);
+        assert!(
+            rendered
+                .plan
+                .records
+                .iter()
+                .any(|record| record.evidence == SelectionEvidence::default())
+        );
+        assert!(
+            rendered
+                .text
+                .contains("selected record audit detail omitted")
+        );
         assert_eq!(rendered, render_projection(&input).unwrap());
     }
 

--- a/src/service/search/render.rs
+++ b/src/service/search/render.rs
@@ -33,7 +33,12 @@ impl std::error::Error for RenderError {}
 
 pub(crate) fn render_projection(plan: &ProjectionPlan) -> Result<RenderedResponse, RenderError> {
     let mut plan = plan.clone();
-    let attempts = plan.spans.len().saturating_mul(2).saturating_add(64);
+    let attempts = plan
+        .spans
+        .len()
+        .saturating_mul(2)
+        .saturating_add(plan.candidate_audit.len())
+        .saturating_add(1);
     for _ in 0..attempts {
         let (text, accounting) = render_once(&plan)?;
         if within_budget(&accounting.total, &plan.request.budget) {
@@ -810,7 +815,7 @@ mod tests {
     fn evidence_budget_deterministically_trims_candidate_audit_after_bodies() {
         let mut input = plan(SearchProjection::Evidence);
         input.request.budget.max_rendered_bytes = Some(4_096);
-        input.candidate_audit = (1..=20)
+        input.candidate_audit = (1..=200)
             .map(|rank| CandidateAudit {
                 candidate_rank: rank,
                 identity: RecordIdentity {
@@ -837,7 +842,7 @@ mod tests {
         assert!(rendered.text.contains("## Candidate audit"));
         assert!(rendered.text.contains("candidate audit truncated"));
         assert!(!rendered.plan.candidate_audit.is_empty());
-        assert!(rendered.plan.candidate_audit.len() < 20);
+        assert!(rendered.plan.candidate_audit.len() < 100);
         assert_eq!(rendered, render_projection(&input).unwrap());
     }
 

--- a/src/service/search/render.rs
+++ b/src/service/search/render.rs
@@ -43,13 +43,44 @@ pub(crate) fn render_projection(plan: &ProjectionPlan) -> Result<RenderedRespons
                 plan,
             });
         }
-        if !shrink_last_body(&mut plan, &accounting.total) {
+        if !shrink_last_body(&mut plan, &accounting.total)
+            && !shrink_last_candidate_audit(&mut plan)
+        {
             return Err(RenderError::BudgetTooSmall {
                 minimum: accounting.total,
             });
         }
     }
     Err(RenderError::AccountingDidNotConverge)
+}
+
+fn shrink_last_candidate_audit(plan: &mut ProjectionPlan) -> bool {
+    if plan.request.projection != SearchProjection::Evidence || plan.candidate_audit.pop().is_none()
+    {
+        return false;
+    }
+    let detail = "candidate audit truncated to satisfy the final rendered budget; retry with a larger budget for the complete audit";
+    if !plan.omissions.iter().any(|omission| {
+        omission.record_id.is_none()
+            && omission.source.is_none()
+            && omission.code == OmissionCode::RenderBudget
+            && omission.detail == detail
+    }) {
+        plan.omissions.push(ProjectionOmission {
+            record_id: None,
+            source: None,
+            code: OmissionCode::RenderBudget,
+            detail: detail.to_string(),
+        });
+        plan.omissions.sort_by(|a, b| {
+            a.record_id
+                .cmp(&b.record_id)
+                .then_with(|| a.source.cmp(&b.source))
+                .then_with(|| a.code.cmp(&b.code))
+                .then_with(|| a.detail.cmp(&b.detail))
+        });
+    }
+    true
 }
 
 fn within_budget(cost: &RenderCost, budget: &ProjectionBudget) -> bool {
@@ -273,6 +304,19 @@ fn render_metadata(plan: &ProjectionPlan) -> String {
         }
         if let Some(lane) = record.selection.lane {
             output.push_str(&format!("   - lane: {lane}\n"));
+        }
+        if let Some(source) = &record.symbol.extraction_source {
+            output.push_str(&format!(
+                "   - extraction_source: src:{}\n",
+                one_line(source)
+            ));
+        }
+        for (name, value) in &record.symbol.declared_metadata {
+            output.push_str(&format!(
+                "   - metadata.{}: {}\n",
+                one_line(name),
+                one_line(value)
+            ));
         }
         if let Some(handle) = &record.source_handle {
             output.push_str(&format!(
@@ -505,6 +549,8 @@ mod tests {
                     kind: "function".into(),
                     language: "rust".into(),
                     signature: "fn β()".into(),
+                    extraction_source: None,
+                    declared_metadata: BTreeMap::new(),
                 },
                 selection: selection.clone(),
                 evidence,
@@ -583,6 +629,8 @@ mod tests {
                     kind: "function".into(),
                     language: "rust".into(),
                     signature: "fn β()".into(),
+                    extraction_source: None,
+                    declared_metadata: BTreeMap::new(),
                 },
                 selection: SelectionSummary {
                     channel: SelectionChannel::Exact,
@@ -756,6 +804,41 @@ mod tests {
             render_projection(&input),
             Err(RenderError::BudgetTooSmall { .. })
         ));
+    }
+
+    #[test]
+    fn evidence_budget_deterministically_trims_candidate_audit_after_bodies() {
+        let mut input = plan(SearchProjection::Evidence);
+        input.request.budget.max_rendered_bytes = Some(4_096);
+        input.candidate_audit = (1..=20)
+            .map(|rank| CandidateAudit {
+                candidate_rank: rank,
+                identity: RecordIdentity {
+                    node_id: format!("candidate-{rank:02}"),
+                    source: None,
+                },
+                disposition: CandidateDisposition::Omitted,
+                reason: "bounded candidate was not selected; deterministic audit detail ".repeat(3),
+                evidence: SelectionEvidence {
+                    candidate_rank: Some(rank),
+                    content_hash: Some(format!("hash-{rank:02}")),
+                    diagnostics: BTreeMap::from([(
+                        "tie_break".into(),
+                        "stable identity after calibrated channel ranks".into(),
+                    )]),
+                    ..Default::default()
+                },
+            })
+            .collect();
+
+        let rendered = render_projection(&input).unwrap();
+
+        assert!(rendered.text.len() <= 4_096);
+        assert!(rendered.text.contains("## Candidate audit"));
+        assert!(rendered.text.contains("candidate audit truncated"));
+        assert!(!rendered.plan.candidate_audit.is_empty());
+        assert!(rendered.plan.candidate_audit.len() < 20);
+        assert_eq!(rendered, render_projection(&input).unwrap());
     }
 
     #[test]

--- a/src/service/search/render.rs
+++ b/src/service/search/render.rs
@@ -1,0 +1,771 @@
+//! Canonical agent/evidence rendering with self-inclusive cost accounting.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use super::model::*;
+use super::projection::utf8_prefix;
+
+const ESTIMATE_NAME: &str = "unicode_chars_div_4_ceiling";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RenderError {
+    BudgetTooSmall { minimum: RenderCost },
+    AccountingDidNotConverge,
+}
+
+impl fmt::Display for RenderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BudgetTooSmall { minimum } => write!(
+                f,
+                "render budget is smaller than the non-body response ({} bytes, {} estimated tokens)",
+                minimum.utf8_bytes, minimum.estimated_tokens
+            ),
+            Self::AccountingDidNotConverge => {
+                f.write_str("self-inclusive render accounting did not converge")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RenderError {}
+
+pub(crate) fn render_projection(plan: &ProjectionPlan) -> Result<RenderedResponse, RenderError> {
+    let mut plan = plan.clone();
+    let attempts = plan.spans.len().saturating_mul(2).saturating_add(64);
+    for _ in 0..attempts {
+        let (text, accounting) = render_once(&plan)?;
+        if within_budget(&accounting.total, &plan.request.budget) {
+            return Ok(RenderedResponse {
+                text,
+                accounting,
+                plan,
+            });
+        }
+        if !shrink_last_body(&mut plan, &accounting.total) {
+            return Err(RenderError::BudgetTooSmall {
+                minimum: accounting.total,
+            });
+        }
+    }
+    Err(RenderError::AccountingDidNotConverge)
+}
+
+fn within_budget(cost: &RenderCost, budget: &ProjectionBudget) -> bool {
+    budget
+        .max_rendered_bytes
+        .is_none_or(|limit| cost.utf8_bytes <= limit)
+        && budget
+            .max_estimated_tokens
+            .is_none_or(|limit| cost.estimated_tokens <= limit)
+}
+
+fn shrink_last_body(plan: &mut ProjectionPlan, cost: &RenderCost) -> bool {
+    let Some(index) = plan.spans.iter().rposition(|span| !span.text.is_empty()) else {
+        return false;
+    };
+    let span = &plan.spans[index];
+    let byte_reduction = plan
+        .request
+        .budget
+        .max_rendered_bytes
+        .map_or(0, |limit| cost.utf8_bytes.saturating_sub(limit));
+    let allowed_chars = plan
+        .request
+        .budget
+        .max_estimated_tokens
+        .map(|limit| limit.saturating_mul(4));
+    let char_reduction = allowed_chars.map_or(0, |limit| cost.unicode_chars.saturating_sub(limit));
+    let target_bytes = span.text.len().saturating_sub(byte_reduction.max(1));
+    let target_chars = span.text.chars().count().saturating_sub(char_reduction);
+    let by_bytes = utf8_prefix(&span.text, target_bytes);
+    let prefix: String = by_bytes.chars().take(target_chars).collect();
+
+    if prefix.is_empty() {
+        let removed = plan.spans.remove(index);
+        update_records(plan, &removed, BodyRepresentation::SignatureOnly, true);
+        for mapping in removed.mappings {
+            add_budget_omission(
+                plan,
+                &mapping,
+                "body omitted to satisfy the final rendered budget",
+            );
+        }
+    } else {
+        let mut affected = Vec::new();
+        {
+            let span = &mut plan.spans[index];
+            span.text = prefix;
+            span.representation = BodyRepresentation::Truncated;
+            for mapping in &mut span.mappings {
+                mapping.coverage = SpanCoverage::Partial;
+                affected.push(mapping.clone());
+            }
+        }
+        let snapshot = plan.spans[index].clone();
+        update_records(plan, &snapshot, BodyRepresentation::Truncated, false);
+        for mapping in affected {
+            add_budget_omission(
+                plan,
+                &mapping,
+                "body truncated to satisfy the final rendered budget",
+            );
+        }
+    }
+    true
+}
+
+fn update_records(
+    plan: &mut ProjectionPlan,
+    span: &ProjectedSpan,
+    body: BodyRepresentation,
+    remove_span: bool,
+) {
+    let span_id = span.source.stable_id();
+    for mapping in &span.mappings {
+        for record in plan.records.iter_mut().filter(|record| {
+            record.selection_rank == mapping.selection_rank
+                && record.identity.node_id == mapping.record_id
+        }) {
+            record.body = body;
+            if remove_span {
+                record.span_ids.retain(|id| id != &span_id);
+            }
+        }
+    }
+}
+
+fn add_budget_omission(plan: &mut ProjectionPlan, mapping: &SpanMapping, detail: &str) {
+    let omission = ProjectionOmission {
+        record_id: Some(mapping.record_id.clone()),
+        source: Some(mapping.requested.clone()),
+        code: OmissionCode::RenderBudget,
+        detail: detail.to_string(),
+    };
+    if !plan.omissions.contains(&omission) {
+        plan.omissions.push(omission);
+    }
+    plan.omissions.sort_by(|a, b| {
+        a.record_id
+            .cmp(&b.record_id)
+            .then_with(|| a.source.cmp(&b.source))
+            .then_with(|| a.code.cmp(&b.code))
+            .then_with(|| a.detail.cmp(&b.detail))
+    });
+}
+
+fn render_once(plan: &ProjectionPlan) -> Result<(String, RenderAccounting), RenderError> {
+    let fixed = [
+        (CostSection::Headers, render_headers(plan)),
+        (CostSection::Metadata, render_metadata(plan)),
+        (CostSection::Bodies, render_bodies(plan)),
+        (CostSection::Relationships, render_relationships(plan)),
+    ];
+    let mut footer = String::new();
+    for _ in 0..64 {
+        let accounting = accounting(&fixed, &footer);
+        let next = render_footer(&accounting);
+        if next == footer {
+            let mut text = String::new();
+            for (_, section) in &fixed {
+                text.push_str(section);
+            }
+            text.push_str(&footer);
+            debug_assert_eq!(text.len(), accounting.total.utf8_bytes);
+            debug_assert_eq!(text.chars().count(), accounting.total.unicode_chars);
+            return Ok((text, accounting));
+        }
+        footer = next;
+    }
+    Err(RenderError::AccountingDidNotConverge)
+}
+
+fn accounting(fixed: &[(CostSection, String)], footer: &str) -> RenderAccounting {
+    let mut sections = BTreeMap::new();
+    for (kind, text) in fixed {
+        sections.insert(*kind, measure(text));
+    }
+    sections.insert(CostSection::Footer, measure(footer));
+    let utf8_bytes = sections.values().map(|cost| cost.utf8_bytes).sum();
+    let unicode_chars = sections.values().map(|cost| cost.unicode_chars).sum();
+    RenderAccounting {
+        total: RenderCost {
+            utf8_bytes,
+            unicode_chars,
+            estimated_tokens: estimate_tokens(unicode_chars),
+        },
+        sections,
+        estimate_name: ESTIMATE_NAME.to_string(),
+        provider_usage: false,
+    }
+}
+
+fn measure(value: &str) -> RenderCost {
+    let unicode_chars = value.chars().count();
+    RenderCost {
+        utf8_bytes: value.len(),
+        unicode_chars,
+        estimated_tokens: estimate_tokens(unicode_chars),
+    }
+}
+
+fn estimate_tokens(chars: usize) -> usize {
+    chars.saturating_add(3) / 4
+}
+
+fn render_headers(plan: &ProjectionPlan) -> String {
+    format!(
+        "# RNA search context\n\n- projection: {}\n- intent: {}\n- body_policy: {}\n- selected_records: {}\n",
+        plan.request.projection,
+        plan.request.intent,
+        plan.request.body_policy,
+        plan.records.len()
+    )
+}
+
+fn render_metadata(plan: &ProjectionPlan) -> String {
+    let mut output = String::new();
+    if !plan.capabilities.is_empty() {
+        output.push_str("\n## Capability status\n");
+        for capability in &plan.capabilities {
+            output.push_str(&format!(
+                "\n- {}: {}",
+                one_line(&capability.capability),
+                capability.state
+            ));
+            if plan.request.projection == SearchProjection::Evidence
+                && !capability.detail.is_empty()
+            {
+                output.push_str(&format!(" — {}", one_line(&capability.detail)));
+            }
+        }
+        output.push('\n');
+    }
+    output.push_str("\n## Results\n");
+    if plan.records.is_empty() {
+        output.push_str("\nNo selected records.\n");
+    }
+    for record in &plan.records {
+        let location = record.identity.source.as_ref().map_or_else(
+            || "no source".to_string(),
+            |span| {
+                format!(
+                    "[{}] {}:{}-{}",
+                    span.root, span.path, span.start_line, span.end_line
+                )
+            },
+        );
+        output.push_str(&format!(
+            "\n{}. {} `{}` — {}\n   - id: {}\n   - signature: {}\n   - channel: {}; reason: {}\n   - body: {}\n",
+            record.selection_rank + 1,
+            one_line(&record.symbol.kind),
+            one_line(&record.symbol.name),
+            location,
+            inline_code(&record.identity.node_id),
+            inline_code(&one_line(&record.symbol.signature)),
+            record.selection.channel,
+            one_line(&record.selection.reason),
+            record.body,
+        ));
+        if let Some(role) = record.selection.role {
+            output.push_str(&format!("   - role: {role}\n"));
+        }
+        if let Some(lane) = record.selection.lane {
+            output.push_str(&format!("   - lane: {lane}\n"));
+        }
+        if let Some(handle) = &record.source_handle {
+            output.push_str(&format!(
+                "   - hydrate_source: {}\n",
+                inline_code(&handle.encode())
+            ));
+        }
+        if let Some(handle) = &record.evidence_handle {
+            output.push_str(&format!(
+                "   - hydrate_evidence: {}\n",
+                inline_code(&handle.encode())
+            ));
+        }
+        if plan.request.projection == SearchProjection::Evidence {
+            render_evidence(&mut output, &record.evidence);
+        }
+    }
+    if plan.request.projection == SearchProjection::Evidence && !plan.candidate_audit.is_empty() {
+        output.push_str("\n## Candidate audit\n");
+        for candidate in &plan.candidate_audit {
+            let location = candidate.identity.source.as_ref().map_or_else(
+                || "no source".to_string(),
+                |span| {
+                    format!(
+                        "[{}] {}:{}-{}",
+                        span.root, span.path, span.start_line, span.end_line
+                    )
+                },
+            );
+            output.push_str(&format!(
+                "\n{}. {} — {}; disposition={}; reason={}\n",
+                candidate.candidate_rank,
+                inline_code(&candidate.identity.node_id),
+                location,
+                candidate.disposition,
+                one_line(&candidate.reason),
+            ));
+            render_evidence(&mut output, &candidate.evidence);
+        }
+    }
+    if !plan.omissions.is_empty() {
+        output.push_str("\n## Omissions and degradation\n");
+        for omission in &plan.omissions {
+            output.push_str(&format!(
+                "\n- {}: {}",
+                omission.code,
+                one_line(&omission.detail)
+            ));
+            if let Some(record) = &omission.record_id {
+                output.push_str(&format!("; record={}", inline_code(record)));
+            }
+        }
+        output.push('\n');
+    }
+    output
+}
+
+fn render_evidence(output: &mut String, evidence: &SelectionEvidence) {
+    if let Some(rank) = evidence.candidate_rank {
+        output.push_str(&format!("   - evidence.candidate_rank: {rank}\n"));
+    }
+    if let Some(hash) = &evidence.content_hash {
+        output.push_str(&format!(
+            "   - evidence.content_hash: {}\n",
+            inline_code(hash)
+        ));
+    }
+    for (name, score) in &evidence.raw_scores {
+        output.push_str(&format!(
+            "   - evidence.score.{}: {}\n",
+            one_line(name),
+            one_line(score)
+        ));
+    }
+    let mut provenance = evidence.provenance.clone();
+    provenance.sort();
+    for item in provenance {
+        output.push_str(&format!(
+            "   - evidence.provenance: {} — {}\n",
+            one_line(&item.source),
+            one_line(&item.detail)
+        ));
+    }
+    for (name, diagnostic) in &evidence.diagnostics {
+        output.push_str(&format!(
+            "   - evidence.diagnostic.{}: {}\n",
+            one_line(name),
+            one_line(diagnostic)
+        ));
+    }
+}
+
+fn render_bodies(plan: &ProjectionPlan) -> String {
+    if plan.spans.is_empty() {
+        return String::new();
+    }
+    let mut output = "\n## Source bodies\n".to_string();
+    for span in &plan.spans {
+        output.push_str(&format!(
+            "\n### [{}] `{}`:{}-{} ({})\n",
+            span.source.root,
+            span.source.path,
+            span.source.start_line,
+            span.source.end_line,
+            span.representation
+        ));
+        output.push_str(&format!(
+            "- hydrate: {}\n",
+            inline_code(&span.hydration.encode())
+        ));
+        for mapping in &span.mappings {
+            output.push_str(&format!(
+                "- satisfies: {} role={} channel={} coverage={} reason={}\n",
+                inline_code(&mapping.record_id),
+                mapping
+                    .selection
+                    .role
+                    .map_or("unknown", ContextRole::as_str),
+                mapping.selection.channel,
+                mapping.coverage,
+                one_line(&mapping.selection.reason)
+            ));
+        }
+        let fence = safe_fence(&span.text);
+        output.push_str(&format!("\n{fence}text\n{}{fence}\n", span.text));
+    }
+    output
+}
+
+fn render_relationships(plan: &ProjectionPlan) -> String {
+    if plan.relationships.is_empty() {
+        return String::new();
+    }
+    let mut output = "\n## Relationships\n".to_string();
+    for relationship in &plan.relationships {
+        output.push_str(&format!(
+            "\n- {} --{}--> {}: {}",
+            inline_code(&relationship.from),
+            one_line(&relationship.kind),
+            inline_code(&relationship.to),
+            one_line(&relationship.reason)
+        ));
+    }
+    output.push('\n');
+    output
+}
+
+fn render_footer(accounting: &RenderAccounting) -> String {
+    let section = |kind| accounting.sections.get(&kind).copied().unwrap_or_default();
+    let mut output = format!(
+        "\n## Render accounting\n\n- total: bytes={} chars={} estimated_tokens={}\n- estimate: {} (deterministic estimate; not provider usage)\n- sections:\n",
+        accounting.total.utf8_bytes,
+        accounting.total.unicode_chars,
+        accounting.total.estimated_tokens,
+        accounting.estimate_name
+    );
+    for kind in [
+        CostSection::Headers,
+        CostSection::Bodies,
+        CostSection::Relationships,
+        CostSection::Metadata,
+        CostSection::Footer,
+    ] {
+        let cost = section(kind);
+        output.push_str(&format!(
+            "  - {kind}: bytes={} chars={} estimated_tokens={}\n",
+            cost.utf8_bytes, cost.unicode_chars, cost.estimated_tokens
+        ));
+    }
+    output
+}
+
+fn one_line(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn inline_code(value: &str) -> String {
+    let longest = value
+        .split(|character| character != '`')
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+    let fence = "`".repeat(longest.saturating_add(1).max(1));
+    format!("{fence} {value} {fence}")
+}
+
+fn safe_fence(value: &str) -> String {
+    let longest = value
+        .split(|character| character != '`')
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+    "`".repeat(longest.saturating_add(1).max(3))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan(projection: SearchProjection) -> ProjectionPlan {
+        let source = SourceSpan {
+            root: "repo".into(),
+            path: "src/ü.rs".into(),
+            start_line: 1,
+            end_line: 1,
+        };
+        let selection = SelectionSummary {
+            channel: SelectionChannel::Semantic,
+            reason: "useful".into(),
+            role: Some(ContextRole::DefinitionOrApiState),
+            lane: Some(RetrievalLane::DefinitionOrState),
+        };
+        let mut evidence = SelectionEvidence::default();
+        evidence.raw_scores.insert("cosine".into(), "0.75".into());
+        evidence.content_hash = Some("secret-hash".into());
+        ProjectionPlan {
+            request: ProjectionRequest {
+                projection,
+                body_policy: BodyPolicy::Complete,
+                ..Default::default()
+            },
+            records: vec![ProjectedRecord {
+                selection_rank: 0,
+                identity: RecordIdentity {
+                    node_id: "node".into(),
+                    source: Some(source.clone()),
+                },
+                symbol: SymbolSummary {
+                    name: "β".into(),
+                    kind: "function".into(),
+                    language: "rust".into(),
+                    signature: "fn β()".into(),
+                },
+                selection: selection.clone(),
+                evidence,
+                body: BodyRepresentation::Complete,
+                span_ids: vec![source.stable_id()],
+                source_handle: Some(HydrationHandle::source("node", source.clone())),
+                evidence_handle: Some(HydrationHandle::evidence("node")),
+            }],
+            candidate_audit: vec![CandidateAudit {
+                candidate_rank: 2,
+                identity: RecordIdentity {
+                    node_id: "omitted-node".into(),
+                    source: None,
+                },
+                disposition: CandidateDisposition::Omitted,
+                reason: "outside bounded selection".into(),
+                evidence: SelectionEvidence {
+                    content_hash: Some("audit-secret-hash".into()),
+                    ..Default::default()
+                },
+            }],
+            spans: vec![ProjectedSpan {
+                source: source.clone(),
+                text: "β();\n".into(),
+                representation: BodyRepresentation::Complete,
+                mappings: vec![SpanMapping {
+                    record_id: "node".into(),
+                    selection_rank: 0,
+                    selection,
+                    requested: source.clone(),
+                    coverage: SpanCoverage::Complete,
+                }],
+                hydration: HydrationHandle::source("node", source),
+            }],
+            relationships: vec![],
+            omissions: vec![],
+            capabilities: vec![CapabilityStatus {
+                capability: "lsp".into(),
+                state: CapabilityState::Unavailable,
+                detail: "internal-scorer-path=/tmp/private-model".into(),
+            }],
+        }
+    }
+
+    fn empty_plan(projection: SearchProjection) -> ProjectionPlan {
+        ProjectionPlan {
+            request: ProjectionRequest {
+                projection,
+                ..Default::default()
+            },
+            records: Vec::new(),
+            candidate_audit: Vec::new(),
+            spans: Vec::new(),
+            relationships: Vec::new(),
+            omissions: Vec::new(),
+            capabilities: Vec::new(),
+        }
+    }
+
+    fn unicode_signature_plan() -> ProjectionPlan {
+        ProjectionPlan {
+            request: ProjectionRequest::default(),
+            records: vec![ProjectedRecord {
+                selection_rank: 0,
+                identity: RecordIdentity {
+                    node_id: "node:β".into(),
+                    source: Some(SourceSpan {
+                        root: "répo".into(),
+                        path: "src/ü.rs".into(),
+                        start_line: 1,
+                        end_line: 1,
+                    }),
+                },
+                symbol: SymbolSummary {
+                    name: "β".into(),
+                    kind: "function".into(),
+                    language: "rust".into(),
+                    signature: "fn β()".into(),
+                },
+                selection: SelectionSummary {
+                    channel: SelectionChannel::Exact,
+                    reason: "café match".into(),
+                    role: Some(ContextRole::EditableSource),
+                    lane: Some(RetrievalLane::ExactReference),
+                },
+                evidence: SelectionEvidence::default(),
+                body: BodyRepresentation::SignatureOnly,
+                span_ids: Vec::new(),
+                source_handle: None,
+                evidence_handle: None,
+            }],
+            candidate_audit: Vec::new(),
+            spans: Vec::new(),
+            relationships: Vec::new(),
+            omissions: Vec::new(),
+            capabilities: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn empty_agent_and_evidence_outputs_match_exact_byte_goldens() {
+        const AGENT: &str = "# RNA search context\n\n- projection: agent\n- intent: discover\n- body_policy: signature_only\n- selected_records: 0\n\n## Results\n\nNo selected records.\n\n## Render accounting\n\n- total: bytes=575 chars=575 estimated_tokens=144\n- estimate: unicode_chars_div_4_ceiling (deterministic estimate; not provider usage)\n- sections:\n  - headers: bytes=113 chars=113 estimated_tokens=29\n  - bodies: bytes=0 chars=0 estimated_tokens=0\n  - relationships: bytes=0 chars=0 estimated_tokens=0\n  - metadata: bytes=34 chars=34 estimated_tokens=9\n  - footer: bytes=428 chars=428 estimated_tokens=107\n";
+        const EVIDENCE: &str = "# RNA search context\n\n- projection: evidence\n- intent: discover\n- body_policy: signature_only\n- selected_records: 0\n\n## Results\n\nNo selected records.\n\n## Render accounting\n\n- total: bytes=578 chars=578 estimated_tokens=145\n- estimate: unicode_chars_div_4_ceiling (deterministic estimate; not provider usage)\n- sections:\n  - headers: bytes=116 chars=116 estimated_tokens=29\n  - bodies: bytes=0 chars=0 estimated_tokens=0\n  - relationships: bytes=0 chars=0 estimated_tokens=0\n  - metadata: bytes=34 chars=34 estimated_tokens=9\n  - footer: bytes=428 chars=428 estimated_tokens=107\n";
+
+        assert_eq!(
+            render_projection(&empty_plan(SearchProjection::Agent))
+                .unwrap()
+                .text,
+            AGENT
+        );
+        assert_eq!(
+            render_projection(&empty_plan(SearchProjection::Evidence))
+                .unwrap()
+                .text,
+            EVIDENCE
+        );
+    }
+
+    #[test]
+    fn unicode_signature_output_matches_exact_byte_golden() {
+        const GOLDEN: &str = "# RNA search context\n\n- projection: agent\n- intent: discover\n- body_policy: signature_only\n- selected_records: 1\n\n## Results\n\n1. function `β` — [répo] src/ü.rs:1-1\n   - id: ` node:β `\n   - signature: ` fn β() `\n   - channel: exact; reason: café match\n   - body: signature_only\n   - role: editable_source\n   - lane: exact_reference\n\n## Render accounting\n\n- total: bytes=770 chars=762 estimated_tokens=191\n- estimate: unicode_chars_div_4_ceiling (deterministic estimate; not provider usage)\n- sections:\n  - headers: bytes=113 chars=113 estimated_tokens=29\n  - bodies: bytes=0 chars=0 estimated_tokens=0\n  - relationships: bytes=0 chars=0 estimated_tokens=0\n  - metadata: bytes=226 chars=218 estimated_tokens=55\n  - footer: bytes=431 chars=431 estimated_tokens=108\n";
+
+        assert_eq!(
+            render_projection(&unicode_signature_plan()).unwrap().text,
+            GOLDEN
+        );
+    }
+
+    #[test]
+    fn evidence_output_with_candidate_audit_matches_exact_byte_golden() {
+        const GOLDEN: &str = "# RNA search context\n\n- projection: evidence\n- intent: discover\n- body_policy: signature_only\n- selected_records: 1\n\n## Capability status\n\n- semantic_search: degraded — model=/tmp/private\n\n## Results\n\n1. function `β` — [répo] src/ü.rs:1-1\n   - id: ` node:β `\n   - signature: ` fn β() `\n   - channel: exact; reason: café match\n   - body: signature_only\n   - role: editable_source\n   - lane: exact_reference\n   - evidence.candidate_rank: 1\n   - evidence.content_hash: ` hash-β `\n   - evidence.score.vector_distance: 0.25\n   - evidence.provenance: vector — rank=1\n   - evidence.diagnostic.tie_break: stable_id\n\n## Candidate audit\n\n2. ` node:γ ` — no source; disposition=omitted; reason=outside limit\n   - evidence.candidate_rank: 2\n   - evidence.content_hash: ` hash-γ `\n   - evidence.score.lexical: 3\n\n## Render accounting\n\n- total: bytes=1250 chars=1233 estimated_tokens=309\n- estimate: unicode_chars_div_4_ceiling (deterministic estimate; not provider usage)\n- sections:\n  - headers: bytes=116 chars=116 estimated_tokens=29\n  - bodies: bytes=0 chars=0 estimated_tokens=0\n  - relationships: bytes=0 chars=0 estimated_tokens=0\n  - metadata: bytes=700 chars=683 estimated_tokens=171\n  - footer: bytes=434 chars=434 estimated_tokens=109\n";
+        let mut input = unicode_signature_plan();
+        input.request.projection = SearchProjection::Evidence;
+        input.records[0].evidence = SelectionEvidence {
+            raw_scores: BTreeMap::from([("vector_distance".into(), "0.25".into())]),
+            content_hash: Some("hash-β".into()),
+            candidate_rank: Some(1),
+            provenance: vec![EvidenceProvenance {
+                source: "vector".into(),
+                detail: "rank=1".into(),
+            }],
+            diagnostics: BTreeMap::from([("tie_break".into(), "stable_id".into())]),
+        };
+        input.candidate_audit = vec![CandidateAudit {
+            candidate_rank: 2,
+            identity: RecordIdentity {
+                node_id: "node:γ".into(),
+                source: None,
+            },
+            disposition: CandidateDisposition::Omitted,
+            reason: "outside limit".into(),
+            evidence: SelectionEvidence {
+                raw_scores: BTreeMap::from([("lexical".into(), "3".into())]),
+                content_hash: Some("hash-γ".into()),
+                candidate_rank: Some(2),
+                ..Default::default()
+            },
+        }];
+        input.capabilities = vec![CapabilityStatus {
+            capability: "semantic_search".into(),
+            state: CapabilityState::Degraded,
+            detail: "model=/tmp/private".into(),
+        }];
+
+        assert_eq!(render_projection(&input).unwrap().text, GOLDEN);
+    }
+
+    #[test]
+    fn agent_omits_evidence_but_handle_retains_it() {
+        let action = render_projection(&plan(SearchProjection::Agent)).unwrap();
+        assert!(!action.text.contains("secret-hash"));
+        assert!(!action.text.contains("cosine"));
+        assert!(!action.text.contains("audit-secret-hash"));
+        assert!(!action.text.contains("outside bounded selection"));
+        assert!(!action.text.contains("internal-scorer-path"));
+        assert!(action.text.contains("- lsp: unavailable"));
+        assert!(action.text.contains("hydrate_evidence"));
+        let evidence = render_projection(&plan(SearchProjection::Evidence)).unwrap();
+        assert!(evidence.text.contains("secret-hash"));
+        assert!(evidence.text.contains("cosine"));
+        assert!(evidence.text.contains("audit-secret-hash"));
+        assert!(evidence.text.contains("outside bounded selection"));
+        assert!(evidence.text.contains("internal-scorer-path"));
+    }
+
+    #[test]
+    fn footer_accounts_for_itself_and_unicode() {
+        let rendered = render_projection(&plan(SearchProjection::Agent)).unwrap();
+        assert_eq!(rendered.text.len(), rendered.accounting.total.utf8_bytes);
+        assert_eq!(
+            rendered.text.chars().count(),
+            rendered.accounting.total.unicode_chars
+        );
+        assert_eq!(
+            rendered
+                .accounting
+                .sections
+                .values()
+                .map(|cost| cost.utf8_bytes)
+                .sum::<usize>(),
+            rendered.accounting.total.utf8_bytes
+        );
+        assert!(!rendered.accounting.provider_usage);
+        assert_eq!(
+            render_projection(&plan(SearchProjection::Agent))
+                .unwrap()
+                .text,
+            rendered.text
+        );
+    }
+
+    #[test]
+    fn persisted_plan_reopens_to_byte_identical_output() {
+        let original = plan(SearchProjection::Evidence);
+        let bytes = serde_json::to_vec(&original).unwrap();
+        let reopened: ProjectionPlan = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(
+            render_projection(&original).unwrap().text.as_bytes(),
+            render_projection(&reopened).unwrap().text.as_bytes()
+        );
+    }
+
+    #[test]
+    fn empty_agent_projection_is_explicit_and_accounted() {
+        let empty = ProjectionPlan {
+            request: ProjectionRequest::default(),
+            records: Vec::new(),
+            candidate_audit: Vec::new(),
+            spans: Vec::new(),
+            relationships: Vec::new(),
+            omissions: Vec::new(),
+            capabilities: Vec::new(),
+        };
+
+        let rendered = render_projection(&empty).unwrap();
+
+        assert!(rendered.text.contains("No selected records."));
+        assert!(rendered.text.contains("projection: agent"));
+        assert_eq!(rendered.text.len(), rendered.accounting.total.utf8_bytes);
+        assert!(!rendered.accounting.provider_usage);
+    }
+
+    #[test]
+    fn impossible_budget_returns_a_typed_error() {
+        let mut input = plan(SearchProjection::Agent);
+        input.request.budget.max_rendered_bytes = Some(1);
+        assert!(matches!(
+            render_projection(&input),
+            Err(RenderError::BudgetTooSmall { .. })
+        ));
+    }
+
+    #[test]
+    fn non_graph_record_does_not_emit_a_dead_evidence_handle() {
+        let mut input = plan(SearchProjection::Agent);
+        input.records[0].evidence_handle = None;
+
+        let rendered = render_projection(&input).unwrap();
+
+        assert!(!rendered.text.contains("hydrate_evidence:"));
+        assert!(rendered.text.contains("hydrate_source:"));
+    }
+}

--- a/src/service/search/source.rs
+++ b/src/service/search/source.rs
@@ -1,0 +1,308 @@
+//! Exact, root-confined source reads used by projection and hydration.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fs;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+use super::model::SourceSpan;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SourceReadLimits {
+    pub(crate) max_lines: u32,
+    pub(crate) max_span_bytes: usize,
+    pub(crate) max_scanned_bytes: usize,
+}
+
+impl Default for SourceReadLimits {
+    fn default() -> Self {
+        Self {
+            max_lines: 200,
+            max_span_bytes: 64 * 1024,
+            max_scanned_bytes: 16 * 1024 * 1024,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SourceSlice {
+    pub(crate) span: SourceSpan,
+    /// Exact UTF-8 bytes from the current filesystem, including original line endings.
+    pub(crate) text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SourceError {
+    InvalidRoot(String),
+    UnknownRoot(String),
+    InvalidPath(String),
+    InvalidRange,
+    TooManyLines {
+        requested: u64,
+        limit: u32,
+    },
+    EscapesRoot(String),
+    NotFile(String),
+    Io {
+        operation: &'static str,
+        kind: std::io::ErrorKind,
+    },
+    ScanLimit(usize),
+    SpanLimit(usize),
+    Binary,
+    InvalidUtf8,
+    OutOfRange {
+        requested: u32,
+        available: u32,
+    },
+}
+
+impl fmt::Display for SourceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRoot(root) => write!(f, "invalid source root `{root}`"),
+            Self::UnknownRoot(root) => write!(f, "unknown source root `{root}`"),
+            Self::InvalidPath(path) => write!(f, "source path must be root-relative: `{path}`"),
+            Self::InvalidRange => f.write_str("source lines must be a non-empty 1-based range"),
+            Self::TooManyLines { requested, limit } => {
+                write!(f, "source range has {requested} lines; limit is {limit}")
+            }
+            Self::EscapesRoot(path) => write!(f, "source path escapes its root: `{path}`"),
+            Self::NotFile(path) => write!(f, "source path is not a regular file: `{path}`"),
+            Self::Io { operation, kind } => write!(f, "source {operation} failed ({kind:?})"),
+            Self::ScanLimit(limit) => write!(f, "source scan exceeded {limit} bytes"),
+            Self::SpanLimit(limit) => write!(f, "source span exceeded {limit} bytes"),
+            Self::Binary => f.write_str("source contains NUL bytes"),
+            Self::InvalidUtf8 => f.write_str("source is not valid UTF-8"),
+            Self::OutOfRange {
+                requested,
+                available,
+            } => write!(
+                f,
+                "source line {requested} is out of range (file has {available} lines)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SourceError {}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SourceReader {
+    roots: BTreeMap<String, PathBuf>,
+    limits: SourceReadLimits,
+}
+
+impl SourceReader {
+    #[cfg(test)]
+    pub(crate) fn for_root(
+        slug: impl Into<String>,
+        path: impl AsRef<Path>,
+    ) -> Result<Self, SourceError> {
+        Self::new(
+            [(slug.into(), path.as_ref().to_path_buf())],
+            SourceReadLimits::default(),
+        )
+    }
+
+    pub(crate) fn new(
+        roots: impl IntoIterator<Item = (String, PathBuf)>,
+        limits: SourceReadLimits,
+    ) -> Result<Self, SourceError> {
+        let mut resolved = BTreeMap::new();
+        for (slug, path) in roots {
+            if slug.trim().is_empty() {
+                return Err(SourceError::InvalidRoot(slug));
+            }
+            let canonical = fs::canonicalize(&path).map_err(|error| SourceError::Io {
+                operation: "root resolution",
+                kind: error.kind(),
+            })?;
+            if !canonical.is_dir() {
+                return Err(SourceError::InvalidRoot(slug));
+            }
+            resolved.insert(slug, canonical);
+        }
+        Ok(Self {
+            roots: resolved,
+            limits,
+        })
+    }
+
+    pub(crate) fn limits(&self) -> SourceReadLimits {
+        self.limits
+    }
+
+    pub(crate) fn read(&self, span: &SourceSpan) -> Result<SourceSlice, SourceError> {
+        if !span.is_valid() {
+            return Err(SourceError::InvalidRange);
+        }
+        let line_count = u64::from(span.end_line) - u64::from(span.start_line) + 1;
+        if line_count > u64::from(self.limits.max_lines) {
+            return Err(SourceError::TooManyLines {
+                requested: line_count,
+                limit: self.limits.max_lines,
+            });
+        }
+        let relative = Path::new(&span.path);
+        if relative.is_absolute()
+            || relative.components().any(|part| {
+                matches!(
+                    part,
+                    Component::ParentDir | Component::RootDir | Component::Prefix(_)
+                )
+            })
+        {
+            return Err(SourceError::InvalidPath(span.path.clone()));
+        }
+        let root = self
+            .roots
+            .get(&span.root)
+            .ok_or_else(|| SourceError::UnknownRoot(span.root.clone()))?;
+        let joined = root.join(relative);
+        let canonical = fs::canonicalize(&joined).map_err(|error| SourceError::Io {
+            operation: "path resolution",
+            kind: error.kind(),
+        })?;
+        if !canonical.starts_with(root) {
+            return Err(SourceError::EscapesRoot(span.path.clone()));
+        }
+        if !fs::metadata(&canonical)
+            .map_err(|error| SourceError::Io {
+                operation: "metadata",
+                kind: error.kind(),
+            })?
+            .is_file()
+        {
+            return Err(SourceError::NotFile(span.path.clone()));
+        }
+
+        let mut file = fs::File::open(&canonical).map_err(|error| SourceError::Io {
+            operation: "open",
+            kind: error.kind(),
+        })?;
+        let mut buffer = [0_u8; 8192];
+        let mut selected = Vec::new();
+        let mut scanned = 0_usize;
+        let mut line = 1_u32;
+        let mut saw_byte = false;
+        let mut last_newline = false;
+        let mut complete = false;
+        'read: loop {
+            let count = file.read(&mut buffer).map_err(|error| SourceError::Io {
+                operation: "read",
+                kind: error.kind(),
+            })?;
+            if count == 0 {
+                break;
+            }
+            scanned = scanned.saturating_add(count);
+            if scanned > self.limits.max_scanned_bytes {
+                return Err(SourceError::ScanLimit(self.limits.max_scanned_bytes));
+            }
+            for &byte in &buffer[..count] {
+                saw_byte = true;
+                last_newline = byte == b'\n';
+                if byte == 0 {
+                    return Err(SourceError::Binary);
+                }
+                if (span.start_line..=span.end_line).contains(&line) {
+                    if selected.len() == self.limits.max_span_bytes {
+                        return Err(SourceError::SpanLimit(self.limits.max_span_bytes));
+                    }
+                    selected.push(byte);
+                }
+                if byte == b'\n' {
+                    if line == span.end_line {
+                        complete = true;
+                        break 'read;
+                    }
+                    line = line.saturating_add(1);
+                }
+            }
+        }
+        let available = if complete {
+            span.end_line
+        } else if !saw_byte {
+            0
+        } else if last_newline {
+            line.saturating_sub(1)
+        } else {
+            line
+        };
+        if span.start_line > available {
+            return Err(SourceError::OutOfRange {
+                requested: span.start_line,
+                available,
+            });
+        }
+        if span.end_line > available {
+            return Err(SourceError::OutOfRange {
+                requested: span.end_line,
+                available,
+            });
+        }
+        let text = String::from_utf8(selected).map_err(|_| SourceError::InvalidUtf8)?;
+        Ok(SourceSlice {
+            span: span.clone(),
+            text,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_unicode_and_original_line_endings() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("sample.rs"), "one\r\nβeta\nthree").unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+        let span = SourceSpan {
+            root: "repo".into(),
+            path: "sample.rs".into(),
+            start_line: 1,
+            end_line: 2,
+        };
+        assert_eq!(reader.read(&span).unwrap().text, "one\r\nβeta\n");
+    }
+
+    #[test]
+    fn rejects_parent_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let reader = SourceReader::for_root("repo", dir.path()).unwrap();
+        let span = SourceSpan {
+            root: "repo".into(),
+            path: "../secret".into(),
+            start_line: 1,
+            end_line: 1,
+        };
+        assert!(matches!(
+            reader.read(&span),
+            Err(SourceError::InvalidPath(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("secret"), "nope").unwrap();
+        symlink(outside.path().join("secret"), root.path().join("link")).unwrap();
+        let reader = SourceReader::for_root("repo", root.path()).unwrap();
+        let span = SourceSpan {
+            root: "repo".into(),
+            path: "link".into(),
+            start_line: 1,
+            end_line: 1,
+        };
+        assert!(matches!(
+            reader.read(&span),
+            Err(SourceError::EscapesRoot(_))
+        ));
+    }
+}

--- a/src/service/search/task_context.rs
+++ b/src/service/search/task_context.rs
@@ -114,6 +114,13 @@ pub(crate) enum TaskContextError {
     ConflictingDuplicate {
         evidence_id: String,
     },
+    BundleCost {
+        reason: String,
+    },
+    BundleCostExceedsBudget {
+        actual: usize,
+        limit: usize,
+    },
 }
 
 impl fmt::Display for TaskContextError {
@@ -148,6 +155,13 @@ impl fmt::Display for TaskContextError {
             Self::ConflictingDuplicate { evidence_id } => write!(
                 formatter,
                 "candidate {evidence_id:?} was supplied with conflicting metadata"
+            ),
+            Self::BundleCost { reason } => {
+                write!(formatter, "canonical task bundle cost failed: {reason}")
+            }
+            Self::BundleCostExceedsBudget { actual, limit } => write!(
+                formatter,
+                "canonical task bundle fixed sections cost {actual} bytes; budget is {limit}"
             ),
         }
     }
@@ -716,10 +730,55 @@ struct CoverageGain {
     facets: BTreeSet<TaskFacet>,
 }
 
+#[cfg(test)]
 pub(crate) fn select_context(
     candidates: Vec<EvidenceCandidate>,
     policy: &SelectionPolicy,
 ) -> Result<ContextSelection, TaskContextError> {
+    let costs = candidates
+        .iter()
+        .map(|candidate| (candidate.evidence_id.clone(), candidate.rendered_cost))
+        .collect::<BTreeMap<_, _>>();
+    select_context_with_cost(candidates, policy, |selected_ids| {
+        Ok(selected_ids
+            .iter()
+            .filter_map(|id| costs.get(id))
+            .copied()
+            .sum())
+    })
+}
+
+/// Select task context against the canonical cost of the complete provisional
+/// bundle. The callback receives every selected identity in deterministic
+/// selection order and must include shared projection overhead, coalesced
+/// bodies, and task-only metadata—not standalone record costs.
+#[cfg(test)]
+pub(crate) fn select_context_with_cost<F>(
+    candidates: Vec<EvidenceCandidate>,
+    policy: &SelectionPolicy,
+    bundle_cost: F,
+) -> Result<ContextSelection, TaskContextError>
+where
+    F: FnMut(&[String]) -> Result<usize, TaskContextError>,
+{
+    select_context_with_cost_and_interactions(candidates, policy, bundle_cost, |_, _| Vec::new())
+}
+
+pub(crate) type FutureInteractionKey = (String, String, String, String);
+pub(crate) type FutureInteractionSignature = Vec<(String, Vec<FutureInteractionKey>)>;
+
+/// Select task context while preserving graph relationships whose rendered
+/// cost can appear only after a remaining candidate is selected.
+pub(crate) fn select_context_with_cost_and_interactions<F, G>(
+    candidates: Vec<EvidenceCandidate>,
+    policy: &SelectionPolicy,
+    mut bundle_cost: F,
+    mut interaction_signature: G,
+) -> Result<ContextSelection, TaskContextError>
+where
+    F: FnMut(&[String]) -> Result<usize, TaskContextError>,
+    G: FnMut(&[String], &[String]) -> FutureInteractionSignature,
+{
     validate_policy(policy)?;
     if candidates.len() > policy.candidate_limit {
         return Err(TaskContextError::TooManyCandidates {
@@ -737,7 +796,14 @@ pub(crate) fn select_context(
     let mut covered_lanes = BTreeSet::new();
     let mut covered_facets = BTreeSet::new();
     let mut file_counts = BTreeMap::<String, usize>::new();
-    let mut rendered_cost = 0usize;
+    let mut source_plan = BTreeMap::<String, Vec<(u32, u32)>>::new();
+    let mut rendered_cost = bundle_cost(&[])?;
+    if rendered_cost > policy.rendered_budget {
+        return Err(TaskContextError::BundleCostExceedsBudget {
+            actual: rendered_cost,
+            limit: policy.rendered_budget,
+        });
+    }
 
     let mut exact = candidates
         .values()
@@ -750,9 +816,15 @@ pub(crate) fn select_context(
     });
 
     for candidate in exact {
+        let mut provisional_ids = selected
+            .iter()
+            .map(|selected: &SelectedEvidence| selected.evidence_id.clone())
+            .collect::<Vec<_>>();
+        provisional_ids.push(candidate.evidence_id.clone());
+        let provisional_cost = bundle_cost(&provisional_ids)?;
         let reason = if candidate.rendered_cost > policy.per_record_limit {
             Some(OmissionReason::ExactRecordTooLarge)
-        } else if rendered_cost + candidate.rendered_cost > policy.rendered_budget {
+        } else if provisional_cost > policy.rendered_budget {
             Some(OmissionReason::ExactBudgetExhausted)
         } else {
             None
@@ -766,11 +838,12 @@ pub(crate) fn select_context(
             continue;
         }
 
-        rendered_cost += candidate.rendered_cost;
+        rendered_cost = provisional_cost;
         selected_ids.insert(candidate.evidence_id.clone());
         *file_counts
             .entry(candidate.source.path.clone())
             .or_default() += 1;
+        add_source_range(&mut source_plan, &candidate.source);
         covered_roles.extend(candidate.roles.iter().copied());
         covered_lanes.extend(candidate.lanes.iter().copied());
         covered_facets.extend(candidate.facets.iter().copied());
@@ -796,6 +869,9 @@ pub(crate) fn select_context(
         lane_mask: lane_mask(&covered_lanes),
         facet_mask: facet_mask(&covered_facets),
         file_counts: file_counts.clone(),
+        source_plan: source_plan.clone(),
+        future_overlap_signature: Vec::new(),
+        future_interaction_signature: Vec::new(),
         channel_rank_sum: 0,
     }];
     let initially_relevant_files = eligible
@@ -815,13 +891,12 @@ pub(crate) fn select_context(
         let mut expanded = Vec::with_capacity(frontier.len().saturating_mul(2));
         for state in &frontier {
             expanded.push(state.clone());
-            if state.rendered_cost + candidate.rendered_cost > policy.rendered_budget
-                || state
-                    .file_counts
-                    .get(&candidate.source.path)
-                    .copied()
-                    .unwrap_or(0)
-                    >= policy.per_file_limit
+            if state
+                .file_counts
+                .get(&candidate.source.path)
+                .copied()
+                .unwrap_or(0)
+                >= policy.per_file_limit
             {
                 continue;
             }
@@ -837,7 +912,17 @@ pub(crate) fn select_context(
             }
 
             let mut added = state.clone();
-            added.rendered_cost += candidate.rendered_cost;
+            let mut provisional_ids = selected
+                .iter()
+                .map(|selected| selected.evidence_id.clone())
+                .collect::<Vec<_>>();
+            provisional_ids.extend(added.selected_ids.iter().cloned());
+            provisional_ids.push(candidate.evidence_id.clone());
+            let provisional_cost = bundle_cost(&provisional_ids)?;
+            if provisional_cost > policy.rendered_budget {
+                continue;
+            }
+            added.rendered_cost = provisional_cost;
             added.role_mask |= candidate_role_mask;
             added.lane_mask |= candidate_lane_mask;
             added.facet_mask |= candidate_facet_mask;
@@ -845,6 +930,7 @@ pub(crate) fn select_context(
                 .file_counts
                 .entry(candidate.source.path.clone())
                 .or_default() += 1;
+            add_source_range(&mut added.source_plan, &candidate.source);
             added.channel_rank_sum += u64::from(candidate.channel_rank);
             added.selected_ids.push(candidate.evidence_id.clone());
             expanded.push(added);
@@ -857,10 +943,23 @@ pub(crate) fn select_context(
             .iter()
             .map(|candidate| candidate.source.path.clone())
             .collect::<BTreeSet<_>>();
+        let remaining_ids = eligible[index + 1..]
+            .iter()
+            .map(|candidate| candidate.evidence_id.clone())
+            .collect::<Vec<_>>();
         for state in &mut expanded {
             state
                 .file_counts
                 .retain(|path, _| active_files.contains(path));
+            state.future_overlap_signature =
+                future_overlap_signature(&state.source_plan, &eligible[index + 1..]);
+            let mut provisional_ids = selected
+                .iter()
+                .map(|selected| selected.evidence_id.clone())
+                .collect::<Vec<_>>();
+            provisional_ids.extend(state.selected_ids.iter().cloned());
+            state.future_interaction_signature =
+                interaction_signature(&provisional_ids, &remaining_ids);
         }
         frontier = pareto_frontier(expanded);
         if frontier.len() > policy.state_limit {
@@ -875,6 +974,7 @@ pub(crate) fn select_context(
         .into_iter()
         .max_by(selection_state_cmp)
         .expect("selection frontier always contains the empty state");
+    rendered_cost = best.rendered_cost;
     for evidence_id in best.selected_ids {
         let candidate = candidates
             .get(&evidence_id)
@@ -886,7 +986,6 @@ pub(crate) fn select_context(
             &covered_lanes,
             &covered_facets,
         );
-        rendered_cost += candidate.rendered_cost;
         selected_ids.insert(candidate.evidence_id.clone());
         *file_counts
             .entry(candidate.source.path.clone())
@@ -910,9 +1009,15 @@ pub(crate) fn select_context(
         {
             continue;
         }
+        let mut provisional_ids = selected
+            .iter()
+            .map(|selected| selected.evidence_id.clone())
+            .collect::<Vec<_>>();
+        provisional_ids.push(candidate.evidence_id.clone());
+        let provisional_cost = bundle_cost(&provisional_ids)?;
         let reason = if candidate.rendered_cost > policy.per_record_limit {
             OmissionReason::RecordTooLarge
-        } else if rendered_cost + candidate.rendered_cost > policy.rendered_budget {
+        } else if provisional_cost > policy.rendered_budget {
             OmissionReason::BudgetExhausted
         } else if candidate.exact_reference.is_none()
             && file_counts
@@ -956,7 +1061,47 @@ struct SelectionState {
     lane_mask: u16,
     facet_mask: u8,
     file_counts: BTreeMap<String, usize>,
+    /// Canonical coalesced source geometry. Non-additive bundle costs may only
+    /// dominate another state when future source overlap will be identical.
+    source_plan: BTreeMap<String, Vec<(u32, u32)>>,
+    future_overlap_signature: Vec<(String, bool)>,
+    future_interaction_signature: FutureInteractionSignature,
     channel_rank_sum: u64,
+}
+
+fn add_source_range(plan: &mut BTreeMap<String, Vec<(u32, u32)>>, source: &SourceAnchor) {
+    let ranges = plan.entry(source.path.clone()).or_default();
+    ranges.push((source.start_line, source.end_line));
+    ranges.sort();
+    let mut coalesced = Vec::<(u32, u32)>::new();
+    for (start, end) in ranges.drain(..) {
+        if let Some((_, previous_end)) = coalesced.last_mut()
+            && start <= previous_end.saturating_add(1)
+        {
+            *previous_end = (*previous_end).max(end);
+        } else {
+            coalesced.push((start, end));
+        }
+    }
+    *ranges = coalesced;
+}
+
+fn future_overlap_signature(
+    plan: &BTreeMap<String, Vec<(u32, u32)>>,
+    remaining: &[&EvidenceCandidate],
+) -> Vec<(String, bool)> {
+    remaining
+        .iter()
+        .map(|candidate| {
+            let overlaps = plan.get(&candidate.source.path).is_some_and(|ranges| {
+                ranges.iter().any(|(start, end)| {
+                    candidate.source.start_line <= end.saturating_add(1)
+                        && *start <= candidate.source.end_line.saturating_add(1)
+                })
+            });
+            (candidate.evidence_id.clone(), overlaps)
+        })
+        .collect()
 }
 
 fn role_bit(role: ContextRole) -> u16 {
@@ -1024,28 +1169,33 @@ fn selection_state_cmp(left: &SelectionState, right: &SelectionState) -> Orderin
         .then_with(|| right.selected_ids.cmp(&left.selected_ids))
 }
 
-fn file_capacity_no_worse(left: &BTreeMap<String, usize>, right: &BTreeMap<String, usize>) -> bool {
-    left.iter()
-        .all(|(path, count)| *count <= right.get(path).copied().unwrap_or(0))
-}
-
 fn state_dominates(left: &SelectionState, right: &SelectionState) -> bool {
-    let coverage_no_worse = left.role_mask | right.role_mask == left.role_mask
-        && left.lane_mask | right.lane_mask == left.lane_mask
-        && left.facet_mask | right.facet_mask == left.facet_mask;
+    // Coverage must be equal: selection-reason text is rendered from the
+    // prior masks, so a superset can have different future bundle bytes.
+    let coverage_equal = left.role_mask == right.role_mask
+        && left.lane_mask == right.lane_mask
+        && left.facet_mask == right.facet_mask;
+    let source_interactions_equivalent = left.source_plan == right.source_plan
+        || (left
+            .future_overlap_signature
+            .iter()
+            .all(|(_, overlaps)| !overlaps)
+            && right
+                .future_overlap_signature
+                .iter()
+                .all(|(_, overlaps)| !overlaps));
     let resources_no_worse = left.rendered_cost <= right.rendered_cost
         && left.channel_rank_sum <= right.channel_rank_sum
-        && file_capacity_no_worse(&left.file_counts, &right.file_counts);
-    if !coverage_no_worse || !resources_no_worse {
+        && left.file_counts == right.file_counts
+        && source_interactions_equivalent
+        && left.future_interaction_signature == right.future_interaction_signature
+        && left.selected_ids.len() == right.selected_ids.len();
+    if !coverage_equal || !resources_no_worse {
         return false;
     }
 
-    left.role_mask != right.role_mask
-        || left.lane_mask != right.lane_mask
-        || left.facet_mask != right.facet_mask
-        || left.rendered_cost != right.rendered_cost
+    left.rendered_cost != right.rendered_cost
         || left.channel_rank_sum != right.channel_rank_sum
-        || left.file_counts != right.file_counts
         || left.selected_ids <= right.selected_ids
 }
 
@@ -1500,5 +1650,175 @@ mod tests {
             } if newly_covered_roles
                 == &set([ContextRole::EditableSource, ContextRole::Test])
         ));
+    }
+
+    #[test]
+    fn acceptance_remediation_canonical_bundle_cost_controls_coalesced_selection_and_fixed_overhead()
+     {
+        let policy = SelectionPolicy {
+            rendered_budget: 120,
+            per_record_limit: 120,
+            candidate_limit: 8,
+            per_file_limit: 4,
+            state_limit: 32,
+            required_roles: set([ContextRole::EditableSource, ContextRole::Test]),
+        };
+        let candidates = vec![
+            candidate(
+                "source",
+                90,
+                [ContextRole::EditableSource],
+                [RetrievalLane::EditableSource],
+            ),
+            candidate("test", 90, [ContextRole::Test], [RetrievalLane::Tests]),
+        ];
+        let selected = select_context_with_cost(candidates.clone(), &policy, |ids| {
+            Ok(match ids.len() {
+                0 => 40,  // fixed task-only sections
+                1 => 90,  // one canonical record response
+                2 => 110, // shared framing/coalescing makes the pair fit
+                _ => unreachable!(),
+            })
+        })
+        .unwrap();
+        assert_eq!(selected.selected.len(), 2);
+        assert_eq!(selected.rendered_cost, 110);
+        assert!(selected.missing_roles.is_empty());
+
+        let fixed_heavy = SelectionPolicy {
+            rendered_budget: 100,
+            per_record_limit: 100,
+            required_roles: set([ContextRole::EditableSource]),
+            ..policy
+        };
+        let rejected = select_context_with_cost(candidates, &fixed_heavy, |ids| {
+            Ok(if ids.is_empty() { 80 } else { 110 })
+        })
+        .unwrap();
+        assert!(rejected.selected.is_empty());
+        assert_eq!(rejected.rendered_cost, 80);
+        assert!(
+            rejected
+                .omitted
+                .iter()
+                .any(|omitted| omitted.reason == OmissionReason::BudgetExhausted)
+        );
+    }
+
+    #[test]
+    fn acceptance_remediation_disjoint_future_plans_prune_combinatorial_alternatives() {
+        let obligations = [
+            (ContextRole::EditableSource, RetrievalLane::EditableSource),
+            (
+                ContextRole::DefinitionOrApiState,
+                RetrievalLane::DefinitionOrState,
+            ),
+            (ContextRole::Test, RetrievalLane::Tests),
+            (ContextRole::BehavioralAnalogue, RetrievalLane::Analogues),
+        ];
+        let mut candidates = Vec::new();
+        for (role_index, (role, lane)) in obligations.into_iter().enumerate() {
+            for alternative in 0..6 {
+                candidates.push(candidate(
+                    &format!("role-{role_index}-alternative-{alternative}"),
+                    2,
+                    [role],
+                    [lane],
+                ));
+            }
+        }
+        let policy = SelectionPolicy {
+            rendered_budget: 40,
+            per_record_limit: 40,
+            candidate_limit: 32,
+            per_file_limit: 1,
+            state_limit: 1_024,
+            required_roles: obligations.into_iter().map(|(role, _)| role).collect(),
+        };
+        let selection =
+            select_context_with_cost(candidates, &policy, |ids| Ok(20 + ids.len() * 2)).unwrap();
+        assert_eq!(selection.selected.len(), 4);
+        assert!(selection.missing_roles.is_empty());
+        assert_eq!(selection.rendered_cost, 28);
+    }
+
+    #[test]
+    fn acceptance_remediation_relationship_interaction_preserves_future_optimum() {
+        let candidates = vec![
+            candidate(
+                "a",
+                20,
+                [ContextRole::EditableSource],
+                [RetrievalLane::EditableSource],
+            ),
+            candidate(
+                "b",
+                21,
+                [ContextRole::EditableSource],
+                [RetrievalLane::EditableSource],
+            ),
+            candidate("future", 20, [ContextRole::Test], [RetrievalLane::Tests]),
+        ];
+        let policy = SelectionPolicy {
+            rendered_budget: 50,
+            per_record_limit: 50,
+            candidate_limit: 8,
+            per_file_limit: 1,
+            state_limit: 32,
+            required_roles: set([ContextRole::EditableSource, ContextRole::Test]),
+        };
+        let selection = select_context_with_cost_and_interactions(
+            candidates,
+            &policy,
+            |ids| {
+                let has_a = ids.iter().any(|id| id == "a");
+                let has_b = ids.iter().any(|id| id == "b");
+                let has_future = ids.iter().any(|id| id == "future");
+                Ok(if has_a && has_future {
+                    80
+                } else if has_b && has_future {
+                    30
+                } else if has_a {
+                    20
+                } else if has_b {
+                    21
+                } else if has_future {
+                    20
+                } else {
+                    10
+                })
+            },
+            |selected, remaining| {
+                remaining
+                    .iter()
+                    .map(|remaining_id| {
+                        let relationships =
+                            if remaining_id == "future" && selected.iter().any(|id| id == "a") {
+                                vec![(
+                                    "a".into(),
+                                    "calls".into(),
+                                    "future".into(),
+                                    "lsp High".into(),
+                                )]
+                            } else {
+                                Vec::new()
+                            };
+                        (remaining_id.clone(), relationships)
+                    })
+                    .collect()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            selection
+                .selected
+                .iter()
+                .map(|selected| selected.evidence_id.as_str())
+                .collect::<Vec<_>>(),
+            ["b", "future"]
+        );
+        assert_eq!(selection.rendered_cost, 30);
+        assert!(selection.missing_roles.is_empty());
     }
 }

--- a/src/service/search/task_context.rs
+++ b/src/service/search/task_context.rs
@@ -1,0 +1,1504 @@
+//! Deterministic, bounded primitives for assembling task-oriented context.
+//!
+//! This module deliberately stops at typed selection. Adapters in the shared
+//! service layer are responsible for turning selected evidence into source
+//! spans and projecting it for CLI or MCP rendering.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+pub(crate) const MAX_TASK_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_TASK_LINES: usize = 1_024;
+pub(crate) const MAX_EXACT_REFERENCES: usize = 128;
+pub(crate) const MAX_SELECTION_CANDIDATES: usize = 256;
+pub(crate) const HARD_MAX_SELECTION_STATES: usize = 4_096;
+pub(crate) const MAX_RENDERED_BUDGET: usize = 128 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum TaskFacet {
+    Behavior,
+    ApiOrState,
+    Test,
+    Analogue,
+    Proposal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ContextRole {
+    EditableSource,
+    DefinitionOrApiState,
+    Test,
+    BehavioralAnalogue,
+    DirectDependency,
+    CallerOrImpact,
+    ProposalDelta,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum RetrievalLane {
+    ExactReference,
+    EditableSource,
+    DefinitionOrState,
+    Tests,
+    Analogues,
+    Dependencies,
+    GraphImpact,
+    ProposalDelta,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ReferenceOrigin {
+    Prose,
+    CodeFence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ExactReferenceKind {
+    RepositoryPath,
+    CompilerLocation,
+    QualifiedName,
+    TestName,
+    CodeIdentifier,
+    BacktickedIdentifier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExactReference {
+    pub(crate) raw: String,
+    pub(crate) normalized: String,
+    pub(crate) kind: ExactReferenceKind,
+    pub(crate) origin: ReferenceOrigin,
+    pub(crate) byte_start: usize,
+    pub(crate) byte_end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedTask {
+    pub(crate) facets: BTreeSet<TaskFacet>,
+    /// Explicit references in prose. These are eligible for exact-first
+    /// resolution and pinning.
+    pub(crate) exact_references: Vec<ExactReference>,
+    /// Reference-shaped tokens inside a fenced proposal. These are kept
+    /// separate so a proposal cannot silently become current-source truth.
+    pub(crate) proposal_references: Vec<ExactReference>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TaskContextError {
+    TaskTooLarge {
+        actual: usize,
+        limit: usize,
+    },
+    TooManyLines {
+        actual: usize,
+        limit: usize,
+    },
+    TooManyReferences {
+        limit: usize,
+    },
+    TooManyCandidates {
+        actual: usize,
+        limit: usize,
+    },
+    SelectionStateLimitExceeded {
+        actual: usize,
+        limit: usize,
+    },
+    InvalidSelectionPolicy(&'static str),
+    InvalidCandidate {
+        evidence_id: String,
+        reason: &'static str,
+    },
+    ConflictingDuplicate {
+        evidence_id: String,
+    },
+}
+
+impl fmt::Display for TaskContextError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TaskTooLarge { actual, limit } => {
+                write!(formatter, "task is {actual} bytes; limit is {limit}")
+            }
+            Self::TooManyLines { actual, limit } => {
+                write!(formatter, "task is {actual} lines; limit is {limit}")
+            }
+            Self::TooManyReferences { limit } => {
+                write!(
+                    formatter,
+                    "task contains more than {limit} exact references"
+                )
+            }
+            Self::TooManyCandidates { actual, limit } => {
+                write!(formatter, "received {actual} candidates; limit is {limit}")
+            }
+            Self::SelectionStateLimitExceeded { actual, limit } => write!(
+                formatter,
+                "task-context selection needs {actual} Pareto states; limit is {limit}"
+            ),
+            Self::InvalidSelectionPolicy(reason) => {
+                write!(formatter, "invalid task-context selection policy: {reason}")
+            }
+            Self::InvalidCandidate {
+                evidence_id,
+                reason,
+            } => write!(formatter, "invalid candidate {evidence_id:?}: {reason}"),
+            Self::ConflictingDuplicate { evidence_id } => write!(
+                formatter,
+                "candidate {evidence_id:?} was supplied with conflicting metadata"
+            ),
+        }
+    }
+}
+
+impl Error for TaskContextError {}
+
+pub(crate) fn parse_task(task: &str) -> Result<ParsedTask, TaskContextError> {
+    if task.len() > MAX_TASK_BYTES {
+        return Err(TaskContextError::TaskTooLarge {
+            actual: task.len(),
+            limit: MAX_TASK_BYTES,
+        });
+    }
+
+    let line_count = if task.is_empty() {
+        0
+    } else {
+        task.as_bytes()
+            .iter()
+            .filter(|byte| **byte == b'\n')
+            .count()
+            + 1
+    };
+    if line_count > MAX_TASK_LINES {
+        return Err(TaskContextError::TooManyLines {
+            actual: line_count,
+            limit: MAX_TASK_LINES,
+        });
+    }
+
+    let mut references = Vec::new();
+    let mut prose = String::new();
+    let mut byte_offset = 0;
+    let mut fence: Option<(u8, usize)> = None;
+
+    for line_with_ending in task.split_inclusive('\n') {
+        let line = line_with_ending
+            .strip_suffix('\n')
+            .unwrap_or(line_with_ending)
+            .strip_suffix('\r')
+            .unwrap_or_else(|| {
+                line_with_ending
+                    .strip_suffix('\n')
+                    .unwrap_or(line_with_ending)
+            });
+        let trimmed = line.trim_start();
+        let fence_marker = fence_run(trimmed);
+
+        match (fence, fence_marker) {
+            (Some((expected, minimum)), Some((actual, length)))
+                if expected == actual && length >= minimum =>
+            {
+                fence = None;
+            }
+            (None, Some(marker)) => {
+                fence = Some(marker);
+            }
+            (Some(_), _) => extract_line_references(
+                line,
+                byte_offset,
+                ReferenceOrigin::CodeFence,
+                &mut references,
+            )?,
+            (None, _) => {
+                prose.push_str(line);
+                prose.push('\n');
+                extract_line_references(
+                    line,
+                    byte_offset,
+                    ReferenceOrigin::Prose,
+                    &mut references,
+                )?;
+            }
+        }
+
+        byte_offset += line_with_ending.len();
+    }
+
+    references.sort_by(|left, right| {
+        left.byte_start
+            .cmp(&right.byte_start)
+            .then_with(|| left.byte_end.cmp(&right.byte_end))
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.normalized.cmp(&right.normalized))
+    });
+
+    let mut seen = BTreeSet::new();
+    references.retain(|reference| {
+        seen.insert((
+            reference.origin,
+            reference.kind,
+            reference.normalized.clone(),
+        ))
+    });
+
+    let (proposal_references, exact_references): (Vec<_>, Vec<_>) = references
+        .into_iter()
+        .partition(|reference| reference.origin == ReferenceOrigin::CodeFence);
+
+    let mut facets = infer_facets(&prose);
+    if !proposal_references.is_empty() || fence.is_some() {
+        facets.insert(TaskFacet::Proposal);
+    }
+
+    Ok(ParsedTask {
+        facets,
+        exact_references,
+        proposal_references,
+    })
+}
+
+fn fence_run(trimmed: &str) -> Option<(u8, usize)> {
+    let marker = *trimmed.as_bytes().first()?;
+    if marker != b'`' && marker != b'~' {
+        return None;
+    }
+    let length = trimmed
+        .as_bytes()
+        .iter()
+        .take_while(|byte| **byte == marker)
+        .count();
+    (length >= 3).then_some((marker, length))
+}
+
+fn extract_line_references(
+    line: &str,
+    byte_offset: usize,
+    origin: ReferenceOrigin,
+    output: &mut Vec<ExactReference>,
+) -> Result<(), TaskContextError> {
+    let mut inline_ranges = Vec::new();
+
+    if origin == ReferenceOrigin::Prose {
+        let bytes = line.as_bytes();
+        let mut cursor = 0;
+        while cursor < bytes.len() {
+            let Some(open_relative) = bytes[cursor..].iter().position(|byte| *byte == b'`') else {
+                break;
+            };
+            let open = cursor + open_relative;
+            let content_start = open + 1;
+            let Some(close_relative) = bytes[content_start..].iter().position(|byte| *byte == b'`')
+            else {
+                break;
+            };
+            let close = content_start + close_relative;
+            let raw = &line[content_start..close];
+            let leading = raw.len() - raw.trim_start().len();
+            let trimmed = raw.trim();
+            if !trimmed.is_empty()
+                && let Some((kind, normalized)) = classify_reference(trimmed, true)
+            {
+                push_reference(
+                    output,
+                    ExactReference {
+                        raw: trimmed.to_owned(),
+                        normalized,
+                        kind,
+                        origin,
+                        byte_start: byte_offset + content_start + leading,
+                        byte_end: byte_offset + content_start + leading + trimmed.len(),
+                    },
+                )?;
+            }
+            inline_ranges.push((open, close + 1));
+            cursor = close + 1;
+        }
+    }
+
+    let mut token_start = None;
+    for (index, character) in line
+        .char_indices()
+        .chain(std::iter::once((line.len(), ' ')))
+    {
+        if index < line.len() && is_reference_token_character(character) {
+            token_start.get_or_insert(index);
+            continue;
+        }
+
+        let Some(start) = token_start.take() else {
+            continue;
+        };
+        if inline_ranges
+            .iter()
+            .any(|(range_start, range_end)| start >= *range_start && start < *range_end)
+        {
+            continue;
+        }
+        let raw = &line[start..index];
+        if let Some((kind, normalized)) = classify_reference(raw, false) {
+            push_reference(
+                output,
+                ExactReference {
+                    raw: raw.to_owned(),
+                    normalized,
+                    kind,
+                    origin,
+                    byte_start: byte_offset + start,
+                    byte_end: byte_offset + index,
+                },
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn push_reference(
+    output: &mut Vec<ExactReference>,
+    reference: ExactReference,
+) -> Result<(), TaskContextError> {
+    if output.len() >= MAX_EXACT_REFERENCES {
+        return Err(TaskContextError::TooManyReferences {
+            limit: MAX_EXACT_REFERENCES,
+        });
+    }
+    output.push(reference);
+    Ok(())
+}
+
+fn is_reference_token_character(character: char) -> bool {
+    character.is_ascii_alphanumeric()
+        || matches!(character, '_' | '-' | '.' | '/' | ':' | '@' | '#')
+}
+
+fn classify_reference(raw: &str, backticked: bool) -> Option<(ExactReferenceKind, String)> {
+    let token = raw.trim_matches(|character: char| {
+        matches!(
+            character,
+            ',' | ';' | '(' | ')' | '[' | ']' | '{' | '}' | '"' | '\''
+        )
+    });
+    if token.is_empty() || token.contains("://") {
+        return None;
+    }
+
+    if let Some(location) = normalize_compiler_location(token) {
+        return Some((ExactReferenceKind::CompilerLocation, location));
+    }
+    if is_repository_path(token) {
+        return Some((
+            ExactReferenceKind::RepositoryPath,
+            token.strip_prefix("./").unwrap_or(token).to_owned(),
+        ));
+    }
+    if is_qualified_name(token) {
+        return Some((ExactReferenceKind::QualifiedName, token.to_owned()));
+    }
+    if is_test_name(token) {
+        return Some((ExactReferenceKind::TestName, token.to_owned()));
+    }
+    if is_identifier(token) && token.contains('_') {
+        return Some((ExactReferenceKind::CodeIdentifier, token.to_owned()));
+    }
+    if backticked && is_identifier(token) {
+        return Some((ExactReferenceKind::BacktickedIdentifier, token.to_owned()));
+    }
+    None
+}
+
+fn normalize_compiler_location(token: &str) -> Option<String> {
+    let parts: Vec<_> = token.split(':').collect();
+    if parts.len() < 2
+        || !parts
+            .last()?
+            .chars()
+            .all(|character| character.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let path_end = if parts.len() >= 3
+        && parts[parts.len() - 2]
+            .chars()
+            .all(|character| character.is_ascii_digit())
+    {
+        parts.len() - 2
+    } else {
+        parts.len() - 1
+    };
+    let path = parts[..path_end].join(":");
+    if !is_repository_path(&path) {
+        return None;
+    }
+    let normalized_path = path.strip_prefix("./").unwrap_or(&path);
+    Some(format!(
+        "{}:{}",
+        normalized_path,
+        parts[path_end..].join(":")
+    ))
+}
+
+fn is_repository_path(token: &str) -> bool {
+    let candidate = token.strip_prefix("./").unwrap_or(token);
+    if candidate.is_empty()
+        || candidate.starts_with('/')
+        || candidate.ends_with('/')
+        || candidate.split('/').any(|segment| segment == "..")
+        || !candidate.contains('/')
+    {
+        return false;
+    }
+    let last = candidate.rsplit('/').next().unwrap_or_default();
+    last.contains('.')
+        || candidate.starts_with("src/")
+        || candidate.starts_with("tests/")
+        || candidate.starts_with("crates/")
+        || candidate.starts_with(".oh/")
+}
+
+fn is_identifier(token: &str) -> bool {
+    let mut characters = token.chars();
+    let Some(first) = characters.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+fn is_qualified_name(token: &str) -> bool {
+    token.contains("::")
+        && token
+            .split("::")
+            .all(|component| !component.is_empty() && is_identifier(component))
+}
+
+fn is_test_name(token: &str) -> bool {
+    is_identifier(token)
+        && (token.starts_with("test_")
+            || token.ends_with("_test")
+            || token.starts_with("should_")
+            || token.starts_with("it_"))
+}
+
+fn infer_facets(prose: &str) -> BTreeSet<TaskFacet> {
+    let normalized = prose.to_ascii_lowercase();
+    let mut facets = BTreeSet::new();
+    if contains_any(
+        &normalized,
+        &[
+            "behavior",
+            "behaviour",
+            "implement",
+            "change",
+            "fix",
+            "support",
+        ],
+    ) {
+        facets.insert(TaskFacet::Behavior);
+    }
+    if contains_any(
+        &normalized,
+        &[" api", "schema", "state", "contract", "interface", "field"],
+    ) {
+        facets.insert(TaskFacet::ApiOrState);
+    }
+    if contains_any(&normalized, &["test", "assert", "verify", "regression"]) {
+        facets.insert(TaskFacet::Test);
+    }
+    if contains_any(
+        &normalized,
+        &[
+            "analogue",
+            "analog",
+            "precedent",
+            "similar",
+            "existing pattern",
+        ],
+    ) {
+        facets.insert(TaskFacet::Analogue);
+    }
+    if contains_any(&normalized, &["proposal", "patch", "diff", "sketch"]) {
+        facets.insert(TaskFacet::Proposal);
+    }
+    facets
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExactCandidate {
+    pub(crate) evidence_id: String,
+    pub(crate) display: String,
+    pub(crate) match_keys: BTreeSet<String>,
+    pub(crate) source_file: String,
+    pub(crate) source_line: Option<u32>,
+}
+
+impl ExactCandidate {
+    pub(crate) fn canonical_match_keys(&self) -> BTreeSet<String> {
+        let mut keys = self
+            .match_keys
+            .iter()
+            .map(|key| normalize_match_key(key))
+            .collect::<BTreeSet<_>>();
+        keys.insert(normalize_match_key(&self.display));
+        keys.insert(normalize_match_key(&self.source_file));
+        if let Some(line) = self.source_line {
+            keys.insert(normalize_match_key(&format!("{}:{line}", self.source_file)));
+        }
+        keys
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ExactResolution {
+    Hit(ExactCandidate),
+    Ambiguous(Vec<ExactCandidate>),
+    Miss,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedExactReference {
+    pub(crate) reference: ExactReference,
+    pub(crate) resolution: ExactResolution,
+}
+
+pub(crate) fn resolve_exact_references(
+    references: &[ExactReference],
+    candidates: &[ExactCandidate],
+) -> Vec<ResolvedExactReference> {
+    let mut canonical_candidates = candidates.to_vec();
+    canonical_candidates.sort_by(|left, right| {
+        left.evidence_id
+            .cmp(&right.evidence_id)
+            .then_with(|| left.display.cmp(&right.display))
+            .then_with(|| left.source_file.cmp(&right.source_file))
+            .then_with(|| left.source_line.cmp(&right.source_line))
+    });
+    canonical_candidates.dedup_by(|left, right| left.evidence_id == right.evidence_id);
+
+    references
+        .iter()
+        .cloned()
+        .map(|reference| {
+            let key = normalize_match_key(&reference.normalized);
+            let matches = canonical_candidates
+                .iter()
+                .filter(|candidate| candidate.canonical_match_keys().contains(&key))
+                .cloned()
+                .collect::<Vec<_>>();
+            let resolution = match matches.as_slice() {
+                [] => ExactResolution::Miss,
+                [candidate] => ExactResolution::Hit(candidate.clone()),
+                _ => ExactResolution::Ambiguous(matches),
+            };
+            ResolvedExactReference {
+                reference,
+                resolution,
+            }
+        })
+        .collect()
+}
+
+fn normalize_match_key(key: &str) -> String {
+    key.trim()
+        .trim_matches('`')
+        .strip_prefix("./")
+        .unwrap_or_else(|| key.trim().trim_matches('`'))
+        .to_owned()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct SourceAnchor {
+    pub(crate) path: String,
+    pub(crate) start_line: u32,
+    pub(crate) end_line: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EvidenceCandidate {
+    pub(crate) evidence_id: String,
+    pub(crate) roles: BTreeSet<ContextRole>,
+    pub(crate) lanes: BTreeSet<RetrievalLane>,
+    pub(crate) facets: BTreeSet<TaskFacet>,
+    pub(crate) rendered_cost: usize,
+    /// Present only when this record is an unambiguous exact-reference hit.
+    pub(crate) exact_reference: Option<String>,
+    pub(crate) source: SourceAnchor,
+    /// Rank inside the candidate's retrieval channel. Lower is better.
+    pub(crate) channel_rank: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SelectionPolicy {
+    pub(crate) rendered_budget: usize,
+    pub(crate) per_record_limit: usize,
+    pub(crate) candidate_limit: usize,
+    pub(crate) per_file_limit: usize,
+    /// Maximum non-dominated states retained by the exact selector. The
+    /// selector rejects the request instead of truncating this frontier.
+    pub(crate) state_limit: usize,
+    pub(crate) required_roles: BTreeSet<ContextRole>,
+}
+
+impl Default for SelectionPolicy {
+    fn default() -> Self {
+        Self {
+            rendered_budget: 32 * 1024,
+            per_record_limit: 16 * 1024,
+            candidate_limit: MAX_SELECTION_CANDIDATES,
+            per_file_limit: 4,
+            state_limit: 1_024,
+            required_roles: BTreeSet::from([
+                ContextRole::EditableSource,
+                ContextRole::DefinitionOrApiState,
+                ContextRole::Test,
+                ContextRole::BehavioralAnalogue,
+            ]),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SelectionReason {
+    ExactReference {
+        reference: String,
+    },
+    CoveragePerCost {
+        newly_covered_roles: BTreeSet<ContextRole>,
+        newly_covered_lanes: BTreeSet<RetrievalLane>,
+        newly_covered_facets: BTreeSet<TaskFacet>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SelectedEvidence {
+    pub(crate) evidence_id: String,
+    pub(crate) reason: SelectionReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum OmissionReason {
+    ExactRecordTooLarge,
+    ExactBudgetExhausted,
+    RecordTooLarge,
+    BudgetExhausted,
+    PerFileLimit,
+    NoMarginalCoverage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OmittedEvidence {
+    pub(crate) evidence_id: String,
+    pub(crate) reason: OmissionReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ContextSelection {
+    pub(crate) selected: Vec<SelectedEvidence>,
+    pub(crate) omitted: Vec<OmittedEvidence>,
+    pub(crate) rendered_cost: usize,
+    pub(crate) covered_roles: BTreeSet<ContextRole>,
+    pub(crate) missing_roles: BTreeSet<ContextRole>,
+    pub(crate) covered_lanes: BTreeSet<RetrievalLane>,
+    pub(crate) covered_facets: BTreeSet<TaskFacet>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CoverageGain {
+    roles: BTreeSet<ContextRole>,
+    lanes: BTreeSet<RetrievalLane>,
+    facets: BTreeSet<TaskFacet>,
+}
+
+pub(crate) fn select_context(
+    candidates: Vec<EvidenceCandidate>,
+    policy: &SelectionPolicy,
+) -> Result<ContextSelection, TaskContextError> {
+    validate_policy(policy)?;
+    if candidates.len() > policy.candidate_limit {
+        return Err(TaskContextError::TooManyCandidates {
+            actual: candidates.len(),
+            limit: policy.candidate_limit,
+        });
+    }
+
+    let candidates = canonicalize_candidates(candidates)?;
+    let mut selected = Vec::new();
+    let mut omitted = Vec::new();
+    let mut selected_ids = BTreeSet::new();
+    let mut omitted_ids = BTreeSet::new();
+    let mut covered_roles = BTreeSet::new();
+    let mut covered_lanes = BTreeSet::new();
+    let mut covered_facets = BTreeSet::new();
+    let mut file_counts = BTreeMap::<String, usize>::new();
+    let mut rendered_cost = 0usize;
+
+    let mut exact = candidates
+        .values()
+        .filter(|candidate| candidate.exact_reference.is_some())
+        .collect::<Vec<_>>();
+    exact.sort_by(|left, right| {
+        left.exact_reference
+            .cmp(&right.exact_reference)
+            .then_with(|| left.evidence_id.cmp(&right.evidence_id))
+    });
+
+    for candidate in exact {
+        let reason = if candidate.rendered_cost > policy.per_record_limit {
+            Some(OmissionReason::ExactRecordTooLarge)
+        } else if rendered_cost + candidate.rendered_cost > policy.rendered_budget {
+            Some(OmissionReason::ExactBudgetExhausted)
+        } else {
+            None
+        };
+        if let Some(reason) = reason {
+            omitted_ids.insert(candidate.evidence_id.clone());
+            omitted.push(OmittedEvidence {
+                evidence_id: candidate.evidence_id.clone(),
+                reason,
+            });
+            continue;
+        }
+
+        rendered_cost += candidate.rendered_cost;
+        selected_ids.insert(candidate.evidence_id.clone());
+        *file_counts
+            .entry(candidate.source.path.clone())
+            .or_default() += 1;
+        covered_roles.extend(candidate.roles.iter().copied());
+        covered_lanes.extend(candidate.lanes.iter().copied());
+        covered_facets.extend(candidate.facets.iter().copied());
+        selected.push(SelectedEvidence {
+            evidence_id: candidate.evidence_id.clone(),
+            reason: SelectionReason::ExactReference {
+                reference: candidate.exact_reference.clone().unwrap_or_default(),
+            },
+        });
+    }
+
+    let eligible = candidates
+        .values()
+        .filter(|candidate| {
+            candidate.exact_reference.is_none()
+                && candidate.rendered_cost <= policy.per_record_limit
+        })
+        .collect::<Vec<_>>();
+    let mut frontier = vec![SelectionState {
+        selected_ids: Vec::new(),
+        rendered_cost,
+        role_mask: role_mask(&covered_roles, &policy.required_roles),
+        lane_mask: lane_mask(&covered_lanes),
+        facet_mask: facet_mask(&covered_facets),
+        file_counts: file_counts.clone(),
+        channel_rank_sum: 0,
+    }];
+    let initially_relevant_files = eligible
+        .iter()
+        .map(|candidate| candidate.source.path.clone())
+        .collect::<BTreeSet<_>>();
+    frontier[0]
+        .file_counts
+        .retain(|path, _| initially_relevant_files.contains(path));
+
+    // This is an exact, bounded dynamic program rather than a greedy pass.
+    // States are the Pareto frontier of coverage, cost, rank, and future
+    // per-file capacity. If that frontier cannot be represented within the
+    // caller's cap, selection fails closed instead of silently becoming
+    // approximate or input-order dependent.
+    for (index, candidate) in eligible.iter().enumerate() {
+        let mut expanded = Vec::with_capacity(frontier.len().saturating_mul(2));
+        for state in &frontier {
+            expanded.push(state.clone());
+            if state.rendered_cost + candidate.rendered_cost > policy.rendered_budget
+                || state
+                    .file_counts
+                    .get(&candidate.source.path)
+                    .copied()
+                    .unwrap_or(0)
+                    >= policy.per_file_limit
+            {
+                continue;
+            }
+
+            let candidate_role_mask = role_mask(&candidate.roles, &policy.required_roles);
+            let candidate_lane_mask = lane_mask(&candidate.lanes);
+            let candidate_facet_mask = facet_mask(&candidate.facets);
+            if candidate_role_mask & !state.role_mask == 0
+                && candidate_lane_mask & !state.lane_mask == 0
+                && candidate_facet_mask & !state.facet_mask == 0
+            {
+                continue;
+            }
+
+            let mut added = state.clone();
+            added.rendered_cost += candidate.rendered_cost;
+            added.role_mask |= candidate_role_mask;
+            added.lane_mask |= candidate_lane_mask;
+            added.facet_mask |= candidate_facet_mask;
+            *added
+                .file_counts
+                .entry(candidate.source.path.clone())
+                .or_default() += 1;
+            added.channel_rank_sum += u64::from(candidate.channel_rank);
+            added.selected_ids.push(candidate.evidence_id.clone());
+            expanded.push(added);
+        }
+
+        // Counts for files with no remaining candidates cannot constrain a
+        // future decision. Forgetting them is exact and prevents irrelevant
+        // file identities from inflating the Pareto frontier.
+        let active_files = eligible[index + 1..]
+            .iter()
+            .map(|candidate| candidate.source.path.clone())
+            .collect::<BTreeSet<_>>();
+        for state in &mut expanded {
+            state
+                .file_counts
+                .retain(|path, _| active_files.contains(path));
+        }
+        frontier = pareto_frontier(expanded);
+        if frontier.len() > policy.state_limit {
+            return Err(TaskContextError::SelectionStateLimitExceeded {
+                actual: frontier.len(),
+                limit: policy.state_limit,
+            });
+        }
+    }
+
+    let best = frontier
+        .into_iter()
+        .max_by(selection_state_cmp)
+        .expect("selection frontier always contains the empty state");
+    for evidence_id in best.selected_ids {
+        let candidate = candidates
+            .get(&evidence_id)
+            .expect("selected evidence came from the canonical candidate map");
+        let gain = coverage_gain(
+            candidate,
+            policy,
+            &covered_roles,
+            &covered_lanes,
+            &covered_facets,
+        );
+        rendered_cost += candidate.rendered_cost;
+        selected_ids.insert(candidate.evidence_id.clone());
+        *file_counts
+            .entry(candidate.source.path.clone())
+            .or_default() += 1;
+        covered_roles.extend(candidate.roles.iter().copied());
+        covered_lanes.extend(candidate.lanes.iter().copied());
+        covered_facets.extend(candidate.facets.iter().copied());
+        selected.push(SelectedEvidence {
+            evidence_id: candidate.evidence_id.clone(),
+            reason: SelectionReason::CoveragePerCost {
+                newly_covered_roles: gain.roles,
+                newly_covered_lanes: gain.lanes,
+                newly_covered_facets: gain.facets,
+            },
+        });
+    }
+
+    for candidate in candidates.values() {
+        if selected_ids.contains(&candidate.evidence_id)
+            || omitted_ids.contains(&candidate.evidence_id)
+        {
+            continue;
+        }
+        let reason = if candidate.rendered_cost > policy.per_record_limit {
+            OmissionReason::RecordTooLarge
+        } else if rendered_cost + candidate.rendered_cost > policy.rendered_budget {
+            OmissionReason::BudgetExhausted
+        } else if candidate.exact_reference.is_none()
+            && file_counts
+                .get(&candidate.source.path)
+                .copied()
+                .unwrap_or(0)
+                >= policy.per_file_limit
+        {
+            OmissionReason::PerFileLimit
+        } else {
+            OmissionReason::NoMarginalCoverage
+        };
+        omitted.push(OmittedEvidence {
+            evidence_id: candidate.evidence_id.clone(),
+            reason,
+        });
+    }
+    omitted.sort_by(|left, right| left.evidence_id.cmp(&right.evidence_id));
+
+    let missing_roles = policy
+        .required_roles
+        .difference(&covered_roles)
+        .copied()
+        .collect();
+    Ok(ContextSelection {
+        selected,
+        omitted,
+        rendered_cost,
+        covered_roles,
+        missing_roles,
+        covered_lanes,
+        covered_facets,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SelectionState {
+    selected_ids: Vec<String>,
+    rendered_cost: usize,
+    role_mask: u16,
+    lane_mask: u16,
+    facet_mask: u8,
+    file_counts: BTreeMap<String, usize>,
+    channel_rank_sum: u64,
+}
+
+fn role_bit(role: ContextRole) -> u16 {
+    1 << match role {
+        ContextRole::EditableSource => 0,
+        ContextRole::DefinitionOrApiState => 1,
+        ContextRole::Test => 2,
+        ContextRole::BehavioralAnalogue => 3,
+        ContextRole::DirectDependency => 4,
+        ContextRole::CallerOrImpact => 5,
+        ContextRole::ProposalDelta => 6,
+    }
+}
+
+fn lane_bit(lane: RetrievalLane) -> u16 {
+    1 << match lane {
+        RetrievalLane::ExactReference => 0,
+        RetrievalLane::EditableSource => 1,
+        RetrievalLane::DefinitionOrState => 2,
+        RetrievalLane::Tests => 3,
+        RetrievalLane::Analogues => 4,
+        RetrievalLane::Dependencies => 5,
+        RetrievalLane::GraphImpact => 6,
+        RetrievalLane::ProposalDelta => 7,
+    }
+}
+
+fn facet_bit(facet: TaskFacet) -> u8 {
+    1 << match facet {
+        TaskFacet::Behavior => 0,
+        TaskFacet::ApiOrState => 1,
+        TaskFacet::Test => 2,
+        TaskFacet::Analogue => 3,
+        TaskFacet::Proposal => 4,
+    }
+}
+
+fn role_mask(roles: &BTreeSet<ContextRole>, required_roles: &BTreeSet<ContextRole>) -> u16 {
+    roles
+        .intersection(required_roles)
+        .fold(0, |mask, role| mask | role_bit(*role))
+}
+
+fn lane_mask(lanes: &BTreeSet<RetrievalLane>) -> u16 {
+    lanes.iter().fold(0, |mask, lane| mask | lane_bit(*lane))
+}
+
+fn facet_mask(facets: &BTreeSet<TaskFacet>) -> u8 {
+    facets
+        .iter()
+        .fold(0, |mask, facet| mask | facet_bit(*facet))
+}
+
+fn selection_state_value(state: &SelectionState) -> u32 {
+    state.role_mask.count_ones() * 64
+        + state.facet_mask.count_ones() * 4
+        + state.lane_mask.count_ones() * 2
+}
+
+fn selection_state_cmp(left: &SelectionState, right: &SelectionState) -> Ordering {
+    selection_state_value(left)
+        .cmp(&selection_state_value(right))
+        .then_with(|| right.rendered_cost.cmp(&left.rendered_cost))
+        .then_with(|| right.channel_rank_sum.cmp(&left.channel_rank_sum))
+        .then_with(|| right.selected_ids.cmp(&left.selected_ids))
+}
+
+fn file_capacity_no_worse(left: &BTreeMap<String, usize>, right: &BTreeMap<String, usize>) -> bool {
+    left.iter()
+        .all(|(path, count)| *count <= right.get(path).copied().unwrap_or(0))
+}
+
+fn state_dominates(left: &SelectionState, right: &SelectionState) -> bool {
+    let coverage_no_worse = left.role_mask | right.role_mask == left.role_mask
+        && left.lane_mask | right.lane_mask == left.lane_mask
+        && left.facet_mask | right.facet_mask == left.facet_mask;
+    let resources_no_worse = left.rendered_cost <= right.rendered_cost
+        && left.channel_rank_sum <= right.channel_rank_sum
+        && file_capacity_no_worse(&left.file_counts, &right.file_counts);
+    if !coverage_no_worse || !resources_no_worse {
+        return false;
+    }
+
+    left.role_mask != right.role_mask
+        || left.lane_mask != right.lane_mask
+        || left.facet_mask != right.facet_mask
+        || left.rendered_cost != right.rendered_cost
+        || left.channel_rank_sum != right.channel_rank_sum
+        || left.file_counts != right.file_counts
+        || left.selected_ids <= right.selected_ids
+}
+
+fn pareto_frontier(mut states: Vec<SelectionState>) -> Vec<SelectionState> {
+    states.sort_by(|left, right| selection_state_cmp(right, left));
+    let mut frontier = Vec::<SelectionState>::new();
+    for candidate in states {
+        if frontier
+            .iter()
+            .any(|existing| state_dominates(existing, &candidate))
+        {
+            continue;
+        }
+        frontier.retain(|existing| !state_dominates(&candidate, existing));
+        frontier.push(candidate);
+    }
+    frontier.sort_by(|left, right| selection_state_cmp(right, left));
+    frontier
+}
+
+fn validate_policy(policy: &SelectionPolicy) -> Result<(), TaskContextError> {
+    if policy.rendered_budget == 0 || policy.rendered_budget > MAX_RENDERED_BUDGET {
+        return Err(TaskContextError::InvalidSelectionPolicy(
+            "rendered_budget must be within the hard service limit",
+        ));
+    }
+    if policy.per_record_limit == 0 || policy.per_record_limit > policy.rendered_budget {
+        return Err(TaskContextError::InvalidSelectionPolicy(
+            "per_record_limit must be non-zero and no larger than rendered_budget",
+        ));
+    }
+    if policy.candidate_limit == 0 || policy.candidate_limit > MAX_SELECTION_CANDIDATES {
+        return Err(TaskContextError::InvalidSelectionPolicy(
+            "candidate_limit must be within the hard service limit",
+        ));
+    }
+    if policy.per_file_limit == 0 || policy.per_file_limit > policy.candidate_limit {
+        return Err(TaskContextError::InvalidSelectionPolicy(
+            "per_file_limit must be non-zero and no larger than candidate_limit",
+        ));
+    }
+    if policy.state_limit == 0 || policy.state_limit > HARD_MAX_SELECTION_STATES {
+        return Err(TaskContextError::InvalidSelectionPolicy(
+            "state_limit must be within the hard service limit",
+        ));
+    }
+    Ok(())
+}
+
+fn canonicalize_candidates(
+    candidates: Vec<EvidenceCandidate>,
+) -> Result<BTreeMap<String, EvidenceCandidate>, TaskContextError> {
+    let mut canonical = BTreeMap::new();
+    for candidate in candidates {
+        if candidate.evidence_id.trim().is_empty() {
+            return Err(TaskContextError::InvalidCandidate {
+                evidence_id: candidate.evidence_id,
+                reason: "evidence_id must not be empty",
+            });
+        }
+        if candidate.rendered_cost == 0 {
+            return Err(TaskContextError::InvalidCandidate {
+                evidence_id: candidate.evidence_id,
+                reason: "rendered_cost must be non-zero",
+            });
+        }
+        if candidate.source.path.trim().is_empty()
+            || candidate.source.start_line == 0
+            || candidate.source.end_line < candidate.source.start_line
+        {
+            return Err(TaskContextError::InvalidCandidate {
+                evidence_id: candidate.evidence_id,
+                reason: "source anchor must name a path and a valid one-based line range",
+            });
+        }
+        match canonical.get(&candidate.evidence_id) {
+            Some(existing) if existing != &candidate => {
+                return Err(TaskContextError::ConflictingDuplicate {
+                    evidence_id: candidate.evidence_id,
+                });
+            }
+            Some(_) => {}
+            None => {
+                canonical.insert(candidate.evidence_id.clone(), candidate);
+            }
+        }
+    }
+    Ok(canonical)
+}
+
+fn coverage_gain(
+    candidate: &EvidenceCandidate,
+    policy: &SelectionPolicy,
+    covered_roles: &BTreeSet<ContextRole>,
+    covered_lanes: &BTreeSet<RetrievalLane>,
+    covered_facets: &BTreeSet<TaskFacet>,
+) -> CoverageGain {
+    CoverageGain {
+        roles: candidate
+            .roles
+            .intersection(&policy.required_roles)
+            .filter(|role| !covered_roles.contains(role))
+            .copied()
+            .collect(),
+        lanes: candidate.lanes.difference(covered_lanes).copied().collect(),
+        facets: candidate
+            .facets
+            .difference(covered_facets)
+            .copied()
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set<T: Ord>(values: impl IntoIterator<Item = T>) -> BTreeSet<T> {
+        values.into_iter().collect()
+    }
+
+    fn candidate(
+        id: &str,
+        cost: usize,
+        roles: impl IntoIterator<Item = ContextRole>,
+        lanes: impl IntoIterator<Item = RetrievalLane>,
+    ) -> EvidenceCandidate {
+        EvidenceCandidate {
+            evidence_id: id.to_owned(),
+            roles: set(roles),
+            lanes: set(lanes),
+            facets: set([TaskFacet::Behavior]),
+            rendered_cost: cost,
+            exact_reference: None,
+            source: SourceAnchor {
+                path: format!("src/{id}.rs"),
+                start_line: 1,
+                end_line: 3,
+            },
+            channel_rank: 0,
+        }
+    }
+
+    #[test]
+    fn parser_keeps_proposal_tokens_out_of_exact_pins() {
+        let parsed = parse_task(
+            "Fix `service::search` in src/service/search.rs:42 and add a regression test.\n\
+             ```rust\n\
+             fn proposed_helper() { service::future(); }\n\
+             ```",
+        )
+        .unwrap();
+
+        assert!(
+            parsed
+                .exact_references
+                .iter()
+                .any(|reference| reference.normalized == "service::search")
+        );
+        assert!(
+            parsed
+                .exact_references
+                .iter()
+                .any(|reference| reference.normalized == "src/service/search.rs:42")
+        );
+        assert!(
+            parsed
+                .proposal_references
+                .iter()
+                .any(|reference| reference.normalized == "proposed_helper")
+        );
+        assert!(parsed.facets.contains(&TaskFacet::Test));
+        assert!(parsed.facets.contains(&TaskFacet::Proposal));
+    }
+
+    #[test]
+    fn exact_resolution_distinguishes_hit_ambiguity_and_miss() {
+        let references = ["only_one", "shared_name", "missing_name"]
+            .into_iter()
+            .enumerate()
+            .map(|(index, name)| ExactReference {
+                raw: name.to_owned(),
+                normalized: name.to_owned(),
+                kind: ExactReferenceKind::CodeIdentifier,
+                origin: ReferenceOrigin::Prose,
+                byte_start: index,
+                byte_end: index + name.len(),
+            })
+            .collect::<Vec<_>>();
+        let candidates = [
+            ("a", "only_one"),
+            ("b", "shared_name"),
+            ("c", "shared_name"),
+        ]
+        .into_iter()
+        .map(|(id, key)| ExactCandidate {
+            evidence_id: id.to_owned(),
+            display: key.to_owned(),
+            match_keys: BTreeSet::new(),
+            source_file: format!("src/{id}.rs"),
+            source_line: Some(1),
+        })
+        .collect::<Vec<_>>();
+
+        let resolved = resolve_exact_references(&references, &candidates);
+        assert!(matches!(resolved[0].resolution, ExactResolution::Hit(_)));
+        assert!(matches!(
+            resolved[1].resolution,
+            ExactResolution::Ambiguous(ref matches) if matches.len() == 2
+        ));
+        assert_eq!(resolved[2].resolution, ExactResolution::Miss);
+    }
+
+    #[test]
+    fn selection_is_invariant_to_candidate_order() {
+        let policy = SelectionPolicy {
+            rendered_budget: 16,
+            per_record_limit: 16,
+            candidate_limit: 16,
+            per_file_limit: 2,
+            state_limit: 128,
+            required_roles: set([
+                ContextRole::EditableSource,
+                ContextRole::Test,
+                ContextRole::BehavioralAnalogue,
+            ]),
+        };
+        let candidates = vec![
+            candidate(
+                "multi",
+                8,
+                [ContextRole::EditableSource, ContextRole::Test],
+                [RetrievalLane::EditableSource, RetrievalLane::Tests],
+            ),
+            candidate(
+                "analogue",
+                4,
+                [ContextRole::BehavioralAnalogue],
+                [RetrievalLane::Analogues],
+            ),
+            candidate("decoy", 15, [], [RetrievalLane::Dependencies]),
+        ];
+        let forward = select_context(candidates.clone(), &policy).unwrap();
+        let reverse = select_context(candidates.into_iter().rev().collect(), &policy).unwrap();
+
+        assert_eq!(forward, reverse);
+        assert!(forward.missing_roles.is_empty());
+        assert_eq!(
+            forward
+                .selected
+                .iter()
+                .map(|evidence| evidence.evidence_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["analogue", "multi"]
+        );
+    }
+
+    #[test]
+    fn exact_hits_are_pinned_before_coverage_candidates() {
+        let policy = SelectionPolicy {
+            rendered_budget: 10,
+            per_record_limit: 10,
+            candidate_limit: 8,
+            per_file_limit: 1,
+            state_limit: 128,
+            required_roles: set([ContextRole::EditableSource]),
+        };
+        let mut exact = candidate("exact", 7, [], [RetrievalLane::ExactReference]);
+        exact.exact_reference = Some("src/exact.rs".to_owned());
+        let high_coverage = candidate(
+            "coverage",
+            5,
+            [ContextRole::EditableSource],
+            [RetrievalLane::EditableSource],
+        );
+
+        let selection = select_context(vec![high_coverage, exact], &policy).unwrap();
+        assert_eq!(selection.selected[0].evidence_id, "exact");
+        assert_eq!(selection.rendered_cost, 7);
+        assert!(
+            selection
+                .omitted
+                .iter()
+                .any(|omission| omission.evidence_id == "coverage"
+                    && omission.reason == OmissionReason::BudgetExhausted)
+        );
+    }
+
+    #[test]
+    fn oversized_records_are_visible_omissions() {
+        let policy = SelectionPolicy {
+            rendered_budget: 10,
+            per_record_limit: 5,
+            candidate_limit: 8,
+            per_file_limit: 2,
+            state_limit: 128,
+            required_roles: set([ContextRole::Test]),
+        };
+        let selection = select_context(
+            vec![candidate(
+                "giant",
+                6,
+                [ContextRole::Test],
+                [RetrievalLane::Tests],
+            )],
+            &policy,
+        )
+        .unwrap();
+
+        assert!(selection.selected.is_empty());
+        assert_eq!(selection.omitted[0].reason, OmissionReason::RecordTooLarge);
+        assert_eq!(selection.missing_roles, set([ContextRole::Test]));
+    }
+
+    #[test]
+    fn pareto_selector_finds_maximum_role_coverage_that_greedy_misses() {
+        let policy = SelectionPolicy {
+            rendered_budget: 6,
+            per_record_limit: 6,
+            candidate_limit: 8,
+            per_file_limit: 2,
+            state_limit: 128,
+            required_roles: set([
+                ContextRole::EditableSource,
+                ContextRole::DefinitionOrApiState,
+                ContextRole::Test,
+                ContextRole::BehavioralAnalogue,
+            ]),
+        };
+        let candidates = vec![
+            candidate(
+                "broad",
+                4,
+                [
+                    ContextRole::EditableSource,
+                    ContextRole::DefinitionOrApiState,
+                    ContextRole::Test,
+                ],
+                [RetrievalLane::EditableSource],
+            ),
+            candidate(
+                "left",
+                3,
+                [
+                    ContextRole::EditableSource,
+                    ContextRole::DefinitionOrApiState,
+                ],
+                [RetrievalLane::EditableSource],
+            ),
+            candidate(
+                "right",
+                3,
+                [ContextRole::Test, ContextRole::BehavioralAnalogue],
+                [RetrievalLane::Analogues],
+            ),
+        ];
+
+        let selection = select_context(candidates, &policy).unwrap();
+        assert_eq!(
+            selection
+                .selected
+                .iter()
+                .map(|evidence| evidence.evidence_id.as_str())
+                .collect::<Vec<_>>(),
+            ["left", "right"]
+        );
+        assert!(selection.missing_roles.is_empty());
+    }
+
+    #[test]
+    fn selector_fails_closed_when_pareto_frontier_exceeds_cap() {
+        let policy = SelectionPolicy {
+            rendered_budget: 8,
+            per_record_limit: 8,
+            candidate_limit: 8,
+            per_file_limit: 2,
+            state_limit: 1,
+            required_roles: set([ContextRole::Test]),
+        };
+        let result = select_context(
+            vec![candidate(
+                "test",
+                1,
+                [ContextRole::Test],
+                [RetrievalLane::Tests],
+            )],
+            &policy,
+        );
+
+        assert_eq!(
+            result,
+            Err(TaskContextError::SelectionStateLimitExceeded {
+                actual: 2,
+                limit: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn graph_only_evidence_can_satisfy_an_impact_role() {
+        let policy = SelectionPolicy {
+            rendered_budget: 8,
+            per_record_limit: 8,
+            candidate_limit: 8,
+            per_file_limit: 2,
+            state_limit: 32,
+            required_roles: set([ContextRole::CallerOrImpact]),
+        };
+        let selection = select_context(
+            vec![candidate(
+                "graph-impact",
+                2,
+                [ContextRole::CallerOrImpact],
+                [RetrievalLane::GraphImpact],
+            )],
+            &policy,
+        )
+        .unwrap();
+
+        assert_eq!(selection.selected[0].evidence_id, "graph-impact");
+        assert_eq!(selection.covered_lanes, set([RetrievalLane::GraphImpact]));
+        assert!(selection.missing_roles.is_empty());
+    }
+
+    #[test]
+    fn one_source_span_can_cover_multiple_roles_without_duplication() {
+        let policy = SelectionPolicy {
+            rendered_budget: 8,
+            per_record_limit: 8,
+            candidate_limit: 8,
+            per_file_limit: 2,
+            state_limit: 32,
+            required_roles: set([ContextRole::EditableSource, ContextRole::Test]),
+        };
+        let selection = select_context(
+            vec![candidate(
+                "multi-role",
+                2,
+                [ContextRole::EditableSource, ContextRole::Test],
+                [RetrievalLane::EditableSource, RetrievalLane::Tests],
+            )],
+            &policy,
+        )
+        .unwrap();
+
+        assert_eq!(selection.selected.len(), 1);
+        assert!(matches!(
+            &selection.selected[0].reason,
+            SelectionReason::CoveragePerCost {
+                newly_covered_roles,
+                ..
+            } if newly_covered_roles
+                == &set([ContextRole::EditableSource, ContextRole::Test])
+        ));
+    }
+}

--- a/src/smoke_test.rs
+++ b/src/smoke_test.rs
@@ -2001,6 +2001,7 @@ async fn run_impact_output_size_check(index: &GraphIndex, nodes: &[Node]) -> Che
         include_body: false,
         minify_body: false,
         verbose: false,
+        ..Default::default()
     };
 
     let output = crate::service::search(&params, &ctx).await;


### PR DESCRIPTION
Closes #810
Closes #811
Closes #812
Closes #813
Closes #814

## Aim
Coding agents receive compact, source-grounded, role-complete repository context per token, with stable evidence handles and an optional pre-edit risk view, instead of spending context on duplicated source and audit internals.

## Problem
The current unified-search pipeline conflates action context with audit evidence, can render overlapping source repeatedly, combines ranking signals with incompatible scales, and selects a flat top-k rather than covering distinct implementation obligations. Proposed edits also lack a bounded counterfactual graph view. These concerns share the same SearchParams, selection, projection, and CLI/MCP delivery seams; serial PRs would repeatedly churn and compile the same contracts.

## Chosen solution
Implement one layered shared-service contract in this PR:

1. Deterministic agent versus evidence projections with final rendered-cost accounting and stable hydration handles.
2. A source-span planner that coalesces overlapping bytes and enforces explicit body/budget policies.
3. Deterministic rank-based calibrated fusion with channel provenance and scale-invariance tests.
4. An opt-in task/edit context mode with exact-first, role-specific retrieval lanes and coverage-per-cost selection.
5. An explicit opt-in beta graph-delta overlay/card that never mutates the graph or ordinary search defaults.

CLI and MCP remain thin adapters over the shared service. Frozen #779 packets/protocol are unchanged. Development uses focused checks; the stabilized batch receives one full test/CI cycle, one consolidated remediation batch, and the mandatory fresh final-diff approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent vs evidence search projections with role-aware task-context controls (`task` and opt-in `graph-delta-beta`) plus proposal-driven graph delta analysis.
  * Added “observed” search results with execution/mode provenance.
  * Exposed new CLI and MCP flags for projections, task context, and output/body budgeting caps.
* **Bug Fixes**
  * MCP `search` now rejects unknown request fields and enforces strict request/contract behavior more consistently.
  * Improved result rendering to be validated as markdown in integrations.
* **Documentation**
  * Updated README and added `docs/search-context.md` for projections, rendered-cost semantics, and opt-in modes.
* **Tests**
  * Strengthened smoke/integration checks for budgeting/truncation, role delivery, deterministic graph-delta invariants, and evidence hydration/renders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->