### PR TITLE
Pilot non-oracle SWE-bench context treatments on development cases

### DIFF
--- a/.oh/sessions/816-dev.md
+++ b/.oh/sessions/816-dev.md
@@ -52,6 +52,35 @@ Select a non-oracle RNA treatment for #817 using a fixed development screen: bar
 - Neither registered C+ graph-delta query reached a revision packet. The exact 13398 diff creates a new file, which #814 rejects in unified-diff form; the 14096 audit required 181,236 bytes/45,299 tokens, exceeding the 160,000/40,000 raw cap. Both v1 failures remain immutable and no model saw their output.
 - The issue's single consolidated remediation freezes a lossless structured-proposal encoding for both exact diffs and raises only the out-of-band audit cap to 256,000/64,000. Model-visible body budgets, novelty rules, revision budget, timeout, and no-retry policy remain unchanged.
 
+### C+ fail-closed outcome
+
+- Both registered v2 graph-delta queries ran exactly once. The 13398 result exceeded the registered non-body render envelope; the 14096 result rendered but the freezer rejected ordinary bounded-truncation markers. No revision prompt, revision model call, or revised patch exists.
+- The immutable infrastructure-failure summary SHA-256 is `d4258b84c51f1471aa1d3a05f27e30739c18141f5673221f25665c211a4f76f9`.
+- The last initial C+ patches were evaluated once only as diagnostics. They are not completed C+ episodes and are excluded from selection.
+
+### Official evaluator
+
+- A fresh reviewer approved evaluator script `d71f2f8bd417180ae7448107fb9a7678b6ea241d84c93ac478d86c3dd07cd7b4` and plan `a745867b03a3ff073fbc047d243a758882e8af7821c62265b7f51e22917b0e78`.
+- The batch authorized, started, and recorded 4/4 evaluations with zero infrastructure failures, two-way cross-case parallelism, same-case serialization, and no remaining containers.
+- Batch receipt SHA-256: `1596abcdba68f6c52488c83cd638b49c277b966f50e43ae2d7518ceef6a928d2`.
+
+### Results and registered decision
+
+- 13398: A, B, and the diagnostic initial C+ patch all remained unresolved at 0/4 FAIL_TO_PASS and 63/68 PASS_TO_PASS (the same five regressions).
+- 14096: A, B, and the diagnostic initial C+ patch all resolved at 1/1 FAIL_TO_PASS and 426/426 PASS_TO_PASS.
+- Eligible A and B therefore tied on resolution and regression preservation. A won the third registered criterion: 10,677,364 versus 14,004,672 total tokens. The registered decision is `A / no_rna_treatment`.
+- Final aggregation manifest SHA-256: `c6d0f89852e6b6767c20af4b5925f5f8e9f2c83639d4d0e857ebda26e5549f64`; report SHA-256: `120aeb81d61c9287e45c1f9d6a048c2eea773b160211fbbe271e0d6de51f03a5`.
+
+### Manipulation check
+
+- RNA packets were present byte-for-byte in both B prompts, but neither assistant transcript cited the supplied context or stable identities.
+- 13398 B began with filesystem discovery and repeated substantially the same localization sequence as A; only 2/4 packet files were explicit Read targets.
+- 14096 B's 57,242-byte packet omitted `SkyCoord.__getattr__`. A and B both began by grepping that symbol, reading `sky_coordinate.py`, and constructing nearly the same reproducer.
+- Tool-use parsing confirms the convergence: 14096 A/B made eleven/ten Grep/rg calls, while 13398 A/B made 102/98 total tool calls and both began with filesystem frame discovery. Neither B run called RNA directly. The immutable uptake audit SHA-256 is `8be7f475a2c98bf4abf5c53149934f9a44d6c696239d9f1e292cf3c1102f6e55`.
+- The evaluator reports are byte-identical between A and B for each case, but model usage is not: B used 1,609,115 more tokens on 13398 and 1,718,193 more on 14096. The record distinguishes outcome identity from usage identity explicitly.
+- The current Claude CLI harness used `--safe-mode` plus an empty strict MCP configuration. That disabled MCP/hooks, and the treatment neither exposed an RNA MCP tool nor directed an RNA CLI workflow through Bash; B was passive packet injection rather than an RNA-directed tool-use policy.
+- The conclusion is therefore narrow: the registered passive treatment loses. It is not evidence that an actively enforced RNA-first navigation policy is ineffective.
+
 ## RNA Tool Friction Log
 
 | Phase | Tool | What happened | Workaround | Severity |
@@ -61,4 +90,4 @@ Select a non-oracle RNA treatment for #817 using a fixed development screen: bar
 
 ## Current gate
 
-Run the two registered amended C+ delta constructions once, freeze their proposal-dependent packets, and perform one same-session revision per C+ arm. Then evaluate each B/C+ terminal patch exactly once through the independently reviewed evaluator harness.
+Record the immutable development-screen result and complete the #816 ship gate. #817 is not authorized by this result because no eligible RNA treatment was selected; any active RNA-tool policy requires a separately preregistered development trial before #817 can start.

--- a/.oh/sessions/816-dev.md
+++ b/.oh/sessions/816-dev.md
@@ -1,0 +1,56 @@
+---
+session: "816-dev"
+artifact_type: session
+issue: 816
+outcome: context-assembly
+updated: 2026-07-22
+---
+
+# Dev Pipeline — non-oracle SWE-bench treatment screen
+
+**Issue:** #816
+
+**Branch:** `issue/816`
+
+**Draft PR:** #824
+
+**Evidence root:** `/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z`
+
+## Aim
+
+Select a non-oracle RNA treatment for #817 using a fixed development screen: bare control A, strict semantic acquisition B, and semantic plus typed graph boundaries plus one bounded revision C+. Preserve every failure and exclude all development cases from confirmation.
+
+## Frozen framing
+
+- No oracle arm and no manual or LLM retrieval fallback.
+- A, B, and C+ share model, checkout, base agent policy, visible tools, hidden-evaluator boundary, and terminal evaluation rule.
+- C+ alone receives one registered proposal-dependent graph-delta critique/revision.
+- Selection order is official resolution, PASS_TO_PASS preservation, then tokens, cost, and end-to-end time.
+
+## Execution log
+
+### Control A
+
+- `astropy__astropy-13398`: unresolved; 0/4 FAIL_TO_PASS and five PASS_TO_PASS regressions. Patch SHA-256 `eb566b529439c4dc55f1f49318fdf1e3f5aca08dd48b538d0f0e12f0177b1060`; official report SHA-256 `584cf4388f61fa1327ca8650902c895bf0ed11591e425e424d270a85ba44e211`.
+- `astropy__astropy-14096`: resolved; 1/1 FAIL_TO_PASS and 426/426 PASS_TO_PASS. The terminal Claude response was recovered from the completed transcript without a rerun. Patch SHA-256 `c949f84a9828bd2c58282ad05fafd558b96d4ef1ef39378f5cb43fe07b48752e`; official report SHA-256 `b83e0b1a3d3276f3a24051e581f4ba72819d4b0c40de92f1e39ed0bdfc7f148e`.
+
+### Treatment-construction diagnostics
+
+- Exact #822 fresh reopen is READY for both active cases.
+- The original 13398 query omitted the populated root and included hidden GitHub HTML-template comments. Root binding plus HTML-comment-only stripping produced 20 code and 20 documentation records.
+- The original raw 14096 query produced 20 documentation records and no code; native task mode selected zero records. The arm failed closed before model spend.
+- `--language=python` produced 20 code records for 13398 but zero for 14096, so that correction was rejected rather than special-cased.
+- Native task context is not usable for these cases: 13398 exceeds the artifact's 1,024 Pareto-state limit; 14096 has ambiguous/unresolved exact references and no covered lanes. Both failures were retained.
+- Model-visible source hydration is restricted to RNA-selected stable identities and verifier-matched Git line spans using the SHA-bound #787 `source_slice` implementation.
+- A generic salient-query probe and a graph-edge-derived boundary projector are in progress. No B/C+ model call starts until both mechanics and all packet hashes are frozen.
+
+## RNA Tool Friction Log
+
+| Phase | Tool | What happened | Workaround | Severity |
+|---|---|---|---|---|
+| Session template | `sed` | RNA search returned the dev-pipeline requirement but not a representative session-file body. | Read the first bounded section of `.oh/sessions/783-dev.md` to preserve the repository's frontmatter/section convention. | low |
+| External evidence | `find`/`sed`/`jq` | RNA indexes repository content, not the temporary external evidence root. | Inspected only named receipts, prompts, and official evaluator reports under the registered evidence root. | expected |
+
+## Current gate
+
+Freeze a single deterministic query/projection policy that returns code for both active cases and a graph-grounded C+ boundary packet. Then run B/C+ in parallel, perform one proposal-dependent C+ revision, and evaluate each terminal patch exactly once.

--- a/.oh/sessions/816-dev.md
+++ b/.oh/sessions/816-dev.md
@@ -71,6 +71,15 @@ Select a non-oracle RNA treatment for #817 using a fixed development screen: bar
 - Eligible A and B therefore tied on resolution and regression preservation. A won the third registered criterion: 10,677,364 versus 14,004,672 total tokens. The registered decision is `A / no_rna_treatment`.
 - Final aggregation manifest SHA-256: `c6d0f89852e6b6767c20af4b5925f5f8e9f2c83639d4d0e857ebda26e5549f64`; report SHA-256: `120aeb81d61c9287e45c1f9d6a048c2eea773b160211fbbe271e0d6de51f03a5`.
 
+### Ship review accounting remediation
+
+- The six committed episode records now distinguish one model-stage invocation from Claude-reported turns and from the unavailable provider request count; JSONL assistant records are not relabeled as model calls.
+- Exact transcript `tool_use` counts are recorded for every episode: 13398 A/B/C+ = 102/98/52 and 14096 A/B/C+ = 42/45/31, with exact tool-name breakdowns and transcript SHA-256 identities.
+- Five episodes retain exact empty permission-denial lists from their top-level Claude results. The 14096 A top-level result was lost after terminal `end_turn`, so its denial count is explicitly unavailable rather than inferred from `bypassPermissions` or transcript silence.
+- The misleading `end_to_end_wall_ms` label is removed. `accounted_wall_ms` is explicitly the model duration plus receipt-backed RNA CLI intervals; true end-to-end time is unavailable because projection, hydration, rendering, packet/prompt assembly, and orchestration gaps were not independently timed.
+- C+ initial and post-draft work is split. For 13398, initial semantic/graph CLI work is 377,900 ms and the failed v1/v2 delta queries add 146,880 ms. For 14096, those values are 384,808 ms and 35,347 ms. Both have zero revision model calls; untimed conversion/rendering remains explicit.
+- Amended result document SHA-256: `ceb466a258ab1f650cf7415945a40f0de06165b251ddacd29c217db07c35e3ef`.
+
 ### Manipulation check
 
 - RNA packets were present byte-for-byte in both B prompts, but neither assistant transcript cited the supplied context or stable identities.

--- a/.oh/sessions/816-dev.md
+++ b/.oh/sessions/816-dev.md
@@ -44,6 +44,14 @@ Select a non-oracle RNA treatment for #817 using a fixed development screen: bar
 - Model-visible source hydration is restricted to RNA-selected stable identities and verifier-matched Git line spans using the SHA-bound #787 `source_slice` implementation.
 - A generic salient-query probe and a graph-edge-derived boundary projector are in progress. No B/C+ model call starts until both mechanics and all packet hashes are frozen.
 
