### PR TITLE
Restore isolated Claude authentication before selector launch

### DIFF
--- a/.oh/sessions/835-ship.md
+++ b/.oh/sessions/835-ship.md
@@ -1,0 +1,99 @@
+# Ship Pipeline — PR #835
+
+**Started:** 2026-07-24T02:22:00Z
+**Record prepared:** 2026-07-24T02:36:10Z
+
+## Step 1: RNA-Grounded Review
+
+**Verdict:** CONTINUE
+
+The provider parent receives read access to only the exact regular
+`~/Library/Keychains/login.keychain-db` file on macOS. It receives no Keychain
+write root. `claude auth status --json` runs inside the final episode Seatbelt
+before treatment acquisition or model launch, and retains only sanitized
+zero-spend status.
+
+RNA exact and broadened queries did not index the changed benchmark modules.
+The exact diff, focused tests, and real Seatbelt execution were used as the
+bounded authority. No graph metadata or Rust input changes.
+
+## Step 2: Independent Code Review
+
+**Reviewer:** `/root/pr835_auth_review`
+**Reviewed commit:** `f0a08ff0352f28f8ffe03614c93a2a63e2731bde`
+**Verdict:** APPROVE
+
+The initial review requested portable historical verification, exact `--json`
+argv, and a real retained read-only proof. All three were fixed and rechecked.
+
+## Step 3: Fix
+
+- Historical #830 source identity is verified through the immutable
+  qualification-closure digest without requiring shallow-missing Git objects.
+- The exact auth command includes `--json`.
+- A real macOS probe reads the exact Keychain file, cannot open it for append,
+  and retains no Keychain bytes or digest.
+
+## Step 3b: Ready for Review
+
+PR #835 was marked ready. Rust jobs are not gating because no Rust CI or
+artifact-producing input changed.
+
+## Step 4: Regression Oracle
+
+- issue827: 145/145 passed.
+- evaluator tools: 11/11 passed.
+- issue830: 4/4 passed.
+- Real exact-Keychain read/unwritable Seatbelt probe passed.
+
+## Step 5: Merit Assessment
+
+**Verdict:** MERGE
+
+The change removes the proven cause of the failed pilot and prevents paid model
+launch when the exact sandbox cannot authenticate.
+
+## Step 6: Resolve TODOs
+
+No TODO, FIXME, or HACK was added. Twenty-case count generalization and terminal
+aggregation are owned by #836.
+
+## Step 7a: Manual Verification
+
+Retained proof:
+`/Users/muness/swebench-evidence/issue834-auth-preflight-f0a08ff0-attempt-002/real-provider-auth-preflight.json`
+
+SHA-256:
+`a6fcb5bdafadbb8369e9d8767b4c518b31fa08eddfd906a528a5728ac362eb8a`
+
+Result: logged in, Keychain unwritable, zero model/provider calls, zero cost,
+and no credential bytes, digest, email, or organization identifier retained.
+Failed setup attempt 001 remains preserved.
+
+## Step 7b: Delivery Verification
+
+No MCP or graph metadata changes; computed-but-not-delivered is not implicated.
+
+## Step 8: README
+
+No user-facing RNA capability documentation change is required. The operational
+contract and next experiment are recorded in #834 and #836.
+
+## Steps 9-10: Smoke and CI
+
+The exact Python suites and real zero-spend sandbox check pass. Relevant
+non-Rust CI is authoritative. No Rust build is dispatched or awaited by the
+coordinator.
+
+## Step 10b: Final Comment Sweep
+
+**Verdict:** CLEAR
+
+All independent review findings were fixed and approved. CodeRabbit was neither
+triggered nor awaited.
+
+## Step 10c: Independent Final-Diff Review
+
+Pending on the exact commit containing this ship record. The authoritative
+approval will be the fresh reviewer's PR comment; no diff change is permitted
+after it.

--- a/benchmark/swebench-rna-first/issue827/run_selector.py
+++ b/benchmark/swebench-rna-first/issue827/run_selector.py
@@ -40,6 +40,7 @@ SELECTION_SCHEMA = "issue827-fresh-pair-selection-v1"
 IDENTITY_SCHEMA = "issue827-runtime-identity-v1"
 RECEIPT_SCHEMA = "issue827-episode-receipt-v1"
 QUERY_EVIDENCE_SCHEMA = "issue827-query-evidence-v1"