+### Initial B/C+ execution
+
+- The four initial sessions launched in parallel from pushed head `4879afe3fa6931407434c95f048c9a1ac3803fdf`; their exact prompts and empty-MCP configuration were frozen first.
+- 13398 B reached the registered 1,200-second wall limit and retained its terminal patch; the timeout is an outcome and is not retried.
+- 13398 C+, 14096 B, and 14096 C+ completed normally and retained their patches/receipts.
+- Neither registered C+ graph-delta query reached a revision packet. The exact 13398 diff creates a new file, which #814 rejects in unified-diff form; the 14096 audit required 181,236 bytes/45,299 tokens, exceeding the 160,000/40,000 raw cap. Both v1 failures remain immutable and no model saw their output.
+- The issue's single consolidated remediation freezes a lossless structured-proposal encoding for both exact diffs and raises only the out-of-band audit cap to 256,000/64,000. Model-visible body budgets, novelty rules, revision budget, timeout, and no-retry policy remain unchanged.
+
 ## RNA Tool Friction Log
 
 | Phase | Tool | What happened | Workaround | Severity |
@@ -53,4 +61,4 @@ Select a non-oracle RNA treatment for #817 using a fixed development screen: bar
 
 ## Current gate
 
-Freeze a single deterministic query/projection policy that returns code for both active cases and a graph-grounded C+ boundary packet. Then run B/C+ in parallel, perform one proposal-dependent C+ revision, and evaluate each terminal patch exactly once.
+Run the two registered amended C+ delta constructions once, freeze their proposal-dependent packets, and perform one same-session revision per C+ arm. Then evaluate each B/C+ terminal patch exactly once through the independently reviewed evaluator harness.

--- a/benchmark/swebench-non-oracle/development-screen-results.json
+++ b/benchmark/swebench-non-oracle/development-screen-results.json
@@ -1,0 +1,285 @@
+{
+  "schema": "swebench-non-oracle-development-screen-results-v1",
+  "issue": 816,
+  "status": "COMPLETE_ELIGIBLE_SUBSET",
+  "registration": {
+    "commit": "ff240a9fe658bbeb155b7f9d2949845d9db297e0",
+    "document_sha256": "0bb3be243132bf061e28ae69cefc7e872cb758b920fc1825475007e9b25fb22a",
+    "run_manifest_sha256": "fd2be798f860e77cc81b7ac48ff4992e0528681c695be2feb2b6320218f30648"
+  },
+  "decision": {
+    "eligible_arm": "A",
+    "treatment": "no_rna_treatment",
+    "selection_order": [
+      "official_resolution",
+      "pass_to_pass_regressions",
+      "total_tokens",
+      "total_cost_usd",
+      "end_to_end_wall_ms"
+    ],
+    "reason": "A and B tied at one of two resolved cases and five PASS_TO_PASS regressions; A won the third registered criterion with 10,677,364 versus 14,004,672 total tokens.",
+    "claim_boundary": "This rejects the registered passive packet-injection treatment. It does not establish that an RNA-directed tool-usage policy is ineffective because observable evidence did not establish B treatment uptake."
+  },
+  "evidence": {
+    "root": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z",
+    "final_manifest_sha256": "c6d0f89852e6b6767c20af4b5925f5f8e9f2c83639d4d0e857ebda26e5549f64",
+    "final_report_sha256": "120aeb81d61c9287e45c1f9d6a048c2eea773b160211fbbe271e0d6de51f03a5",
+    "cplus_diagnostic_sidecar_sha256": "075b5b3a89befb30f260473a442084074e08ba0187ebc86df4059ec8733ee41f",
+    "cplus_infrastructure_failure_sha256": "d4258b84c51f1471aa1d3a05f27e30739c18141f5673221f25665c211a4f76f9",
+    "evaluator_batch_receipt_sha256": "1596abcdba68f6c52488c83cd638b49c277b966f50e43ae2d7518ceef6a928d2",
+    "evaluator_script_sha256": "d71f2f8bd417180ae7448107fb9a7678b6ea241d84c93ac478d86c3dd07cd7b4",
+    "evaluator_plan_sha256": "a745867b03a3ff073fbc047d243a758882e8af7821c62265b7f51e22917b0e78",
+    "aggregator_sha256": "e99e525bc04197e299e9c9f488b271ddefbe66c19966d9c7ee2ad14bb153232c",
+    "aggregator_regression_sha256": "d4dd7bc444342ee201d3c013772a47f5a24c9deebaf8082bb12403601320ae5b",
+    "rna_uptake_audit_sha256": "8be7f475a2c98bf4abf5c53149934f9a44d6c696239d9f1e292cf3c1102f6e55"
+  },
+  "official_evaluator": {
+    "authorized": 4,
+    "started": 4,
+    "recorded": 4,
+    "infrastructure_failures": 0,
+    "max_parallel": 2,
+    "same_case_serialized": true,
+    "remaining_containers": 0,
+    "fresh_harness_review": "APPROVE"
+  },
+  "episodes": [
+    {
+      "instance_id": "astropy__astropy-13398",
+      "arm": "A",
+      "eligible": true,
+      "run_status": "complete",
+      "resolved": false,
+      "fail_to_pass": {"passed": 0, "total": 4},
+      "pass_to_pass": {"passed": 63, "total": 68, "regressions": 5},
+      "turns": 103,
+      "tokens": {"input": 2339, "cache_creation": 149551, "cache_read": 9012434, "output": 42361, "total": 9206685},
+      "cost_usd": "4.2390002",
+      "model_wall_ms": 719997,
+      "rna_work_ms": 0,
+      "end_to_end_wall_ms": 719997,
+      "patch_sha256": "eb566b529439c4dc55f1f49318fdf1e3f5aca08dd48b538d0f0e12f0177b1060",
+      "official_report_sha256": "584cf4388f61fa1327ca8650902c895bf0ed11591e425e424d270a85ba44e211"
+    },
+    {
+      "instance_id": "astropy__astropy-13398",
+      "arm": "B",
+      "eligible": true,
+      "run_status": "registered_timeout_terminal_patch",
+      "resolved": false,
+      "fail_to_pass": {"passed": 0, "total": 4},
+      "pass_to_pass": {"passed": 63, "total": 68, "regressions": 5},
+      "turns": 100,
+      "tokens": {"input": 9149, "cache_creation": 193100, "cache_read": 10533804, "output": 79747, "total": 10815800},
+      "cost_usd": "5.5242812",
+      "model_wall_ms": 1199767,
+      "rna_work_ms": 28665,
+      "end_to_end_wall_ms": 1228432,
+      "model_receipt_sha256": "a8ffc0c0da4a041ccfb2c7da2ae5d5304a18dc1b5a5a7948d1d685b43b30444d",
+      "patch_sha256": "e1548dd95c8bc1a78ca4fb48cbc688d72cca1f156f7e360d2b3428e901ac8ca8",
+      "evaluator_receipt_sha256": "d50d2c53361f1249191ee4d373c32b48f18ec876ab95cefbe96f0035cd8e4838",
+      "official_report_sha256": "584cf4388f61fa1327ca8650902c895bf0ed11591e425e424d270a85ba44e211"
+    },
+    {
+      "instance_id": "astropy__astropy-13398",
+      "arm": "C+",
+      "eligible": false,
+      "run_status": "infrastructure_failed_before_revision",
+      "diagnostic_initial_patch_only": true,
+      "resolved": false,
+      "fail_to_pass": {"passed": 0, "total": 4},
+      "pass_to_pass": {"passed": 63, "total": 68, "regressions": 5},
+      "turns": 53,
+      "tokens": {"input": 18511, "cache_creation": 115820, "cache_read": 4003109, "output": 23559, "total": 4160999},
+      "cost_usd": "2.2677507",
+      "model_wall_ms": 399608,
+      "rna_work_ms": 377900,
+      "end_to_end_wall_ms": 777508,
+      "model_receipt_sha256": "a9de50ddedcb90d9a02f193a072f20d3dd824598137bc65942aeaa64cea3f19e",
+      "patch_sha256": "6323a7c68edd31f893c1e3dbbe273880be4185c9f881ae769f67cd4e87ffa5c5",
+      "evaluator_receipt_sha256": "331a9a08f004f2b291df9339caa84400f4be3dfda28139fa85068d391a215719",
+      "diagnostic_report_sha256": "584cf4388f61fa1327ca8650902c895bf0ed11591e425e424d270a85ba44e211"
+    },
+    {
+      "instance_id": "astropy__astropy-14096",
+      "arm": "A",
+      "eligible": true,
+      "run_status": "complete_transcript_recovery",
+      "resolved": true,
+      "fail_to_pass": {"passed": 1, "total": 1},
+      "pass_to_pass": {"passed": 426, "total": 426, "regressions": 0},
+      "turns": 43,
+      "tokens": {"input": 86, "cache_creation": 41727, "cache_read": 1413679, "output": 15187, "total": 1470679},
+      "cost_usd": "0.9025287",
+      "model_wall_ms": 364605,
+      "rna_work_ms": 0,
+      "end_to_end_wall_ms": 364605,
+      "patch_sha256": "c949f84a9828bd2c58282ad05fafd558b96d4ef1ef39378f5cb43fe07b48752e",
+      "official_report_sha256": "b83e0b1a3d3276f3a24051e581f4ba72819d4b0c40de92f1e39ed0bdfc7f148e"
+    },
+    {
+      "instance_id": "astropy__astropy-14096",
+      "arm": "B",
+      "eligible": true,
+      "run_status": "complete",
+      "resolved": true,
+      "fail_to_pass": {"passed": 1, "total": 1},
+      "pass_to_pass": {"passed": 426, "total": 426, "regressions": 0},
+      "turns": 46,
+      "tokens": {"input": 16328, "cache_creation": 95889, "cache_read": 3045899, "output": 30756, "total": 3188872},
+      "cost_usd": "1.9667457",
+      "model_wall_ms": 436676,
+      "rna_work_ms": 28799,
+      "end_to_end_wall_ms": 465475,
+      "model_receipt_sha256": "0829be8ba45d1aa988c9a4783fbdd5493464784840e5010952ac4bae2890a639",
+      "patch_sha256": "cda66d11ea8f20d14bcd9a4b411ad44f9541b5a55f6d9fdd267661cd9846ae2e",
+      "evaluator_receipt_sha256": "4b45620c71dc97f603956949b7099f545d6306ce6dabea882eb3d042426e8094",
+      "official_report_sha256": "b83e0b1a3d3276f3a24051e581f4ba72819d4b0c40de92f1e39ed0bdfc7f148e"
+    },
+    {
+      "instance_id": "astropy__astropy-14096",
+      "arm": "C+",
+      "eligible": false,
+      "run_status": "infrastructure_failed_before_revision",
+      "diagnostic_initial_patch_only": true,
+      "resolved": true,
+      "fail_to_pass": {"passed": 1, "total": 1},
+      "pass_to_pass": {"passed": 426, "total": 426, "regressions": 0},
+      "turns": 32,
+      "tokens": {"input": 28932, "cache_creation": 88893, "cache_read": 2155527, "output": 14304, "total": 2287656},
+      "cost_usd": "1.4234561",
+      "model_wall_ms": 228894,
+      "rna_work_ms": 384808,
+      "end_to_end_wall_ms": 613702,
+      "model_receipt_sha256": "11a261685eeeaac9377109c80c8540a3744133c5e4d93c2e50dfe0b1cf58938f",
+      "patch_sha256": "5ec12420bb6dbe63480bb5d071eb7cdcd490cc490ec0cae6739fc59bc273d25c",
+      "evaluator_receipt_sha256": "994d021070ee8731226d50f04c7e7c1c10e72f230424baed33d7d6bd448d345c",
+      "diagnostic_report_sha256": "b83e0b1a3d3276f3a24051e581f4ba72819d4b0c40de92f1e39ed0bdfc7f148e"
+    }
+  ],
+  "manipulation_check": {
+    "status": "UPTAKE_NOT_DEMONSTRATED",
+    "classification": "RNA packet delivered byte-for-byte, followed predominantly by checkout rediscovery; 13398 has weak circumstantial use only and 14096 use is not demonstrated",
+    "assistant_rna_context_citations": 0,
+    "outcome_identity": [
+      {
+        "instance_id": "astropy__astropy-13398",
+        "a_b_official_report_sha256_equal": true,
+        "official_report_sha256": "584cf4388f61fa1327ca8650902c895bf0ed11591e425e424d270a85ba44e211",
+        "a_b_total_tokens_equal": false,
+        "a_total_tokens": 9206685,
+        "b_total_tokens": 10815800,
+        "b_minus_a_total_tokens": 1609115
+      },
+      {
+        "instance_id": "astropy__astropy-14096",
+        "a_b_official_report_sha256_equal": true,
+        "official_report_sha256": "b83e0b1a3d3276f3a24051e581f4ba72819d4b0c40de92f1e39ed0bdfc7f148e",
+        "a_b_total_tokens_equal": false,
+        "a_total_tokens": 1470679,
+        "b_total_tokens": 3188872,
+        "b_minus_a_total_tokens": 1718193
+      }
+    ],
+    "tool_usage": [
+      {
+        "instance_id": "astropy__astropy-13398",
+        "arm": "A",
+        "total_tool_calls": 102,
+        "by_tool": {"Bash": 81, "Edit": 6, "Read": 14, "Write": 1},
+        "rna_cli_calls": 0,
+        "bash_grep_or_rg_calls": 20,
+        "bash_find_calls": 2,
+        "bash_cat_calls": 3,
+        "bash_sed_calls": 7,
+        "first_localization_action": "filesystem find for ITRS/AltAz/HADec frame files"
+      },
+      {
+        "instance_id": "astropy__astropy-13398",
+        "arm": "B",
+        "total_tool_calls": 98,
+        "by_tool": {"Bash": 72, "Edit": 11, "Read": 13, "Write": 2},
+        "rna_cli_calls": 0,
+        "bash_grep_or_rg_calls": 18,
+        "bash_find_calls": 11,
+        "bash_cat_calls": 5,
+        "bash_sed_calls": 2,
+        "first_localization_action": "filesystem find for ITRS/AltAz/HADec frame files"
+      },
+      {
+        "instance_id": "astropy__astropy-14096",
+        "arm": "A",
+        "total_tool_calls": 42,
+        "by_tool": {"Bash": 35, "Edit": 2, "Grep": 2, "Read": 3},
+        "rna_cli_calls": 0,
+        "bash_grep_or_rg_calls": 9,
+        "direct_grep_tool_calls": 2,
+        "combined_grep_or_rg_calls": 11,
+        "bash_find_calls": 3,
+        "bash_cat_calls": 3,
+        "bash_sed_calls": 0,
+        "first_localization_action": "grep __getattr__/__setattr__ in sky_coordinate.py"
+      },
+      {
+        "instance_id": "astropy__astropy-14096",
+        "arm": "B",
+        "total_tool_calls": 45,
+        "by_tool": {"Bash": 37, "Edit": 4, "Read": 4},
+        "rna_cli_calls": 0,
+        "bash_grep_or_rg_calls": 10,
+        "direct_grep_tool_calls": 0,
+        "combined_grep_or_rg_calls": 10,
+        "bash_find_calls": 5,
+        "bash_cat_calls": 1,
+        "bash_sed_calls": 1,
+        "first_localization_action": "grep __getattr__/__setattr__/__delattr__ in sky_coordinate.py"
+      }
+    ],
+    "cases": [
+      {
+        "instance_id": "astropy__astropy-13398",
+        "packet_sha256": "29ce72aeb19c99913d05b9dd5146f777c8e37f8321157ee47fa7af624d6dcb38",
+        "packet_bytes": 19405,
+        "b_prompt_bytes": 25754,
+        "tool_calls": 98,
+        "packet_files_explicitly_read": 2,
+        "packet_files_total": 4,
+        "finding": "B began with filesystem find and repeated substantially the same frame-file localization sequence as A."
+      },
+      {
+        "instance_id": "astropy__astropy-14096",
+        "packet_sha256": "3706c387c7f134cfcec7aa6ef7cb334184e0ef825855abce37206e1bb60f32b1",
+        "packet_bytes": 57242,
+        "b_prompt_bytes": 59250,
+        "tool_calls": 45,
+        "packet_files_touched": 3,
+        "packet_files_total": 12,
+        "target_symbol_in_packet": false,
+        "missing_target_symbol": "SkyCoord.__getattr__",
+        "finding": "A and B both began by grepping __getattr__/__setattr__ in sky_coordinate.py, reading it, and building nearly the same property reproducer."
+      }
+    ],
+    "harness_constraint": "Claude CLI was invoked with --safe-mode and an empty strict MCP configuration, which disabled MCP/hooks; the treatment neither exposed an RNA MCP tool nor directed an RNA CLI workflow through Bash."
+  },
+  "cplus_failure": {
+    "status": "INELIGIBLE",
+    "reason": "Neither case reached the registered graph-delta critique/revision stage after the single allowed remediation.",
+    "revision_model_calls": 0,
+    "official_diagnostic_evaluations": 2,
+    "causal_claim": "No claim about completed C+ or graph-versus-revision effects is supported."
+  },
+  "limitations": [
+    "This N=2 development screen selects a policy; it is not a confirmatory effect estimate.",
+    "The registered B packet-injection manipulation was delivered, but observable evidence did not establish uptake.",
+    "The 14096 semantic packet omitted the actual target symbol.",
+    "C+ never completed its registered revision stage and is excluded from selection.",
+    "RNA timing covers receipt-backed CLI operations but omits deterministic projection and rendering overhead; wall time was not decision-relevant because selection stopped at tokens.",
+    "The 13398 B run retained its terminal patch at the registered 1,200-second wall limit.",
+    "The 14096 A result was recovered from a SHA-bound completed transcript after a host restart."
+  ],
+  "downstream": {
+    "issue_817_disposition": "not_authorized_by_issue_816",
+    "reason": "No eligible RNA treatment was selected, so issue 816 supplies no T arm to freeze or confirm. Issue 817 must not start from this result.",
+    "future_work_boundary": "A corrected RNA-directed tool-usage policy requires a new separately preregistered development trial; it must not be retrofitted into this result."
+  }
+}

--- a/benchmark/swebench-non-oracle/development-screen-results.json
+++ b/benchmark/swebench-non-oracle/development-screen-results.json
@@ -43,6 +43,19 @@
     "remaining_containers": 0,
     "fresh_harness_review": "APPROVE"
   },
+  "accounting_definitions": {
+    "model_stage_invocations": "Counted from the frozen orchestration plan and retained stage receipts. This is not relabeled as provider API-request count.",
+    "reported_turns": "Claude CLI num_turns when a top-level result was retained; recovered Sonnet API-message count for astropy__astropy-14096 A, whose top-level result was lost after terminal end_turn.",
+    "provider_model_request_count": "Unavailable for every episode because Claude CLI 2.1.216 retained aggregate num_turns/usage but no provider request ledger; assistant JSONL record counts are not substituted.",
+    "tool_calls": "Exact count of assistant JSONL message.content elements with type=tool_use, grouped by exact name.",
+    "permission_denials": "Copied only from a retained top-level Claude result or orchestration receipt. Missing top-level result data is reported unavailable rather than inferred from permission mode or transcript silence.",
+    "rna_receipt_backed_cli_ms": "Sum of elapsed_ms from retained RNA CLI query receipts only. Deterministic projection, hydration, rendering, packet assembly, and orchestration overhead were not independently timed.",
+    "accounted_wall_ms": "model_wall_ms plus every receipt-backed RNA CLI interval attributable to the episode, including failed C+ post-draft queries. This is a partial additive accounting metric, not true end-to-end elapsed time.",
+    "true_end_to_end_wall_ms": {
+      "status": "unavailable",
+      "reason": "The development harness did not time deterministic projection, hydration, rendering, packet/prompt assembly, or orchestration gaps separately. The registered selection stopped at total tokens, so the unavailable fifth criterion does not affect the decision."
+    }
+  },
   "episodes": [
     {
       "instance_id": "astropy__astropy-13398",
@@ -52,12 +65,28 @@
       "resolved": false,
       "fail_to_pass": {"passed": 0, "total": 4},
       "pass_to_pass": {"passed": 63, "total": 68, "regressions": 5},
-      "turns": 103,
+      "model_call_accounting": {
+        "stage_invocations": {"initial": 1},
+        "reported_turns": {"count": 103, "kind": "claude_cli_num_turns"},
+        "provider_request_count": {"status": "unavailable", "reason": "Claude CLI retained num_turns but no provider request ledger."}
+      },
+      "tool_call_accounting": {
+        "status": "available",
+        "count": 102,
+        "by_tool": {"Bash": 81, "Edit": 6, "Read": 14, "Write": 1},
+        "transcript_sha256": "f276a96776fa9e5036ead6a8b3a9d4cbd8dabd53684ee0fc196429a2b3dbd67d"
+      },
+      "permission_denials": {
+        "status": "available",
+        "count": 0,
+        "entries": [],
+        "source_sha256": "0a66a7602003f3f69b370e3584c5c93cfab66fe73bf0db1fbf29bfcd5498d69e"
+      },
       "tokens": {"input": 2339, "cache_creation": 149551, "cache_read": 9012434, "output": 42361, "total": 9206685},
       "cost_usd": "4.2390002",
       "model_wall_ms": 719997,
-      "rna_work_ms": 0,
-      "end_to_end_wall_ms": 719997,
+      "rna_receipt_backed_cli_ms": 0,
+      "accounted_wall_ms": 719997,
       "patch_sha256": "eb566b529439c4dc55f1f49318fdf1e3f5aca08dd48b538d0f0e12f0177b1060",
       "official_report_sha256": "584cf4388f61fa1327ca8650902c895bf0ed11591e425e424d270a85ba44e211"
     },
@@ -69,12 +98,28 @@
       "resolved": false,
       "fail_to_pass": {"passed": 0, "total": 4},
       "pass_to_pass": {"passed": 63, "total": 68, "regressions": 5},
-      "turns": 100,
+      "model_call_accounting": {
+        "stage_invocations": {"initial": 1},
+        "reported_turns": {"count": 100, "kind": "claude_cli_num_turns"},
+        "provider_request_count": {"status": "unavailable", "reason": "Claude CLI retained num_turns but no provider request ledger."}
+      },
+      "tool_call_accounting": {
+        "status": "available",
+        "count": 98,
+        "by_tool": {"Bash": 72, "Edit": 11, "Read": 13, "Write": 2},
+        "transcript_sha256": "82f2b90e14cfcdfaf7eb94019cae60d890fed9ab20b36637121eee18e4d9f97d"
+      },
+      "permission_denials": {
+        "status": "available",
+        "count": 0,
+        "entries": [],
+        "source_sha256": "a8ffc0c0da4a041ccfb2c7da2ae5d5304a18dc1b5a5a7948d1d685b43b30444d"
+      },
       "tokens": {"input": 9149, "cache_creation": 193100, "cache_read": 10533804, "output": 79747, "total": 10815800},
       "cost_usd": "5.5242812",
       "model_wall_ms": 1199767,
-      "rna_work_ms": 28665,
-      "end_to_end_wall_ms": 1228432,
+      "rna_receipt_backed_cli_ms": 28665,
+      "accounted_wall_ms": 1228432,
       "model_receipt_sha256": "a8ffc0c0da4a041ccfb2c7da2ae5d5304a18dc1b5a5a7948d1d685b43b30444d",
       "patch_sha256": "e1548dd95c8bc1a78ca4fb48cbc688d72cca1f156f7e360d2b3428e901ac8ca8",
       "evaluator_receipt_sha256": "d50d2c53361f1249191ee4d373c32b48f18ec876ab95cefbe96f0035cd8e4838",
@@ -89,12 +134,45 @@
       "resolved": false,
       "fail_to_pass": {"passed": 0, "total": 4},
       "pass_to_pass": {"passed": 63, "total": 68, "regressions": 5},
-      "turns": 53,
+      "model_call_accounting": {
+        "stage_invocations": {"initial": 1, "revision": 0},
+        "reported_turns": {"count": 53, "kind": "claude_cli_num_turns", "stage": "initial"},
+        "provider_request_count": {"status": "unavailable", "reason": "Claude CLI retained num_turns but no provider request ledger; no revision model call occurred."}
+      },
+      "tool_call_accounting": {
+        "status": "available",
+        "count": 52,
+        "by_tool": {"Bash": 34, "Edit": 3, "Grep": 4, "Read": 10, "Write": 1},
+        "stage": "initial",
+        "transcript_sha256": "8bfd004ab14c842a80bbbc99f1c33765ea9f67cb43ac66cb6dbd436bdf405b88"
+      },
+      "permission_denials": {
+        "status": "available",
+        "count": 0,
+        "entries": [],
+        "source_sha256": "a9de50ddedcb90d9a02f193a072f20d3dd824598137bc65942aeaa64cea3f19e"
+      },
       "tokens": {"input": 18511, "cache_creation": 115820, "cache_read": 4003109, "output": 23559, "total": 4160999},
       "cost_usd": "2.2677507",
       "model_wall_ms": 399608,
-      "rna_work_ms": 377900,
-      "end_to_end_wall_ms": 777508,
+      "rna_receipt_backed_cli_ms": 524780,
+      "accounted_wall_ms": 924388,
+      "cplus_stage_timing": {
+        "initial_context_construction": {
+          "semantic_acquisition_ms": 28665,
+          "graph_traversal_ms": 349235,
+          "receipt_backed_cli_ms": 377900,
+          "projection_hydration_rendering_ms": {"status": "unavailable", "reason": "The deterministic projector emitted hashes and bytes but no elapsed-time receipt."}
+        },
+        "post_draft_graph_delta": {
+          "v1_query_ms": 7061,
+          "v2_query_ms": 139819,
+          "receipt_backed_cli_ms": 146880,
+          "proposal_conversion_rendering_ms": {"status": "unavailable", "reason": "Structured conversion and freeze checks emitted receipts without elapsed-time fields."},
+          "revision_model_calls": 0,
+          "revision_model_ms": 0
+        }
+      },
       "model_receipt_sha256": "a9de50ddedcb90d9a02f193a072f20d3dd824598137bc65942aeaa64cea3f19e",
       "patch_sha256": "6323a7c68edd31f893c1e3dbbe273880be4185c9f881ae769f67cd4e87ffa5c5",
       "evaluator_receipt_sha256": "331a9a08f004f2b291df9339caa84400f4be3dfda28139fa85068d391a215719",
@@ -108,12 +186,27 @@
       "resolved": true,
       "fail_to_pass": {"passed": 1, "total": 1},
       "pass_to_pass": {"passed": 426, "total": 426, "regressions": 0},
-      "turns": 43,
+      "model_call_accounting": {
+        "stage_invocations": {"initial": 1},
+        "reported_turns": {"count": 43, "kind": "recovered_sonnet_api_messages"},
+        "provider_request_count": {"status": "unavailable", "reason": "The top-level Claude result was lost after terminal end_turn; the recovery receipt counts Sonnet API messages but does not provide a provider request ledger."}
+      },
+      "tool_call_accounting": {
+        "status": "available",
+        "count": 42,
+        "by_tool": {"Bash": 35, "Edit": 2, "Grep": 2, "Read": 3},
+        "transcript_sha256": "ba0dc88ef0d3197707807fa2adc021e222e4fccaa960d3aaef46f8fc607a63e2"
+      },
+      "permission_denials": {
+        "status": "unavailable",
+        "reason": "The top-level Claude result was not retained after host restart; permission-denial count is not inferred from bypassPermissions or transcript silence.",
+        "recovery_receipt_sha256": "b7981390f9fd9695229049d99637c8947978c048e7fb798e54f58d40c8545d46"
+      },
       "tokens": {"input": 86, "cache_creation": 41727, "cache_read": 1413679, "output": 15187, "total": 1470679},
       "cost_usd": "0.9025287",
       "model_wall_ms": 364605,
-      "rna_work_ms": 0,
-      "end_to_end_wall_ms": 364605,
+      "rna_receipt_backed_cli_ms": 0,
+      "accounted_wall_ms": 364605,
       "patch_sha256": "c949f84a9828bd2c58282ad05fafd558b96d4ef1ef39378f5cb43fe07b48752e",
       "official_report_sha256": "b83e0b1a3d3276f3a24051e581f4ba72819d4b0c40de92f1e39ed0bdfc7f148e"
     },