+PROVIDER_AUTH_STATUS_SCHEMA = "issue827-provider-auth-status-v1"
 ISOLATION_REGISTRATION_SCHEMA = "issue827-isolation-registration-v1"
 ISOLATION_HOST_SCHEMA = "issue827-isolation-host-v1"
 WORKER_IMAGE_SCHEMA = "issue827-worker-image-manifest-v1"
@@ -1574,6 +1575,7 @@ def configure_episode(
     read_roots = [
         *map(Path, prepared.isolation_host["system_read_roots"]),
         *map(Path, prepared.isolation_host["provider_read_roots"]),
+        *provider_auth_read_files(),
         case.checkouts[arm],
         episode,
         harness_paths["harness"],
@@ -2241,6 +2243,121 @@ def provider_parent_env(model_private: Path) -> dict[str, str]:
     ):
         env[name] = str(private_tmp)
     return env
+
+
+def provider_auth_read_files(home: Path | None = None) -> list[Path]:
+    """Return the exact host credential file needed by Claude on macOS."""
+
+    if sys.platform != "darwin":
+        return []
+    keychain = (
+        (home if home is not None else Path.home())
+        / "Library"
+        / "Keychains"
+        / "login.keychain-db"
+    )
+    require(
+        keychain.is_absolute()
+        and keychain.is_file()
+        and not keychain.is_symlink()
+        and keychain.resolve(strict=True) == keychain,
+        "Claude login Keychain is not an exact regular file",
+    )
+    return [keychain]
+
+
+def verify_provider_auth(
+    prepared: PreparedRun,
+    config: Mapping[str, Any],
+    model_private: Path,
+    evidence: Path,
+) -> dict[str, Any]:
+    """Prove Claude is logged in inside the exact final provider sandbox."""
+
+    profile = Path(str(config["seatbelt_profile"]))
+    require(
+        profile.is_file() and not profile.is_symlink(),
+        "provider auth Seatbelt profile invalid",
+    )
+    command = [
+        str(prepared.isolation_host["sandbox_exec"]),
+        "-f",
+        str(profile),
+        str(prepared.claude_path),
+        "auth",
+        "status",
+    ]
+    started_at = utc_now()
+    started = time.monotonic()
+    error: str | None = None
+    returncode: int | None = None
+    stdout = b""
+    stderr = b""
+    status: dict[str, Any] = {}
+    try:
+        result = subprocess.run(
+            command,
+            cwd=model_private,
+            env=provider_parent_env(model_private),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=30.0,
+        )
+        returncode = result.returncode
+        stdout = result.stdout
+        stderr = result.stderr
+        loaded = json.loads(stdout)
+        if isinstance(loaded, dict):
+            status = loaded
+        else:
+            error = "provider auth status is not an object"
+    except (
+        OSError,
+        subprocess.TimeoutExpired,
+        UnicodeError,
+        json.JSONDecodeError,
+    ) as exc:
+        error = f"{type(exc).__name__}:{exc}"
+    logged_in = status.get("loggedIn") is True
+    valid = returncode == 0 and logged_in and error is None
+    receipt = {
+        "schema_version": PROVIDER_AUTH_STATUS_SCHEMA,
+        "started_at": started_at,
+        "ended_at": utc_now(),
+        "elapsed_seconds": time.monotonic() - started,
+        "command": command,
+        "claude": file_ref(prepared.claude_path),
+        "seatbelt_profile": file_ref(profile),
+        "returncode": returncode,
+        "logged_in": logged_in,
+        "auth_method": (
+            status.get("authMethod")
+            if isinstance(status.get("authMethod"), str)
+            else None
+        ),
+        "api_provider": (
+            status.get("apiProvider")
+            if isinstance(status.get("apiProvider"), str)
+            else None
+        ),
+        "subscription_type": (
+            status.get("subscriptionType")
+            if isinstance(status.get("subscriptionType"), str)
+            else None
+        ),
+        "stdout_sha256": sha_bytes(stdout),
+        "stderr_sha256": sha_bytes(stderr),
+        "error": error,
+        "model_invoked": False,
+        "provider_requests": 0,
+        "cost_usd": 0.0,
+    }
+    receipt_path = evidence / "provider-auth-status.json"
+    atomic_write(receipt_path, canonical(receipt))
+    require(valid, "Claude is not logged in inside the provider sandbox")
+    return file_ref(receipt_path)
 
 
 def start_trusted_rna_broker(
@@ -3083,6 +3200,11 @@ def failed_pre_model_receipt(
         "runtime_identity": file_ref(identity_path),
         "prompt": None,
         "treatment_system": None,
+        "provider_auth_status": (
+            file_ref(evidence / "provider-auth-status.json")
+            if (evidence / "provider-auth-status.json").is_file()
+            else None
+        ),
         "query_evidence": dict(query_evidence) if query_evidence is not None else None,
         "command": None,
         "started_at": None,
@@ -3141,6 +3263,26 @@ def launch_episode(
 ) -> dict[str, Any]:
     verify_checkout(str(case.checkouts[arm]), case.base_commit, case.base_tree, f"{case.case_id}/{arm} prelaunch")
     episode, evidence, identity_path, settings_path, config = configure_episode(prepared, case, arm, case_root, harness_paths)
+    try:
+        verify_provider_auth(
+            prepared,
+            config,
+            episode / "private",
+            evidence,
+        )
+    except FailClosed as exc:
+        return failed_pre_model_receipt(
+            prepared,
+            case,
+            arm,
+            episode,
+            evidence,
+            identity_path,
+            config,
+            f"provider_auth_preflight_failed:{exc}",
+            0.0,
+            None,
+        )
     treatment_system_path: Path | None = None
     query_evidence: dict[str, Any] | None = None
     rna_seconds = 0.0
@@ -3318,6 +3460,9 @@ def launch_episode(
         "runtime_identity": file_ref(identity_path),
         "prompt": file_ref(prompt_path),
         "treatment_system": file_ref(treatment_system_path) if treatment_system_path else None,
+        "provider_auth_status": file_ref(
+            evidence / "provider-auth-status.json"
+        ),
         "query_evidence": query_evidence,
         "command": command,
         "started_at": started_at,

--- a/benchmark/swebench-rna-first/issue827/run_selector.py
+++ b/benchmark/swebench-rna-first/issue827/run_selector.py
@@ -2286,6 +2286,7 @@ def verify_provider_auth(
         str(prepared.claude_path),
         "auth",
         "status",
+        "--json",
     ]
     started_at = utc_now()
     started = time.monotonic()

--- a/benchmark/swebench-rna-first/issue827/tests/test_selector_harness.py
+++ b/benchmark/swebench-rna-first/issue827/tests/test_selector_harness.py
@@ -341,6 +341,83 @@ class TrustedRnaCacheReadScopeTests(unittest.TestCase):
             )
 
 
+class ProviderAuthSeatbeltTests(unittest.TestCase):
+    @unittest.skipUnless(
+        sys.platform == "darwin" and Path("/usr/bin/sandbox-exec").is_file(),
+        "requires macOS Seatbelt",
+    )
+    def test_real_keychain_file_is_readable_and_unwritable(self) -> None:
+        keychain = (
+            Path.home()
+            / "Library"
+            / "Keychains"
+            / "login.keychain-db"
+        )
+        if not keychain.is_file() or keychain.is_symlink():
+            self.skipTest("exact login Keychain is unavailable")
+        self.assertEqual(
+            run_selector.provider_auth_read_files(),
+            [keychain],
+        )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary).resolve()
+            state = root / "state"
+            state.mkdir()
+            runtime_roots = [
+                path
+                for path in (
+                    Path("/usr"),
+                    Path("/System"),
+                    Path("/Library"),
+                    Path("/opt/homebrew"),
+                    Path(sys.prefix),
+                    Path("/private/etc"),
+                    Path("/private/var/db"),
+                    Path("/private/var/select"),
+                )
+                if path.exists()
+            ]
+            profile = root / "provider-auth-keychain.sb"
+            profile.write_text(
+                run_selector.isolation.generate_outer_seatbelt_profile(
+                    read_roots=[*runtime_roots, keychain, state],
+                    write_roots=[state],
+                )
+            )
+            profile.chmod(0o444)
+            proof = state / "proof"
+            probe = subprocess.run(
+                [
+                    "/usr/bin/sandbox-exec",
+                    "-f",
+                    str(profile),
+                    str(Path(sys.executable).resolve()),
+                    "-c",
+                    (
+                        "import os, sys; from pathlib import Path; "
+                        "target=Path(sys.argv[1]); target.read_bytes()[:1]; "
+                        "\ntry: fd=os.open(target, os.O_WRONLY|os.O_APPEND)"
+                        "\nexcept PermissionError: "
+                        "Path(sys.argv[2]).write_text('readable-unwritable')"
+                        "\nelse: os.close(fd); raise SystemExit(4)"
+                    ),
+                    str(keychain),
+                    str(proof),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(
+                probe.returncode,
+                0,
+                probe.stderr.decode(errors="replace"),
+            )
+            self.assertEqual(probe.stdout, b"")
+            self.assertEqual(proof.read_text(), "readable-unwritable")
+
+
 class TrustedRnaToolchainReadScopeTests(unittest.TestCase):
     def fixture(
         self, root: Path
@@ -1948,6 +2025,7 @@ class RunnerAndVerifierTests(unittest.TestCase):
                     str(claude),
                     "auth",
                     "status",
+                    "--json",
                 ],
             )
 

--- a/benchmark/swebench-rna-first/issue827/tests/test_selector_harness.py
+++ b/benchmark/swebench-rna-first/issue827/tests/test_selector_harness.py
@@ -1870,6 +1870,132 @@ class RunnerAndVerifierTests(unittest.TestCase):
             ):
                 self.assertEqual(env[name], expected)
 
+    def test_provider_auth_read_files_exposes_only_exact_login_keychain(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp).resolve()
+            keychains = home / "Library" / "Keychains"
+            keychains.mkdir(parents=True)
+            login = keychains / "login.keychain-db"
+            login.write_bytes(b"opaque\n")
+            sibling = keychains / "unrelated.keychain-db"
+            sibling.write_bytes(b"opaque\n")
+
+            with mock.patch.object(run_selector.sys, "platform", "darwin"):
+                files = run_selector.provider_auth_read_files(home)
+
+            self.assertEqual(files, [login])
+            self.assertNotIn(sibling, files)
+
+    def test_provider_auth_status_is_sandboxed_zero_spend_and_sanitized(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            claude = root / "claude"
+            claude.write_bytes(b"binary\n")
+            profile = root / "outer.sb"
+            profile.write_bytes(b"(version 1)\n")
+            model_private = root / "private"
+            (model_private / "tmp").mkdir(parents=True)
+            evidence = root / "evidence"
+            evidence.mkdir()
+            prepared = SimpleNamespace(
+                claude_path=claude,
+                isolation_host={"sandbox_exec": Path("/usr/bin/sandbox-exec")},
+            )
+            status = {
+                "loggedIn": True,
+                "authMethod": "claude.ai",
+                "apiProvider": "firstParty",
+                "email": "must-not-be-retained@example.invalid",
+                "orgId": "must-not-be-retained",
+                "subscriptionType": "team",
+            }
+            result = SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(status).encode(),
+                stderr=b"",
+            )
+
+            with mock.patch.object(
+                run_selector.subprocess,
+                "run",
+                return_value=result,
+            ) as launched:
+                reference = run_selector.verify_provider_auth(
+                    prepared,
+                    {"seatbelt_profile": str(profile)},
+                    model_private,
+                    evidence,
+                )
+
+            receipt = json.loads(
+                (evidence / "provider-auth-status.json").read_bytes()
+            )
+            self.assertEqual(reference["path"], str(evidence / "provider-auth-status.json"))
+            self.assertTrue(receipt["logged_in"])
+            self.assertFalse(receipt["model_invoked"])
+            self.assertEqual(receipt["provider_requests"], 0)
+            self.assertEqual(receipt["cost_usd"], 0.0)
+            self.assertNotIn("email", receipt)
+            self.assertNotIn("orgId", receipt)
+            self.assertNotIn("must-not-be-retained", json.dumps(receipt))
+            command = launched.call_args.args[0]
+            self.assertEqual(
+                command,
+                [
+                    "/usr/bin/sandbox-exec",
+                    "-f",
+                    str(profile),
+                    str(claude),
+                    "auth",
+                    "status",
+                ],
+            )
+
+    def test_provider_auth_status_fails_before_model_when_logged_out(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            claude = root / "claude"
+            claude.write_bytes(b"binary\n")
+            profile = root / "outer.sb"
+            profile.write_bytes(b"(version 1)\n")
+            model_private = root / "private"
+            (model_private / "tmp").mkdir(parents=True)
+            evidence = root / "evidence"
+            evidence.mkdir()
+            prepared = SimpleNamespace(
+                claude_path=claude,
+                isolation_host={"sandbox_exec": Path("/usr/bin/sandbox-exec")},
+            )
+            result = SimpleNamespace(
+                returncode=1,
+                stdout=b'{"loggedIn":false,"authMethod":"none"}\n',
+                stderr=b"",
+            )
+
+            with mock.patch.object(
+                run_selector.subprocess,
+                "run",
+                return_value=result,
+            ):
+                with self.assertRaisesRegex(
+                    run_selector.FailClosed,
+                    "Claude is not logged in inside the provider sandbox",
+                ):
+                    run_selector.verify_provider_auth(
+                        prepared,
+                        {"seatbelt_profile": str(profile)},
+                        model_private,
+                        evidence,
+                    )
+
+            receipt = json.loads(
+                (evidence / "provider-auth-status.json").read_bytes()
+            )
+            self.assertFalse(receipt["logged_in"])
+            self.assertFalse(receipt["model_invoked"])
+            self.assertEqual(receipt["provider_requests"], 0)
+            self.assertEqual(receipt["cost_usd"], 0.0)
+
     def test_token_ledger_prefers_whole_invocation_model_usage_without_double_counting(self):
         summary = {
             "usage": {

--- a/benchmark/swebench-rna-first/issue830/verify_successor.py
+++ b/benchmark/swebench-rna-first/issue830/verify_successor.py
@@ -9,16 +9,12 @@ import json
 from pathlib import Path
 import re
 import stat
-import subprocess
 import sys
 from typing import Any, Mapping
 
 
 HERE = Path(__file__).resolve().parent
 HARNESS = HERE.parent / "issue827"
-REPOSITORY = HERE.parents[2]
-REGISTERED_SOURCE_COMMIT = "d40069ad28f8525560ba7af59268b1653a74d481"
-REGISTERED_SOURCE_TREE = "370b08743c7bed38896ce3246ca67c7bd5bee202"
 HEX40 = re.compile(r"[0-9a-f]{40}")
 EXPECTED_ARTIFACT = {
     "producer_commit": "13c74539441adeef1ffd7d68b413ff148203f21c",
@@ -83,58 +79,6 @@ def sha_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def verify_historical_registered_sources(
-    registration: Mapping[str, Any],
-    registered_file_names: Mapping[str, str],
-) -> None:
-    tree = subprocess.run(
-        [
-            "git",
-            "-C",
-            str(REPOSITORY),
-            "rev-parse",
-            f"{REGISTERED_SOURCE_COMMIT}^{{tree}}",
-        ],
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    require(
-        tree.returncode == 0
-        and tree.stdout.decode().strip() == REGISTERED_SOURCE_TREE,
-        "historical registered source tree unavailable",
-    )
-    registered = registration.get("registered_files")
-    require(isinstance(registered, dict), "registered source hashes missing")
-    for key, filename in registered_file_names.items():
-        source = subprocess.run(
-            [
-                "git",
-                "-C",
-                str(REPOSITORY),
-                "show",
-                (
-                    f"{REGISTERED_SOURCE_COMMIT}:"
-                    "benchmark/swebench-rna-first/issue827/"
-                    f"{filename}"
-                ),
-            ],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=False,
-        )
-        require(
-            source.returncode == 0,
-            f"historical registered source unavailable: {filename}",
-        )
-        require(
-            registered.get(key) == sha_bytes(source.stdout),
-            f"historical registered source hash mismatch: {filename}",
-        )
-
-
 def verify_registration(
     registration_path: Path,
     lineage_path: Path,
@@ -154,9 +98,10 @@ def verify_registration(
         registration_contract.validate_registration(registration)
     except registration_contract.RegistrationContractError as exc:
         raise SuccessorVerificationError(str(exc)) from exc
-    verify_historical_registered_sources(
-        registration,
-        registration_contract.REGISTERED_FILE_NAMES,
+    require(
+        closure.get("registered_files_sha256")
+        == sha_bytes(canonical(registration["registered_files"])),
+        "qualification closure registered source identity mismatch",
     )
 
     require(registration.get("issue") == 827, "runner compatibility issue drift")

--- a/benchmark/swebench-rna-first/issue830/verify_successor.py
+++ b/benchmark/swebench-rna-first/issue830/verify_successor.py
@@ -9,12 +9,16 @@ import json
 from pathlib import Path
 import re
 import stat
+import subprocess
 import sys
 from typing import Any, Mapping
 
 
 HERE = Path(__file__).resolve().parent
 HARNESS = HERE.parent / "issue827"
+REPOSITORY = HERE.parents[2]
+REGISTERED_SOURCE_COMMIT = "d40069ad28f8525560ba7af59268b1653a74d481"
+REGISTERED_SOURCE_TREE = "370b08743c7bed38896ce3246ca67c7bd5bee202"
 HEX40 = re.compile(r"[0-9a-f]{40}")
 EXPECTED_ARTIFACT = {
     "producer_commit": "13c74539441adeef1ffd7d68b413ff148203f21c",
@@ -79,6 +83,58 @@ def sha_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def verify_historical_registered_sources(
+    registration: Mapping[str, Any],
+    registered_file_names: Mapping[str, str],
+) -> None:
+    tree = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(REPOSITORY),
+            "rev-parse",
+            f"{REGISTERED_SOURCE_COMMIT}^{{tree}}",
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    require(
+        tree.returncode == 0
+        and tree.stdout.decode().strip() == REGISTERED_SOURCE_TREE,
+        "historical registered source tree unavailable",
+    )
+    registered = registration.get("registered_files")
+    require(isinstance(registered, dict), "registered source hashes missing")
+    for key, filename in registered_file_names.items():
+        source = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(REPOSITORY),
+                "show",
+                (
+                    f"{REGISTERED_SOURCE_COMMIT}:"
+                    "benchmark/swebench-rna-first/issue827/"
+                    f"{filename}"
+                ),
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        require(
+            source.returncode == 0,
+            f"historical registered source unavailable: {filename}",
+        )
+        require(
+            registered.get(key) == sha_bytes(source.stdout),
+            f"historical registered source hash mismatch: {filename}",
+        )
+
+
 def verify_registration(
     registration_path: Path,
     lineage_path: Path,
@@ -95,12 +151,13 @@ def verify_registration(
     closure, closure_bytes = load_object(closure_path, "qualification closure")
 
     try:
-        registration_contract.validate_registration(
-            registration,
-            source_root=HARNESS,
-        )
+        registration_contract.validate_registration(registration)
     except registration_contract.RegistrationContractError as exc:
         raise SuccessorVerificationError(str(exc)) from exc
+    verify_historical_registered_sources(
+        registration,
+        registration_contract.REGISTERED_FILE_NAMES,
+    )
 
     require(registration.get("issue") == 827, "runner compatibility issue drift")
     require(


### PR DESCRIPTION
Closes #834

## Problem

The #830 pilot proved the host Claude login existed, but the registered outer Seatbelt denied the exact macOS Keychain file. Three one-shot launches therefore failed immediately as logged out.

## Solution

Expose only the exact `login.keychain-db` file as read-only on macOS and run `claude auth status` inside the final episode Seatbelt before any treatment query or model launch. Persist only sanitized zero-spend status evidence; never retain credential values, email, or organization identifiers.

## Verification so far

- Original retained sandbox: logged out.
- Same sandbox plus exact Keychain file read: logged in.
- Three focused unit tests pass.
- No model invocation or spend.

The fresh 20-case A/T experiment follows after this fix is verifier-clean and shipped.