@@ -125,12 +218,28 @@
       "resolved": true,
       "fail_to_pass": {"passed": 1, "total": 1},
       "pass_to_pass": {"passed": 426, "total": 426, "regressions": 0},
-      "turns": 46,
+      "model_call_accounting": {
+        "stage_invocations": {"initial": 1},
+        "reported_turns": {"count": 46, "kind": "claude_cli_num_turns"},
+        "provider_request_count": {"status": "unavailable", "reason": "Claude CLI retained num_turns but no provider request ledger."}
+      },
+      "tool_call_accounting": {
+        "status": "available",
+        "count": 45,
+        "by_tool": {"Bash": 37, "Edit": 4, "Read": 4},
+        "transcript_sha256": "0cba4ef48baeffd993a0d4b237226b8346b449164d02ee61d37e1a137878acc3"
+      },
+      "permission_denials": {
+        "status": "available",
+        "count": 0,
+        "entries": [],
+        "source_sha256": "0829be8ba45d1aa988c9a4783fbdd5493464784840e5010952ac4bae2890a639"
+      },
       "tokens": {"input": 16328, "cache_creation": 95889, "cache_read": 3045899, "output": 30756, "total": 3188872},
       "cost_usd": "1.9667457",
       "model_wall_ms": 436676,
-      "rna_work_ms": 28799,
-      "end_to_end_wall_ms": 465475,
+      "rna_receipt_backed_cli_ms": 28799,
+      "accounted_wall_ms": 465475,
       "model_receipt_sha256": "0829be8ba45d1aa988c9a4783fbdd5493464784840e5010952ac4bae2890a639",
       "patch_sha256": "cda66d11ea8f20d14bcd9a4b411ad44f9541b5a55f6d9fdd267661cd9846ae2e",
       "evaluator_receipt_sha256": "4b45620c71dc97f603956949b7099f545d6306ce6dabea882eb3d042426e8094",
@@ -145,12 +254,45 @@
       "resolved": true,
       "fail_to_pass": {"passed": 1, "total": 1},
       "pass_to_pass": {"passed": 426, "total": 426, "regressions": 0},
-      "turns": 32,
+      "model_call_accounting": {
+        "stage_invocations": {"initial": 1, "revision": 0},
+        "reported_turns": {"count": 32, "kind": "claude_cli_num_turns", "stage": "initial"},
+        "provider_request_count": {"status": "unavailable", "reason": "Claude CLI retained num_turns but no provider request ledger; no revision model call occurred."}
+      },
+      "tool_call_accounting": {
+        "status": "available",
+        "count": 31,
+        "by_tool": {"Bash": 24, "Edit": 2, "Grep": 2, "Read": 3},
+        "stage": "initial",
+        "transcript_sha256": "88f69a78427ffefff217e20637969244a09014a8a1a4811b976facf76bcf302b"
+      },
+      "permission_denials": {
+        "status": "available",
+        "count": 0,
+        "entries": [],
+        "source_sha256": "11a261685eeeaac9377109c80c8540a3744133c5e4d93c2e50dfe0b1cf58938f"
+      },
       "tokens": {"input": 28932, "cache_creation": 88893, "cache_read": 2155527, "output": 14304, "total": 2287656},
       "cost_usd": "1.4234561",
       "model_wall_ms": 228894,
-      "rna_work_ms": 384808,
-      "end_to_end_wall_ms": 613702,
+      "rna_receipt_backed_cli_ms": 420155,
+      "accounted_wall_ms": 649049,
+      "cplus_stage_timing": {
+        "initial_context_construction": {
+          "semantic_acquisition_ms": 28799,
+          "graph_traversal_ms": 356009,
+          "receipt_backed_cli_ms": 384808,
+          "projection_hydration_rendering_ms": {"status": "unavailable", "reason": "The deterministic projector emitted hashes and bytes but no elapsed-time receipt."}
+        },
+        "post_draft_graph_delta": {
+          "v1_query_ms": 19082,
+          "v2_query_ms": 16265,
+          "receipt_backed_cli_ms": 35347,
+          "proposal_conversion_rendering_ms": {"status": "unavailable", "reason": "Structured conversion and freeze checks emitted receipts without elapsed-time fields."},
+          "revision_model_calls": 0,
+          "revision_model_ms": 0
+        }
+      },
       "model_receipt_sha256": "11a261685eeeaac9377109c80c8540a3744133c5e4d93c2e50dfe0b1cf58938f",
       "patch_sha256": "5ec12420bb6dbe63480bb5d071eb7cdcd490cc490ec0cae6739fc59bc273d25c",
       "evaluator_receipt_sha256": "994d021070ee8731226d50f04c7e7c1c10e72f230424baed33d7d6bd448d345c",
@@ -273,7 +415,7 @@
     "The registered B packet-injection manipulation was delivered, but observable evidence did not establish uptake.",
     "The 14096 semantic packet omitted the actual target symbol.",
     "C+ never completed its registered revision stage and is excluded from selection.",
-    "RNA timing covers receipt-backed CLI operations but omits deterministic projection and rendering overhead; wall time was not decision-relevant because selection stopped at tokens.",
+    "True end-to-end wall time is unavailable because deterministic projection, hydration, rendering, packet/prompt assembly, and orchestration gaps were not independently timed. The result reports only explicitly labeled model, receipt-backed RNA CLI, C+ stage, and partial additive accounted times; time was not decision-relevant because selection stopped at tokens.",
     "The 13398 B run retained its terminal patch at the registered 1,200-second wall limit.",
     "The 14096 A result was recovered from a SHA-bound completed transcript after a host restart."
   ],

--- a/benchmark/swebench-non-oracle/development-screen.json
+++ b/benchmark/swebench-non-oracle/development-screen.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rna-non-oracle-development-screen-v1",
+  "registered_at": "2026-07-22T04:15:00Z",
+  "parent_issue": 815,
+  "issue": 816,
+  "dataset": {
+    "name": "SWE-bench_Verified",
+    "configuration": "SWE-bench___swe-bench_verified/default/0.0.0/91aa3ed51b709be6457e12d00300a6a596d4c6a3",
+    "arrow_sha256": "0d119efe73413554335bd410a04d82fd4a586bfd312cee677ee40af5de2ac46e"
+  },
+  "runtime": {
+    "rna_source_commit": "d17eb5b063aef81d0d96fd2e84b684b4c7c6d97c",
+    "rna_binary_sha256": "0ffd79040a424116404fe79ad0aa0a9e198f80d5aba22600c9edfb23fce06536",
+    "rna_artifact_id": 8517613929,
+    "rna_artifact_sha256": "888e2f657d6b71a3eb1531ef5596fa7120ef256de261ac9c964c33db625827ea",
+    "rna_manifest_sha256": "49a66e130a780df518e4d582915c27f8dd0c6f72ef1726d1de0027f7f9984aad",
+    "claude_cli_version": "2.1.216",
+    "model_argument": "claude-sonnet-5",
+    "effort": "high",
+    "permission_mode": "bypassPermissions",
+    "network_policy": "no agent network; WebFetch and WebSearch disabled",
+    "initial_stage_budget_usd": 8.0,
+    "c_plus_revision_budget_usd": 3.0,
+    "terminal_evaluations_per_arm": 1
+  },
+  "cases": [
+    {
+      "instance_id": "astropy__astropy-13398",
+      "repository": "astropy/astropy",
+      "base_commit": "6500928dc0e57be8f06d1162eacc3ba5e2eff692",
+      "problem_statement_utf8_bytes": 5323,
+      "problem_statement_sha256": "c26c8dc258dc5cb9dd34f30bdbaaed3f19a8ada137e0f19d81d7f57dc5f11bba",
+      "role": "known efficacy and regression-safety stress test",
+      "prior_outcomes": "development-only; prior evaluator-feedback resolution is invalid for C+"
+    },
+    {
+      "instance_id": "astropy__astropy-8707",
+      "repository": "astropy/astropy",
+      "base_commit": "a85a0747c54bac75e9c3b2fe436b105ea029d6cf",
+      "problem_statement_utf8_bytes": 840,
+      "problem_statement_sha256": "f7420a19ba5b0c807396a84da376d8303e69ff66d0216c332adf099da589a714",
+      "role": "previously unrun fresh development case",
+      "prior_outcomes": "none"
+    }
+  ],
+  "arms": {
+    "A": {
+      "name": "bare tool-enabled agent",
+      "initial_context": "problem statement only"
+    },
+    "B": {
+      "name": "strict RNA semantic acquisition",
+      "initial_context": "problem statement plus deterministic strict hybrid/rerank agent projection and ranked-body hydration"
+    },
+    "C+": {
+      "name": "semantic plus graph boundaries plus bounded revision",
+      "initial_context": "B plus deterministic task-context boundary roles",
+      "revision": "one resumed turn containing only novel graph-delta-beta evidence derived from the terminal first-stage diff"
+    }
+  },
+  "shared_policy": {
+    "same_checkout": true,
+    "same_base_agent_tools": true,
+    "same_visible_test_policy": true,
+    "same_initial_model_budget": true,
+    "gold_patch_hidden_until_terminal_evaluation": true,
+    "test_patch_hidden_until_terminal_evaluation": true,
+    "fail_to_pass_hidden_until_terminal_evaluation": true,
+    "evaluator_output_never_returned_to_agent": true,
+    "manual_or_llm_retrieval_fallback": false,
+    "official_swebench_terminal_evaluator": true
+  },
+  "selection_order": [
+    "official_resolution",
+    "pass_to_pass_regression_preservation",
+    "total_tokens",
+    "total_cost_usd",
+    "end_to_end_wall_time"
+  ],
+  "confirmatory_exclusion": [
+    "astropy__astropy-13398",
+    "astropy__astropy-14369",
+    "astropy__astropy-8707"
+  ],
+  "causal_limit": "A C+ advantage selects an operational treatment but does not separately identify graph-context and revision-call effects without a later C or compute-matched ablation.",
+  "oracle_arm": null
+}

--- a/benchmark/swebench-non-oracle/development-screen.json
+++ b/benchmark/swebench-non-oracle/development-screen.json
@@ -601,6 +601,90 @@
         "A/14096's recovered transport record is adequate for terminal efficacy but has weaker cost and token provenance than an ordinary top-level Claude result; disclose this if efficiency breaks a tie.",
         "C+ combines graph-boundary evidence with one extra revision call, so any C+ advantage selects an operational policy but does not identify graph evidence separately from revision compute."
       ]
+    },
+    {
+      "id": "816-cplus-delta-mechanics-v3",
+      "amended_at": "2026-07-22T12:25:14.994784Z",
+      "effective_for_arm": "C+ proposal-dependent revision only",
+      "knowledge_state": {
+        "A_B_and_C_plus_initial_outcomes_observed": true,
+        "C_plus_revision_model_calls_started": false,
+        "official_evaluator_or_test_feedback_observed_for_B_or_C_plus": false,
+        "scope": "one consolidated exploratory mechanics remediation before either C+ revision",
+        "v1_delta_attempts_observed": true
+      },
+      "disclosure": [
+        "Both original registered delta attempts remain immutable fail-closed evidence and were not retried under v1.",
+        "V2 is a post-initial, pre-revision exploratory amendment and cannot support a pristine preregistered estimate.",
+        "13398 requires #814 structured input because the exact first-stage patch creates a real new file.",
+        "14096 requires a raw audit cap above the observed 181236-byte/45299-token non-body response."
+      ],
+      "effective_mechanics": {
+        "producer": {
+          "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/cplus-delta-v2/build_cplus_delta_v2.py",
+          "bytes": 35975,
+          "sha256": "2f864c40368a1585f28f143768b87da1d247d64bafc10cc50ab4c5abfaff9d90"
+        },
+        "policy": {
+          "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/cplus-delta-v2/frozen-policy.json",
+          "bytes": 3472,
+          "sha256": "79c3c1145144d50c6c31bf60018dbc4930946aad1ff413acba939d6e079a0ff1"
+        },
+        "query_flags": [
+          "--search-mode=hybrid",
+          "--rerank",
+          "--include-artifacts=false",
+          "--projection=agent",
+          "--body-policy=focused_span",
+          "--limit=20",
+          "--max-body-bytes=3000",
+          "--max-total-body-bytes=16000",
+          "--max-output-bytes=256000",
+          "--max-output-tokens=64000",
+          "--context-mode=graph-delta-beta"
+        ],
+        "query_gate": "exact Git registration commit containing this amendment is required before the single v2 query attempt per case",
+        "single_attempt_per_case": true,
+        "structured_proposals": {
+          "astropy__astropy-13398": {
+            "proposal": {
+              "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/cplus-delta-v2/structured-proposals/astropy__astropy-13398.structured-proposal.json",
+              "bytes": 114286,
+              "sha256": "8b5c1481d30425e3fe3926079d5ef503fe78196aa6b69992af8f3b7082f7eff0"
+            },
+            "conversion_receipt": {
+              "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/cplus-delta-v2/structured-proposals/astropy__astropy-13398.conversion-receipt.json",
+              "bytes": 14643,
+              "sha256": "758171b0eedb74e7a6895b8b6577a1442bc970b0371314be9924e1c1f7dd2aa8"
+            }
+          },
+          "astropy__astropy-14096": {
+            "proposal": {
+              "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/cplus-delta-v2/structured-proposals/astropy__astropy-14096.structured-proposal.json",
+              "bytes": 24189,
+              "sha256": "6de9abb631b0afedda70ab31c314fa2c5156edcaac5ac67d7e46e06b496d2763"
+            },
+            "conversion_receipt": {
+              "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/cplus-delta-v2/structured-proposals/astropy__astropy-14096.conversion-receipt.json",
+              "bytes": 6615,
+              "sha256": "069d30f4860c287e4669820b5c62a64221bd072329e15665b3925adb0455e33f"
+            }
+          }
+        },
+        "lossless_binding": "Each structured changed-file/hunk/line fact round-trips to the exact stage-one unified diff; an audit-only deferred omission carries the raw diff base64 envelope and is removed by live enrichment before model rendering.",
+        "v1_utility": {
+          "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/cplus-delta-v1/build_cplus_delta.py",
+          "bytes": 38439,
+          "sha256": "7b4f48ddc1ce848e133919f0b4ce810d377aaea10b57b57a5f843e46340fae2f"
+        }
+      },
+      "unchanged": [
+        "exact stage-one patch bytes and base commit/tree",
+        "model-visible 3000-byte per-body and 16000-byte total-body limits",
+        "stable-ID/exact-span novelty filter",
+        "3 USD revision budget, 600 second timeout, same-session single revision, no retry",
+        "no evaluator/test/gold feedback and no manual/LLM selection"
+      ]
     }
   ]
 }

--- a/benchmark/swebench-non-oracle/development-screen.json
+++ b/benchmark/swebench-non-oracle/development-screen.json
@@ -37,7 +37,8 @@
     "stop_rule": "one initial Claude Code session per arm; C+ alone receives one resumed revision turn; stop on terminal response, registered dollar budget, or wall timeout; no evaluator feedback and no retry",
     "workspace_rule": "byte-identical separate pristine source-only checkouts at the registered base commit, with no git remote and no .oh cache visible to the model",
     "case_13398_A_prompt_sha256": "81bdb7858000e310ac7f3d0d76557130a0ba74108291b8e96893d016ffab3db8",
-    "case_8707_A_prompt_sha256": "fd8f818724ffb35673142ddc9d8f5b0a51cc244db3c939dc17a1a3727ee20675"
+    "excluded_case_8707_A_prompt_sha256": "fd8f818724ffb35673142ddc9d8f5b0a51cc244db3c939dc17a1a3727ee20675",
+    "case_14096_A_prompt_sha256": "bd3595eac38e7adb734d1752961260c1f60d236a4cf200ff9594da050794ec6b"
   },
   "rna_treatment_construction": {
     "query": "the exact registered problem-statement bytes as the sole positional query",
@@ -112,7 +113,8 @@
   },
   "pre_registration_diagnostics": {
     "invalid_A_attempt": "one A process was started before this exact addendum, interrupted after 89.374 seconds and $0.7090892, received no evaluator output, and is excluded from every comparison",
-    "old_semantic_cache": "the retained aa92ece semantic generation was rejected by exact #822 and is excluded; structural evidence may be retained while embeddings are rebuilt and sealed by exact #822"
+    "old_semantic_cache": "the retained aa92ece semantic generation was rejected by exact #822 and is excluded; structural evidence may be retained while embeddings are rebuilt and sealed by exact #822",
+    "replaced_case_8707": "excluded after its exact #822 cold scan failed strict READY on three repository .templ files with no locked language server; its completed A call and terminal evaluation remain diagnostic-only, no RNA arm will run, and astropy__astropy-14096 is frozen as the fresh replacement before any model call on that case"
   },
   "cases": [
     {
@@ -125,12 +127,12 @@
       "prior_outcomes": "development-only; prior evaluator-feedback resolution is invalid for C+"
     },
     {
-      "instance_id": "astropy__astropy-8707",
+      "instance_id": "astropy__astropy-14096",
       "repository": "astropy/astropy",
-      "base_commit": "a85a0747c54bac75e9c3b2fe436b105ea029d6cf",
-      "problem_statement_utf8_bytes": 840,
-      "problem_statement_sha256": "f7420a19ba5b0c807396a84da376d8303e69ff66d0216c332adf099da589a714",
-      "role": "previously unrun fresh development case",
+      "base_commit": "1a4462d72eb03f30dc83a879b1dd57aac8b2c18b",
+      "problem_statement_utf8_bytes": 982,
+      "problem_statement_sha256": "938971021e89cd882f6ea33d61202fe7aa0091d7be4748b100ddc7e164db90cd",
+      "role": "previously unrun fresh development case replacing an exact-artifact inventory incompatibility",
       "prior_outcomes": "none"
     }
   ],
@@ -172,7 +174,8 @@
   "confirmatory_exclusion": [
     "astropy__astropy-13398",
     "astropy__astropy-14369",
-    "astropy__astropy-8707"
+    "astropy__astropy-8707",
+    "astropy__astropy-14096"
   ],
   "causal_limit": "A C+ advantage selects an operational treatment but does not separately identify graph-context and revision-call effects without a later C or compute-matched ablation.",
   "oracle_arm": null

--- a/benchmark/swebench-non-oracle/development-screen.json
+++ b/benchmark/swebench-non-oracle/development-screen.json
@@ -23,6 +23,96 @@
     "c_plus_revision_budget_usd": 3.0,
     "terminal_evaluations_per_arm": 1
   },
+  "agent_invocation": {
+    "initial_wall_timeout_seconds": 1200,
+    "revision_wall_timeout_seconds": 600,
+    "tools": "Bash,Edit,Read,Write,Glob,Grep",
+    "safe_mode": true,
+    "strict_empty_mcp_config": true,
+    "disallowed_tools": [
+      "WebSearch",
+      "WebFetch"
+    ],
+    "prompt_transport": "stdin",
+    "stop_rule": "one initial Claude Code session per arm; C+ alone receives one resumed revision turn; stop on terminal response, registered dollar budget, or wall timeout; no evaluator feedback and no retry",
+    "workspace_rule": "byte-identical separate pristine source-only checkouts at the registered base commit, with no git remote and no .oh cache visible to the model",
+    "case_13398_A_prompt_sha256": "81bdb7858000e310ac7f3d0d76557130a0ba74108291b8e96893d016ffab3db8"
+  },
+  "rna_treatment_construction": {
+    "query": "the exact registered problem-statement bytes as the sole positional query",
+    "acquisition": {
+      "flags": [
+        "--search-mode=hybrid",
+        "--rerank",
+        "--include-artifacts=false",
+        "--projection=evidence",
+        "--body-policy=none",
+        "--limit=20",
+        "--max-output-bytes=160000",
+        "--max-output-tokens=40000"
+      ]
+    },
+    "ranked_body_hydration": {
+      "flags": [
+        "--search-mode=hybrid",
+        "--rerank",
+        "--include-artifacts=false",
+        "--projection=agent",
+        "--body-policy=focused_span",
+        "--limit=20",
+        "--max-body-bytes=4000",
+        "--max-total-body-bytes=30000",
+        "--max-output-bytes=60000",
+        "--max-output-tokens=15000"
+      ]
+    },
+    "task_boundaries": {
+      "flags": [
+        "--search-mode=hybrid",
+        "--rerank",
+        "--include-artifacts=false",
+        "--projection=agent",
+        "--body-policy=focused_span",
+        "--limit=20",
+        "--max-body-bytes=3000",
+        "--max-total-body-bytes=20000",
+        "--max-output-bytes=50000",
+        "--max-output-tokens=12500",
+        "--context-mode=task",
+        "--context-roles=editable_source,definition_or_api_state,test,behavioral_analogue,direct_dependency,caller_or_impact",
+        "--context-facets=behavior,api_or_state,test,analogue"
+      ],
+      "lane_policy": "request every registered role, preserve every role receipt and omission reason, and never fill an empty lane manually or with an LLM"
+    },
+    "graph_delta": {
+      "flags": [
+        "--search-mode=hybrid",
+        "--rerank",
+        "--include-artifacts=false",
+        "--projection=agent",
+        "--body-policy=focused_span",
+        "--limit=20",
+        "--max-body-bytes=3000",
+        "--max-total-body-bytes=16000",
+        "--max-output-bytes=40000",
+        "--max-output-tokens=10000",
+        "--context-mode=graph-delta-beta",
+        "--proposal=<exact terminal first-stage unified diff bytes>"
+      ],
+      "novelty_rule": "remove records whose stable node identity already appeared in B acquisition/hydration or C+ task-boundary packets; preserve the unfiltered receipt and record every removed identity; never substitute"
+    },
+    "fail_closed": [
+      "exact #822 artifact, binary, manifest, repository commit, tree, and case identities match",
+      "fresh reopen reports strict READY with semantic search and rerank available",
+      "acquisition selects one or more stable node identities and every selected identity hydrates",
+      "task-boundary output contains receipts for every registered role, including explicit omission reasons for empty lanes",
+      "all rendered packet bytes and SHA-256 identities are frozen before the corresponding model call"
+    ]
+  },
+  "pre_registration_diagnostics": {
+    "invalid_A_attempt": "one A process was started before this exact addendum, interrupted after 89.374 seconds and $0.7090892, received no evaluator output, and is excluded from every comparison",
+    "old_semantic_cache": "the retained aa92ece semantic generation was rejected by exact #822 and is excluded; structural evidence may be retained while embeddings are rebuilt and sealed by exact #822"
+  },
   "cases": [
     {
       "instance_id": "astropy__astropy-13398",
@@ -59,7 +149,8 @@
     }
   },
   "shared_policy": {
-    "same_checkout": true,
+    "separate_pristine_checkouts": true,
+    "same_base_commit_and_tree": true,
     "same_base_agent_tools": true,
     "same_visible_test_policy": true,
     "same_initial_model_budget": true,

--- a/benchmark/swebench-non-oracle/development-screen.json
+++ b/benchmark/swebench-non-oracle/development-screen.json
@@ -36,7 +36,8 @@
     "prompt_transport": "stdin",
     "stop_rule": "one initial Claude Code session per arm; C+ alone receives one resumed revision turn; stop on terminal response, registered dollar budget, or wall timeout; no evaluator feedback and no retry",
     "workspace_rule": "byte-identical separate pristine source-only checkouts at the registered base commit, with no git remote and no .oh cache visible to the model",
-    "case_13398_A_prompt_sha256": "81bdb7858000e310ac7f3d0d76557130a0ba74108291b8e96893d016ffab3db8"
+    "case_13398_A_prompt_sha256": "81bdb7858000e310ac7f3d0d76557130a0ba74108291b8e96893d016ffab3db8",
+    "case_8707_A_prompt_sha256": "fd8f818724ffb35673142ddc9d8f5b0a51cc244db3c939dc17a1a3727ee20675"
   },
   "rna_treatment_construction": {
     "query": "the exact registered problem-statement bytes as the sole positional query",

--- a/benchmark/swebench-non-oracle/development-screen.json
+++ b/benchmark/swebench-non-oracle/development-screen.json
@@ -178,5 +178,429 @@
     "astropy__astropy-14096"
   ],
   "causal_limit": "A C+ advantage selects an operational treatment but does not separately identify graph-context and revision-call effects without a later C or compute-matched ablation.",
-  "oracle_arm": null
+  "oracle_arm": null,
+  "preregistration_amendments": [
+    {
+      "id": "816-treatment-construction-mechanics-v2",
+      "amended_at": "2026-07-22T11:55:34Z",
+      "base_document_sha256": "f3a9cd7384373ae501b3a48ce30df605d2b861dddb5a6354b1777f80ac568aca",
+      "base_git_head": "793b70cb5394cc1d3e18af43a03cd1993db2d27b",
+      "effective_for_arms": [
+        "B",
+        "C+"
+      ],
+      "knowledge_state": {
+        "A_outcomes_observed": true,
+        "B_or_C_plus_model_calls_started": false,
+        "retrieval_and_projection_dry_runs_observed": true,
+        "amendment_scope": "treatment-construction mechanics only after both A controls terminated and before any B or C+ model call"
+      },
+      "reason": [
+        "The earlier whole-issue query included hidden GitHub template comments and did not reliably localize both development cases.",
+        "RNA queries must bind the exact populated root rather than depend on ambient root selection.",
+        "Raw renderer metadata can exceed the earlier output limits and must be retained out of band rather than enter model context.",
+        "The exact #822 artifact cannot source-address the injected checkout through native hydration, so ranked stable identities require deterministic verifier-bound tracked-source slicing.",
+        "The exact #822 native task selector does not implement the registered negative-test, rejection-path, validation-consumer, error-path, caller, and analogue boundary lanes; its failed probes remain diagnostic only.",
+        "C+ boundary candidates therefore come only from typed one-hop graph traversal rooted at the frozen B identities under a case-independent policy."
+      ],
+      "unchanged_json_pointers": [
+        "/runtime",
+        "/agent_invocation",
+        "/cases",
+        "/arms",
+        "/shared_policy",
+        "/selection_order",
+        "/causal_limit",
+        "/oracle_arm"
+      ],
+      "supersedes_json_pointers": [
+        "/rna_treatment_construction/query",
+        "/rna_treatment_construction/acquisition",
+        "/rna_treatment_construction/ranked_body_hydration",
+        "/rna_treatment_construction/task_boundaries",
+        "/rna_treatment_construction/graph_delta",
+        "/rna_treatment_construction/fail_closed"
+      ],
+      "effective_treatment_construction": {
+        "model_problem_statement": {
+          "policy": "The model receives the exact raw registered UTF-8 problem-statement bytes; the retrieval-query transform does not alter those prompt bytes."
+        },
+        "retrieval_query": {
+          "policy_id": "salient-query-v1",
+          "transform": "Remove non-overlapping <!--.*?--> byte spans with DOTALL non-greedy matching. From the remaining bytes select the first non-empty line and every equal-delimiter inline backtick span outside fenced code blocks, retaining delimiters, duplicates, and source order. Join components with one LF and no trailing separator. Perform no other trimming, normalization, or line-ending conversion.",
+          "language_filter": "--language=python",
+          "generator": {
+            "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/salient-query-v1/run_probe.py",
+            "bytes": 16693,
+            "sha256": "07091f531da5c139fc841564f188c23b07c73b641c5935909e3a85a415dae653"
+          },
+          "preserved_output_revalidator": {
+            "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/salient-query-v1/revalidate_preserved.py",
+            "sha256": "cfa75cdb84af5989cee3d47e8a3a3718d009e2b5f7f24b220cadb15588b5efb1"
+          },
+          "summary_revalidated": {
+            "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/salient-query-v1/summary-revalidated.json",
+            "sha256": "b2c83b7bd4bc740287d0d27d39a5f0799cb3cc635e1cd48b8428af273342c601",
+            "verdict": "mechanically valid for both cases using preserved stdout only; no RNA rerun"
+          },
+          "cases": {
+            "astropy__astropy-13398": {
+              "raw_issue_utf8_bytes": 5323,
+              "raw_issue_sha256": "c26c8dc258dc5cb9dd34f30bdbaaed3f19a8ada137e0f19d81d7f57dc5f11bba",
+              "html_comment_stripped_utf8_bytes": 4434,
+              "html_comment_stripped_sha256": "876fd0ad143f431be851d7c20261e946260bc9afed140d1be84db4c20b66c24f",
+              "salient_query_utf8_bytes": 186,
+              "salient_query_sha256": "65ad3458f2c42298238b3bed40aef40977d7d46907c1bd68c78df7844058c9e0",
+              "root": "checkout",
+              "argv_sha256": "46954461d82cb984f1a355b4626afbb22e867af40a03d323b651356b8db4d638",
+              "raw_stdout_bytes": 37287,
+              "raw_stdout_sha256": "b8a365d7c01c08cfcad428530ac8021a4a3080ce377ee4e75c22ab4b0e5875ab",
+              "raw_stderr_bytes": 422,
+              "raw_stderr_sha256": "54740fbb0ec8bfe072c005912bc3317597499edab35d87ea36aaa6e290595784"
+            },
+            "astropy__astropy-14096": {
+              "raw_issue_utf8_bytes": 982,
+              "raw_issue_sha256": "938971021e89cd882f6ea33d61202fe7aa0091d7be4748b100ddc7e164db90cd",
+              "html_comment_stripped_utf8_bytes": 982,
+              "html_comment_stripped_sha256": "938971021e89cd882f6ea33d61202fe7aa0091d7be4748b100ddc7e164db90cd",
+              "salient_query_utf8_bytes": 114,
+              "salient_query_sha256": "32fd29bf86670faff5295a570799bb9c36b11e8efae220d7946202e6ce98c404",
+              "root": "astropy-astropy-14096",
+              "argv_sha256": "e618178d582d06f2b586aa8ee2cc447703f7bee58e8d9c4c8561ff61045659b1",
+              "raw_stdout_bytes": 159869,
+              "raw_stdout_sha256": "d534067cacb68079acfcfac0b46235a5a1a25691b78a76aa3242c9f79dd0d036",
+              "raw_stderr_bytes": 422,
+              "raw_stderr_sha256": "634c4a671562a58a2d1cd0ab6be12851c212f4a2e3670818ddad94cc1253650b"
+            }
+          }
+        },
+        "root_and_readiness_binding": {
+          "astropy__astropy-13398": {
+            "root": "checkout",
+            "commit": "6500928dc0e57be8f06d1162eacc3ba5e2eff692",
+            "tree": "059e0f861b196c0e3d666cbef9c8b13281c31b9f",
+            "status": "READY",
+            "included_files": 1615,
+            "completeness_violations": 0,
+            "completeness_digest": "965a519a1e3449523c6bca80d15ee9de66bf7e937e9ad6d59abb1a2ff770c2d0",
+            "completeness_report_sha256": "86b6c21fbc37997e454980c80c962e37a138ecf97ca3789b996bb8ec0dcb7ff5",
+            "extract_completed_sha256": "70699553f0ca79b2b99647bf792a1c7071268ff959a5aa5ae6a260f80c9a982c",
+            "lsp_completed_sha256": "70699553f0ca79b2b99647bf792a1c7071268ff959a5aa5ae6a260f80c9a982c",
+            "graph_snapshot_digest": "79828d9e5c9a58c3999ecc4cb5e33fd838e9df2b88638ac77fe70734d01a8623",
+            "semantic_generation_digest": "5167c4d1cbbb910debe2da43f1f1779a565aa33f8c333540b0803b14bbe6b1af",
+            "semantic_manifest_sha256": "cb981c055169910cd00f67ae9c9445df625ba1283d23b1f74e1ec0723a5f6a83",
+            "semantic_pointer_sha256": "ea4483cc726488e3ec26bda16a0f03f56cdd2fcd1889caec746b8c53eae47ea2"
+          },
+          "astropy__astropy-14096": {
+            "root": "astropy-astropy-14096",
+            "commit": "1a4462d72eb03f30dc83a879b1dd57aac8b2c18b",
+            "tree": "d57ee70657df0c1ff39fb3ca89b07aadae6ca3f6",
+            "status": "READY",
+            "included_files": 1664,
+            "completeness_violations": 0,
+            "completeness_digest": "f70b6a9a58c1d00491e80aefdf9169a91b6aae561b1d23794b5dce4393553761",
+            "completeness_report_sha256": "3070de7636b83e923a8af794a73d89e8bd7c970591d95639d6b49e5d0aeaa5d1",
+            "extract_completed_sha256": "23ff9218470e52d1a91fe16326321048d04d5aa94093e6e09efc3d6420fc5690",
+            "lsp_completed_sha256": "23ff9218470e52d1a91fe16326321048d04d5aa94093e6e09efc3d6420fc5690",
+            "graph_snapshot_digest": "990c0963f51a6ddee95863d653cae645026e3797c1a22c9c34eaada1625f2e5b",
+            "semantic_generation_digest": "559d1f1ce8213fd080c1a6b8738c7a4ab61be3184b31b0cbc8363c7e5dffaa4c",
+            "semantic_manifest_sha256": "3ed9e66856a876af204bc528a146249ec7582e418633540427b82dad64de1a0e",
+            "semantic_pointer_sha256": "1899c58c7e5ebc09a9d3806d38baa67c1a0936dcd06cde58492925f12b5f17fa"
+          },
+          "requirement": "Each command and retained receipt must match the registered root, commit, tree, exact #822 binary, strict READY status, zero completeness violations, semantic generation, and rerank availability."
+        },
+        "semantic_acquisition": {
+          "flags": [
+            "--search-mode=hybrid",
+            "--rerank",
+            "--include-artifacts=false",
+            "--projection=agent",
+            "--body-policy=focused_span",
+            "--limit=20",
+            "--max-body-bytes=4000",
+            "--max-total-body-bytes=30000",
+            "--max-output-bytes=160000",
+            "--max-output-tokens=40000",
+            "--language=python"
+          ],
+          "raw_capture_policy": "Preserve complete stdout, stderr, argv, receipt, hashes, readiness sections, capability sections, and renderer accounting out of band. Any truncation or incomplete terminal section fails closed.",
+          "revalidation_disclosure": "The initial validator falsely marked multiline const/import stable IDs missing. The sha-bound preserved stdout was reparsed without an RNA rerun; summary-revalidated.json is authoritative and reports 20 of 20 stable identities for both cases."
+        },
+        "ranked_source_projection": {
+          "projector": {
+            "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/projection-prototype/project_ranked_code.py",
+            "bytes": 37587,
+            "sha256": "f02adfa2e4d9db1cf354f2226700fcaed4d4cf020bb1bd44ee69069cce1592bf"
+          },
+          "correction_receipt": {
+            "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/projection-prototype/salient-v1/projector-correction-receipt.json",
+            "sha256": "00c686f6928dd849fa14daa6693484e8691922e999ff58c3825f22110ce966ec"
+          },
+          "eligibility": "Retain every RNA-selected identity with the expected root, a tracked .py path, a valid non-empty source span, and kind other than markdown_section. No other node-kind filter, manual selection, LLM selection, or case-specific rule is permitted.",
+          "ordering": "Preserve ascending RNA rank; the first exact stable identity wins only for exact-ID duplication.",
+          "hydration": {
+            "method": "Resolve only each retained stable identity's exact path and line span against the clean verifier-matched checkout, require the tracked git blob, and use scripts/swebench_context_packets.py::source_slice.",
+            "source_module_path": "/Users/muness/src/open-horizon-labs/repo-native-alignment-816/scripts/swebench_context_packets.py",
+            "source_module_sha256": "3aaffdd227880ba807bc78867ed8cd03e6604802b718fe939b375153541204f0",
+            "source_module_git_blob": "99d0ea606208abfac0b849ed60f802def74c9b4f",
+            "span_deduplication": "Identical path/start/end/git-blob spans emit one inline body while every RNA rank and stable identity remains in the manifest receipt."
+          },
+          "model_visible_policy": "Only ranked identity, tracked source address, and hydrated source body enter the model packet. Capability, readiness, renderer accounting, documentation, warnings, and omissions remain out of band.",
+          "cases": {
+            "astropy__astropy-13398": {
+              "manifest_path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/projection-prototype/salient-v1/astropy__astropy-13398/astropy__astropy-13398.projection-manifest.json",
+              "manifest_bytes": 23499,
+              "manifest_sha256": "844f2a78105fa5bb145e13c70035dfbb58e2a49f1ad0e55c9dda37f7fd22e707",
+              "selected_identities": 20,
+              "packet_path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/projection-prototype/salient-v1/astropy__astropy-13398/astropy__astropy-13398.code-context.txt",
+              "packet_utf8_bytes": 19405,
+              "packet_estimated_tokens": 4852,
+              "packet_sha256": "29ce72aeb19c99913d05b9dd5146f777c8e37f8321157ee47fa7af624d6dcb38"
+            },
+            "astropy__astropy-14096": {
+              "manifest_path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/projection-prototype/salient-v1/astropy__astropy-14096-attempt2/astropy__astropy-14096.projection-manifest.json",
+              "manifest_bytes": 46662,
+              "manifest_sha256": "b4d2a778c368c340f7e80666f869c894c4bd281511032e306d0b9870134fe857",
+              "selected_identities": 20,
+              "packet_path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/projection-prototype/salient-v1/astropy__astropy-14096-attempt2/astropy__astropy-14096.code-context.txt",
+              "packet_utf8_bytes": 57242,
+              "packet_estimated_tokens": 14311,
+              "packet_sha256": "3706c387c7f134cfcec7aa6ef7cb334184e0ef825855abce37206e1bb60f32b1"
+            }
+          }
+        },
+        "c_plus_graph_boundaries": {
+          "selection_authority": "Typed one-hop RNA graph neighbors of the frozen arm-B stable identities only; neither issue terms nor native task-context output contribute candidates.",
+          "producer": {
+            "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/graph-boundary-projector/graph_boundary_projector.py",
+            "bytes": 32993,
+            "sha256": "0984ceafb1522482ddebd3e0c9fa418ce0c79f1bf26f2d16929379a4c0d62f5d"
+          },
+          "policy": {
+            "sha256": "83c124c01dcb3fb1267272a76ad5cf7b1a1be4773a656e2c7da7f7343832441c",
+            "case_specific_terms": [],
+            "query": "For each of the 20 frozen B identities, run exact #822 search --repo <clean-checkout> --root=<registered-root> --node <seed> --mode=neighbors --direction=<incoming then outgoing> --hops=1 --limit=100 --compact, yielding exactly 40 traversal receipts per case.",
+            "candidate_requirements": "Every candidate must carry a stable identity, typed edge and seed provenance, tracked UTF-8 source span, and git-blob verification. Exclude B identities, any source span overlapping B, non-source records, and non-allowlisted source extensions.",
+            "lane_order": [
+              "negative_tests",
+              "rejection_paths",
+              "validation_consumers",
+              "error_paths",
+              "callers",
+              "analogues"
+            ],
+            "lane_limits": {
+              "negative_tests": 6,
+              "rejection_paths": 4,
+              "validation_consumers": 4,
+              "error_paths": 4,
+              "callers": 6,
+              "analogues": 4
+            },
+            "body_limits": {
+              "max_selected": 24,
+              "max_body_bytes": 3500,
+              "max_total_body_bytes": 30000,
+              "truncation_head_bytes": 2600,
+              "truncation_tail_bytes": 800
+            },
+            "classification": "Use only the canonical case-independent edge/token predicates serialized in the policy artifact. Empty lanes remain explicitly empty; no fallback impact search, lexical relabeling of B seeds, substitution, manual selection, or LLM selection is allowed.",
+            "ordering": "primary lane order, then minimum B-seed rank, then stable identity",
+            "deduplication": "stable identity, identical tracked source span, and all B source spans"
+          },
+          "aggregate_summary": {
+            "path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/graph-boundary-projector/salient-v1-final.json",
+            "sha256": "71ace338fbd3307fe114f1291c68e153162c6fb25db909705e3a9abc7226643d"
+          },
+          "native_task_selector": "Diagnostic only and never model-visible. Failed native-role probes do not authorize fallback or candidate selection.",
+          "cases": {
+            "astropy__astropy-13398": {
+              "seed_manifest_sha256": "844f2a78105fa5bb145e13c70035dfbb58e2a49f1ad0e55c9dda37f7fd22e707",
+              "traversal_query_count": 40,
+              "traversal_summary_sha256": "2cb8a4df17e0cf08a503529f47505adee55766910b2f40b87e6d2150176b08a4",
+              "manifest_path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/graph-boundary-projector/salient-v1-case13398-v1/manifest.json",
+              "manifest_bytes": 3505,
+              "manifest_sha256": "3dd467dc8ccfdbfec2e72855f78b7e9fa59cf666cb9b94fcafceee4093546bcf",
+              "selected_identities": 16,
+              "primary_lane_counts": {
+                "negative_tests": 2,
+                "rejection_paths": 4,
+                "validation_consumers": 2,
+                "error_paths": 2,
+                "callers": 6,
+                "analogues": 0
+              },
+              "packet_path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/graph-boundary-projector/salient-v1-case13398-v1/graph-boundary-context.txt",
+              "packet_utf8_bytes": 29290,
+              "packet_sha256": "a816f0c5e65ad2ac93b5c1f511e3c7032fa464c5422b31c0f4f8e7746e962037"
+            },
+            "astropy__astropy-14096": {
+              "seed_manifest_sha256": "b4d2a778c368c340f7e80666f869c894c4bd281511032e306d0b9870134fe857",
+              "traversal_query_count": 40,
+              "traversal_summary_sha256": "686e39fbb3c208d93655e0d2b58b3dcb611f56a12bd8fb9a02a1bc82877711fa",
+              "manifest_path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/graph-boundary-projector/salient-v1-case14096-v1/manifest.json",
+              "manifest_bytes": 3528,
+              "manifest_sha256": "c47f1859aac3269c3cab8f47af546de4d24469f27507fd6cb63caeff20375148",
+              "selected_identities": 20,
+              "primary_lane_counts": {
+                "negative_tests": 6,
+                "rejection_paths": 4,
+                "validation_consumers": 2,
+                "error_paths": 4,
+                "callers": 4,
+                "analogues": 0
+              },
+              "packet_path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/graph-boundary-projector/salient-v1-case14096-v1/graph-boundary-context.txt",
+              "packet_utf8_bytes": 41388,
+              "packet_sha256": "f32a112f5ecf2983d8469990d9dafffa3076d51db9e8f3204f70bd0dcbbc5978"
+            }
+          }
+        },
+        "c_plus_revision": {
+          "policy": "After C+'s first terminal draft, run the registered exact-root graph-delta-beta query once using the exact terminal unified diff bytes as proposal. Preserve the complete raw receipt at 160000 output bytes and 40000 output tokens. Remove identities and tracked source spans already present in the frozen B and initial C+ manifests, preserve every removal receipt, freeze the novel packet and hashes before resuming the same Claude session once, and never provide test or evaluator output.",
+          "future_receipt_rule": "Proposal-dependent raw and model-visible hashes are necessarily created after the first-stage diff, but the command, root binding, novelty algorithm, 3000 per-body byte limit, 16000 total-body byte limit, 3 USD budget, 600 second timeout, and no-retry stop rule are frozen by this amendment."
+        },
+        "fail_closed": {
+          "process_checks": [
+            "exit status is zero",
+            "stdout and stderr contain no Error:, Fatal:, Invalid search context:, unknown context_mode, context_roles/context_facets require context_mode=task, or invalid task-context selection policy diagnostic",
+            "the parsed search result contains every required terminal section and no truncation marker"
+          ],
+          "identity_checks": [
+            "exact #822 artifact, binary, manifest, launcher, repository commit, tree, root, case identity, and query SHA match",
+            "strict READY, zero completeness violations, semantic generation, and rerank capability match the registered receipts",
+            "reported selected count equals parsed stable-identity count and is non-zero",
+            "every selected B identity remains in the B manifest and hydrates from a tracked git-blob-verified .py source span",
+            "every selected C+ identity has typed one-hop edge and B-seed provenance, is not a B identity or overlapping B span, and hydrates from a tracked git-blob-verified source span",
+            "every boundary lane has either selected receipts or an explicit empty-lane receipt",
+            "all raw outputs, manifests, packets, prompts, and orchestration inputs match their registered byte counts and SHA-256 identities"
+          ],
+          "native_source_diagnostic_exception": "The exact preserved RNA outputs' native source-root hydration warning is audit evidence, not authorization to omit bodies. It is accepted only because every selected B identity is independently hydrated and verified by the registered projector; any external hydration miss fails the arm.",
+          "rule": "Exit status zero alone is never success; any missing field, mismatch, unexpected diagnostic, truncation, partial archive, projection omission, or hash drift aborts before the model call."
+        },
+        "frozen_model_orchestration": {
+          "manifest_path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/model-orchestration/frozen-run-manifest.json",
+          "manifest_bytes": 8286,
+          "manifest_sha256": "fd2be798f860e77cc81b7ac48ff4992e0528681c695be2feb2b6320218f30648",
+          "orchestrator_path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/model-orchestration/orchestrate_screen.py",
+          "orchestrator_bytes": 37523,
+          "orchestrator_sha256": "06cfff0c98eb63e29967d0d13b9189aba6c8838b9701cbfe139efb2e31f7e542",
+          "strict_empty_mcp_path": "/Users/muness/swebench-evidence/issue816-development-screen-20260722T1015Z/model-orchestration/empty-mcp.json",
+          "strict_empty_mcp_bytes": 18,
+          "strict_empty_mcp_sha256": "e93fc8db2b1bd77107fe6c758bca9545fa864cf7cce8ab93a7b2b93a1d566a7b",
+          "global_preflight": "return code 0 with all expected output paths absent and no model calls",
+          "initial_prompts": {
+            "astropy__astropy-13398": {
+              "B": {
+                "session_id": "81613398-0000-4000-8000-00000000000b",
+                "utf8_bytes": 25754,
+                "sha256": "a52cfe33480615802ffa3b2a865f37aed387dd4b9388811584a020cb22f956e6"
+              },
+              "C+": {
+                "session_id": "81613398-0000-4000-8000-00000000000c",
+                "utf8_bytes": 55617,
+                "sha256": "5846cb78e262c2b5c5eab2af39c3532f878738611ae79310958cb2b24ef44774"
+              }
+            },
+            "astropy__astropy-14096": {
+              "B": {
+                "session_id": "81614096-0000-4000-8000-00000000000b",
+                "utf8_bytes": 59250,
+                "sha256": "ed264b892f1767796da8990a36c3db1ee874a5683d163702b4ffd6b7a6a8355d"
+              },
+              "C+": {
+                "session_id": "81614096-0000-4000-8000-00000000000c",
+                "utf8_bytes": 101211,
+                "sha256": "e425737e8f17131780eae2faeecfb2a068566a3d513f93a07908679bd05675ac"
+              }
+            }
+          }
+        }
+      },
+      "observed_control_outcomes": {
+        "astropy__astropy-13398": {
+          "observed_before_amendment": true,
+          "session_id": "81613398-0000-4000-8000-00000000000a",
+          "terminal_reason": "completed",
+          "stop_reason": "end_turn",
+          "model_wall_ms": 719997,
+          "model_api_ms": 571630,
+          "claude_cli_turns": 103,
+          "unique_sonnet_messages": 100,
+          "usage": {
+            "input_tokens": 200,
+            "cache_creation_input_tokens": 149551,
+            "cache_read_input_tokens": 9012434,
+            "output_tokens": 42342
+          },
+          "model_usage": {
+            "claude-sonnet-5": {
+              "input_tokens": 200,
+              "cache_creation_input_tokens": 149551,
+              "cache_read_input_tokens": 9012434,
+              "output_tokens": 42342,
+              "cost_usd": 4.2367662
+            },
+            "claude-haiku-4-5-20251001": {
+              "input_tokens": 2139,
+              "cache_creation_input_tokens": 0,
+              "cache_read_input_tokens": 0,
+              "output_tokens": 19,
+              "cost_usd": 0.002234
+            }
+          },
+          "total_cost_usd": 4.2390002,
+          "permission_denials": [],
+          "result_json_sha256": "0a66a7602003f3f69b370e3584c5c93cfab66fe73bf0db1fbf29bfcd5498d69e",
+          "terminal_patch_sha256": "eb566b529439c4dc55f1f49318fdf1e3f5aca08dd48b538d0f0e12f0177b1060",
+          "official_evaluation": {
+            "resolved": false,
+            "fail_to_pass_passed": 0,
+            "fail_to_pass_total": 4,
+            "pass_to_pass_regressions": 5,
+            "report_sha256": "584cf4388f61fa1327ca8650902c895bf0ed11591e425e424d270a85ba44e211"
+          }
+        },
+        "astropy__astropy-14096": {
+          "observed_before_amendment": true,
+          "session_id": "81614096-0000-4000-8000-00000000000a",
+          "recovery_disclosure": "The Codex host restarted after the terminal end_turn but before the Claude CLI top-level result object was retained. The one-shot session was not resumed or rerun; usage and terminal response were reconstructed from the retained transcript.",
+          "terminal_reason": "completed",
+          "stop_reason": "end_turn",
+          "model_wall_ms": 364605,
+          "unique_sonnet_messages": 43,
+          "usage": {
+            "input_tokens": 86,
+            "cache_creation_input_tokens": 41727,
+            "cache_read_input_tokens": 1413679,
+            "output_tokens": 15187
+          },
+          "reconstructed_sonnet_cost_usd": 0.9025287,
+          "transcript_sha256": "ba0dc88ef0d3197707807fa2adc021e222e4fccaa960d3aaef46f8fc607a63e2",
+          "terminal_response_sha256": "bb70a08c1e754df6ab95ea4064d1a393228a8b9c51d8da0b9462d5933868b0de",
+          "recovery_record_sha256": "b7981390f9fd9695229049d99637c8947978c048e7fb798e54f58d40c8545d46",
+          "terminal_patch_sha256": "c949f84a9828bd2c58282ad05fafd558b96d4ef1ef39378f5cb43fe07b48752e",
+          "official_evaluation": {
+            "resolved": true,
+            "fail_to_pass_passed": 1,
+            "fail_to_pass_total": 1,
+            "pass_to_pass_passed": 426,
+            "pass_to_pass_total": 426,
+            "pass_to_pass_regressions": 0,
+            "report_sha256": "b83e0b1a3d3276f3a24051e581f4ba72819d4b0c40de92f1e39ed0bdfc7f148e"
+          }
+        }
+      },
+      "validity_caveats": [
+        "This amendment is post-control and pre-treatment, so #816 remains an exploratory development screen rather than a pristine preregistration; #817 must freeze the chosen treatment independently.",
+        "The model-visible issue bytes remain exact, but salient-query-v1 replaces the original exact whole-issue retrieval query. Any report must distinguish model prompt identity from retrieval-query identity.",
+        "The salient query and code-only projection were selected after diagnosing failed retrieval mechanics. They are generic and frozen before treatment calls, but this development-stage choice can favor the treatment and cannot support an unbiased confirmatory estimate.",
+        "External tracked-source hydration and packet projection are part of the treatment. Their exact producers, manifests, source spans, blobs, packets, and hashes are therefore required evidence rather than incidental preprocessing.",
+        "C+ conceptual lanes are frozen generic classifications over typed one-hop graph candidates. They are not native #822 task-role outputs and cannot establish that the native task selector itself is effective.",
+        "The single fresh development case has weak B localization despite mechanically valid retrieval, so treatment selection remains noisy and must be confirmed on #817's disjoint population.",
+        "A/14096's recovered transport record is adequate for terminal efficacy but has weaker cost and token provenance than an ordinary top-level Claude result; disclose this if efficiency breaks a tie.",
+        "C+ combines graph-boundary evidence with one extra revision call, so any C+ advantage selects an operational policy but does not identify graph evidence separately from revision compute."
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Closes #816

## Aim
Coding agents resolve real repository issues with less discovery churn and fewer regressions because RNA supplies compact, source-grounded non-oracle context and bounded post-draft risk evidence.

## Problem
The old experiment tested representation after oracle localization. Existing exploratory evidence now shows a large end-to-end efficiency signal for corrected strict RNA semantic retrieval on one case, but no efficacy gain; manually seeded graph context preserved regressions but was not a valid RNA arm. We need a small clean treatment screen before freezing a confirmatory protocol.

## Problem-space constraints

- Development cases and all tuning outcomes are excluded from confirmation.
- A, B, and C+ use the same model, checkout, base agent/tool policy, evaluator, and terminal-evaluation boundary.
- No gold/test/evaluator-derived localization or feedback reaches an arm.
- RNA acquisition and graph lanes fail closed; no LLM/manual selector may replace a miss.
- C+ receives only bounded novel graph-delta evidence after its draft, with separate call/token/cost/time accounting.
- Selection order is resolution, PASS_TO_PASS preservation, then total tokens, cost, and end-to-end time.

## Chosen solution
Run a fixed small development screen:

- **A:** bare tool-enabled control.
- **B:** strict RNA semantic acquisition plus deterministic ranked-body hydration.
- **C+:** B plus typed graph-boundary context and one bounded post-draft graph-delta critique/revision.

Use the merged #810–#814 shared-service interfaces directly. Register cases, exact prompts, retrieval knobs, budgets, stop rules, and evidence paths before the first model call. Preserve every packet, receipt, transcript, patch, official evaluation, and failure. Select B, C+, or no treatment using the registered order.

## Alternatives considered

- B only: tests efficiency but leaves the regression-safety/efficacy candidate untested.
- Add graph-only C now: useful only for causal attribution; not required to select an operational treatment.
- Add oracle O: rejected because gold localization bypasses the claimed retrieval problem.
- Build formal #818 infrastructure first: rejected because the treatment is not yet selected.
- Simulated/synthetic-only screen: useful for packet validation but cannot answer real efficacy or efficiency.

## Known trade-off
If C+ wins, this screen cannot attribute the gain separately to graph context versus the extra revision call. That narrower claim requires a later C or compute-matched critique ablation; it does not block selecting the best treatment.

No implementation or pilot call preceded this draft PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a complete development-session record for issue 816, including execution details, evaluation criteria, limitations, and completion status.
  * Documented the RNA treatment-screen configuration, runtime constraints, case definitions, and validation rules.
* **Results**
  * Added comprehensive evaluation results covering experiment arms, episode outcomes, tool usage, token and timing metrics, integrity checks, and eligibility.
  * Recorded that arm A was the eligible selection and that the C+ treatment was ineligible.
  * Clarified that downstream issue 817 must not begin based on these results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->