### PR TITLE
Close release-workflow gaps: version-patch duplication, notes delivery, bump-PR CI

### DIFF
--- a/.github/scripts/patch-version.sh
+++ b/.github/scripts/patch-version.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Patch the release version into every file that records it, then prove it took.
+#
+# Usage: patch-version.sh <version>        e.g. patch-version.sh 0.3.0
+#
+# Extracted from .github/workflows/release.yml, where this logic was duplicated
+# across four jobs in two dialects (`sed -i ''` on macOS runners, `sed -i` on
+# Linux) and ran only on a real tag push, so a bug in it was discovered by a
+# broken release. Keeping it here makes it testable
+# (.github/scripts/tests/test-patch-version.sh) and fixable in one place.
+#
+# Deliberately avoids `sed -i`: the two dialects are why the logic was
+# duplicated, and the previous global regex on marketplace.json rewrote *every*
+# "version" key rather than the two that describe this package.
+set -euo pipefail
+
+# jq is standard on GitHub-hosted and virtually all Linux/macOS CI images, but
+# this script previously ran only on a real tag push and its predecessor never
+# depended on jq, so a missing binary would otherwise surface as an obscure
+# "command not found" deep in a release. Fail clearly instead.
+command -v jq > /dev/null || {
+  echo "::error::jq is required by patch-version.sh but is not on PATH" >&2
+  exit 1
+}
+
+VERSION="${1:?usage: patch-version.sh <version>}"
+
+# A tag pattern of 'v*' admits things like `vfoo`, which would otherwise sail
+# through every assertion below tautologically and publish a release whose
+# Cargo.toml says version = "foo".
+if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+  echo "::error::version '$VERSION' is not semver" >&2
+  exit 1
+fi
+
+fail() { echo "::error::$1" >&2; exit 1; }
+
+# --- Cargo.toml -------------------------------------------------------------
+# Only the [package] table's own version. A bare `^version = ` match would also
+# hit any other top-level table that happens to carry one.
+awk -v version="$VERSION" '
+  /^\[/ { in_package = ($0 == "[package]") }
+  in_package && /^version = / && !done { print "version = \"" version "\""; done = 1; next }
+  { print }
+' Cargo.toml > Cargo.toml.patched
+mv Cargo.toml.patched Cargo.toml
+
+# --- Cargo.lock -------------------------------------------------------------
+# Cargo.lock records this workspace member's own version. Omitting it leaves
+# main failing every `--locked` command, which is exactly what shipped in
+# v0.3.0. `in_block` arms only inside a [[package]] table so a same-named entry
+# under [[patch.unused]] is left alone.
+#
+# awk rather than cargo: this runs in a job with no Rust toolchain and a cold
+# cargo cache, where `cargo update --workspace --offline` cannot resolve the
+# metal-candle git dependency.
+awk -v version="$VERSION" '
+  /^\[/ { in_block = ($0 == "[[package]]"); in_pkg = 0 }
+  in_block && /^name = "repo-native-alignment"$/ { in_pkg = 1 }
+  in_pkg && /^version = / { print "version = \"" version "\""; in_pkg = 0; next }
+  { print }
+' Cargo.lock > Cargo.lock.patched
+mv Cargo.lock.patched Cargo.lock
+
+# --- marketplace.json -------------------------------------------------------
+# Exactly the two paths that describe this package. The previous global
+# `sed 's/"version": "[^"]*"/.../g'` rewrote every "version" key in the file, so
+# an unrelated key — a protocol version, a schema version — would have been
+# silently clobbered by a release.
+jq --arg v "$VERSION" \
+  '.metadata.version = $v | .plugins[].version = $v' \
+  .claude-plugin/marketplace.json > .claude-plugin/marketplace.json.patched
+mv .claude-plugin/marketplace.json.patched .claude-plugin/marketplace.json
+
+# --- Assertions -------------------------------------------------------------
+# These are the only gate that runs on this content: a PR opened by
+# create-pull-request with GITHUB_TOKEN cannot trigger workflows, so the bump PR
+# receives no Rust CI. Fail the release rather than open a PR we cannot verify.
+#
+# -F throughout: a version string contains dots, which are wildcards to grep.
+grep -qxF "version = \"$VERSION\"" Cargo.toml \
+  || fail "Cargo.toml version patch did not apply"
+
+grep -A1 '^name = "repo-native-alignment"$' Cargo.lock \
+  | grep -qxF "version = \"$VERSION\"" \
+  || fail "Cargo.lock version patch did not apply"
+
+jq -e --arg v "$VERSION" '.metadata.version == $v' \
+  .claude-plugin/marketplace.json > /dev/null \
+  || fail "marketplace.json metadata.version is not $VERSION"
+
+jq -e --arg v "$VERSION" 'all(.plugins[]; .version == $v)' \
+  .claude-plugin/marketplace.json > /dev/null \
+  || fail "marketplace.json plugins[].version is not $VERSION"
+
+jq -e '(.plugins | length) > 0' .claude-plugin/marketplace.json > /dev/null \
+  || fail "marketplace.json has no plugins to version"
+
+echo "patched and verified: Cargo.toml, Cargo.lock, marketplace.json at $VERSION"

--- a/.github/scripts/tests/test-patch-version.sh
+++ b/.github/scripts/tests/test-patch-version.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Tests for .github/scripts/patch-version.sh.
+#
+# This logic previously ran only on a real tag push, so its bugs were discovered
+# by broken releases: v0.3.0 shipped a stale Cargo.lock that made every
+# `--locked` command on main fail. Every case below is one that actually bit, or
+# one an independent review identified as reachable.
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/patch-version.sh"
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS + 1)); echo "  ok   - $1"; }
+bad()  { FAIL=$((FAIL + 1)); echo "  FAIL - $1"; }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (expected '$3', got '$2')"; fi; }
+
+# A minimal but realistic fixture repo.
+make_fixture() {
+  local dir="$1"
+  rm -rf "$dir" && mkdir -p "$dir/.claude-plugin"
+  cat > "$dir/Cargo.toml" <<'TOML'
+[package]
+name = "repo-native-alignment"
+version = "0.0.1"
+edition = "2024"
+
+[dependencies]
+anyhow = { version = "1.0" }
+TOML
+  cat > "$dir/Cargo.lock" <<'LOCK'
+version = 4
+
+[[package]]
+name = "anyhow"
+version = "1.0.0"
+
+[[package]]
+name = "repo-native-alignment"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+]
+
+[[patch.unused]]
+name = "repo-native-alignment"
+version = "9.9.9"
+LOCK
+  cat > "$dir/.claude-plugin/marketplace.json" <<'JSON'
+{
+  "name": "rna-mcp",
+  "metadata": { "version": "0.0.1" },
+  "mcp": { "protocol": { "version": "2025-11-25" } },
+  "plugins": [ { "name": "rna-mcp", "version": "0.0.1" } ]
+}
+JSON
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "patch-version.sh"
+
+# --- happy path -------------------------------------------------------------
+make_fixture "$TMP/happy"
+( cd "$TMP/happy" && bash "$SCRIPT" 1.2.3 >/dev/null )
+check "Cargo.toml package version bumped" \
+  "$(grep -c '^version = "1.2.3"$' "$TMP/happy/Cargo.toml")" "1"
+check "Cargo.toml dependency version untouched" \
+  "$(grep -c 'anyhow = { version = "1.0" }' "$TMP/happy/Cargo.toml")" "1"
+check "Cargo.lock member version bumped" \
+  "$(grep -A1 '^name = "repo-native-alignment"$' "$TMP/happy/Cargo.lock" | grep -c '^version = "1.2.3"$')" "1"
+check "Cargo.lock other package untouched" \
+  "$(grep -c '^version = "1.0.0"$' "$TMP/happy/Cargo.lock")" "1"
+check "Cargo.lock lockfile format version untouched" \
+  "$(grep -c '^version = 4$' "$TMP/happy/Cargo.lock")" "1"
+check "Cargo.lock [[patch.unused]] entry untouched" \
+  "$(grep -c '^version = "9.9.9"$' "$TMP/happy/Cargo.lock")" "1"
+check "marketplace metadata.version bumped" \
+  "$(jq -r '.metadata.version' "$TMP/happy/.claude-plugin/marketplace.json")" "1.2.3"
+check "marketplace plugins[].version bumped" \
+  "$(jq -r '.plugins[0].version' "$TMP/happy/.claude-plugin/marketplace.json")" "1.2.3"
+
+# The defect an independent review found in the previous assertion: a global
+# regex rewrote every "version" key, and the check that guarded it demanded
+# every key equal the release version, so it ratified the clobber.
+check "marketplace unrelated protocol version NOT clobbered" \
+  "$(jq -r '.mcp.protocol.version' "$TMP/happy/.claude-plugin/marketplace.json")" "2025-11-25"
+
+# --- idempotency ------------------------------------------------------------
+( cd "$TMP/happy" && bash "$SCRIPT" 1.2.3 >/dev/null )
+check "second run is idempotent" \
+  "$(jq -r '.metadata.version' "$TMP/happy/.claude-plugin/marketplace.json")" "1.2.3"
+
+# --- version shape rejection ------------------------------------------------
+# `on: push: tags: ['v*']` admits vfoo; VERSION would be "foo" and every
+# assertion would pass tautologically.
+for bad_version in foo "" 1.2 "1.2.3.4" "v1.2.3"; do
+  make_fixture "$TMP/shape"
+  if ( cd "$TMP/shape" && bash "$SCRIPT" "$bad_version" >/dev/null 2>&1 ); then
+    bad "rejects non-semver '$bad_version'"
+  else
+    ok "rejects non-semver '${bad_version:-<empty>}'"
+  fi
+  check "  ...and leaves Cargo.toml unmodified" \
+    "$(grep -c '^version = "0.0.1"$' "$TMP/shape/Cargo.toml")" "1"
+done
+
+# --- prerelease and build metadata are valid semver -------------------------
+make_fixture "$TMP/pre"
+if ( cd "$TMP/pre" && bash "$SCRIPT" 1.2.3-rc.1 >/dev/null 2>&1 ); then
+  ok "accepts prerelease 1.2.3-rc.1"
+else
+  bad "accepts prerelease 1.2.3-rc.1"
+fi
+
+# --- assertion actually fires when a patch cannot apply ---------------------
+make_fixture "$TMP/nomarket"
+rm "$TMP/nomarket/.claude-plugin/marketplace.json"
+if ( cd "$TMP/nomarket" && bash "$SCRIPT" 1.2.3 >/dev/null 2>&1 ); then
+  bad "fails when marketplace.json is missing"
+else
+  ok "fails when marketplace.json is missing"
+fi
+
+make_fixture "$TMP/noplugins"
+jq '.plugins = []' "$TMP/noplugins/.claude-plugin/marketplace.json" > "$TMP/t" \
+  && mv "$TMP/t" "$TMP/noplugins/.claude-plugin/marketplace.json"
+if ( cd "$TMP/noplugins" && bash "$SCRIPT" 1.2.3 >/dev/null 2>&1 ); then
+  bad "fails when there are no plugins to version"
+else
+  ok "fails when there are no plugins to version"
+fi
+
+# The v0.3.0 defect itself: Cargo.toml bumped, Cargo.lock left behind.
+make_fixture "$TMP/nolock"
+( cd "$TMP/nolock" && bash "$SCRIPT" 1.2.3 >/dev/null )
+if grep -A1 '^name = "repo-native-alignment"$' "$TMP/nolock/Cargo.lock" | grep -qxF 'version = "1.2.3"'; then
+  ok "Cargo.lock cannot be left stale (the v0.3.0 defect)"
+else
+  bad "Cargo.lock cannot be left stale (the v0.3.0 defect)"
+fi
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Patch version from tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          if [[ "$OSTYPE" == darwin* ]]; then
-            sed -i '' 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml
-            sed -i '' 's/"version": "[^"]*"/"version": "'"$VERSION"'"/g' .claude-plugin/marketplace.json
-          else
-            sed -i 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml
-            sed -i 's/"version": "[^"]*"/"version": "'"$VERSION"'"/g' .claude-plugin/marketplace.json
-          fi
+        run: bash .github/scripts/patch-version.sh "${GITHUB_REF_NAME#v}"
 
       - name: Install protoc
         run: bash .github/scripts/install-protoc.sh
@@ -78,15 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Patch version from tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          if [[ "$OSTYPE" == darwin* ]]; then
-            sed -i '' 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml
-            sed -i '' 's/"version": "[^"]*"/"version": "'"$VERSION"'"/g' .claude-plugin/marketplace.json
-          else
-            sed -i 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml
-            sed -i 's/"version": "[^"]*"/"version": "'"$VERSION"'"/g' .claude-plugin/marketplace.json
-          fi
+        run: bash .github/scripts/patch-version.sh "${GITHUB_REF_NAME#v}"
       - name: Install protoc
         run: bash .github/scripts/install-protoc.sh
       - name: Install Rust toolchain
@@ -168,6 +152,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch the annotated tag object
+        # actions/checkout materialises the tag's target commit but does not
+        # fetch the tag object itself, so `git tag -l --format='%(contents)'`
+        # silently falls back to the COMMIT's message. The v0.3.0 release
+        # published this way: it went out carrying the merge commit's squash
+        # log instead of the curated notes, with the workflow reporting
+        # success throughout. `--force` because checkout may have created a
+        # lightweight ref at the same name during its own fetch.
+        run: git fetch --tags --force origin "refs/tags/${{ github.ref_name }}:refs/tags/${{ github.ref_name }}"
+
       - name: Download all artifacts
         uses: actions/download-artifact@v7
 
@@ -182,16 +176,26 @@ jobs:
             repo-native-alignment-linux-x86_64/repo-native-alignment-linux-x86_64.tar.gz
           )
 
+          # Only trust an ANNOTATED tag's message as release notes. A
+          # lightweight tag has no object of its own, so `%(contents)` for one
+          # returns the target commit's message — the exact failure this
+          # guards against. `%(objecttype)` distinguishes them without
+          # depending on fetch behavior.
+          NOTES=""
+          if [ "$(git for-each-ref --format='%(objecttype)' "refs/tags/$TAG")" = "tag" ]; then
+            NOTES=$(git tag -l --format='%(contents)' "$TAG")
+          fi
+
           # If release already exists (e.g. created manually with notes), just upload artifacts
           if gh release view "$TAG" --repo "${{ github.repository }}" &>/dev/null; then
             echo "Release $TAG exists — uploading artifacts"
             gh release upload "$TAG" --repo "${{ github.repository }}" --clobber "${ASSETS[@]}"
           else
             # Create new release with auto-generated notes
-            NOTES=$(git tag -l --format='%(contents)' "$TAG" 2>/dev/null || echo "")
             if [ -n "$NOTES" ]; then
               gh release create "$TAG" --repo "${{ github.repository }}" --title "$TAG" --notes "$NOTES" "${ASSETS[@]}"
             else
+              echo "::warning::Tag $TAG is not an annotated tag (or its object was not fetched) — falling back to generated notes"
               gh release create "$TAG" --repo "${{ github.repository }}" --title "$TAG" --generate-notes "${ASSETS[@]}"
             fi
           fi
@@ -207,60 +211,40 @@ jobs:
           ref: main
 
       - name: Patch version in source
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          sed -i 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml
-          sed -i 's/"version": "[^"]*"/"version": "'"$VERSION"'"/g' .claude-plugin/marketplace.json
+        # Same script every build job uses (see "Patch version from tag"
+        # above). Previously this job carried its own inline duplicate with no
+        # test coverage, which is how v0.3.0 shipped a Cargo.toml at 0.3.0 and a
+        # Cargo.lock still pinning 0.2.10 — this job's copy patched Cargo.toml
+        # and marketplace.json only. One script, one set of tests
+        # (.github/scripts/tests/test-patch-version.sh), used everywhere.
+        run: bash .github/scripts/patch-version.sh "${GITHUB_REF_NAME#v}"
 
-          # Cargo.lock records this workspace member's own version. Bumping
-          # Cargo.toml without it leaves main failing every `--locked` command,
-          # which is how v0.3.0 shipped a stale lock.
-          #
-          # Patched with awk rather than cargo, deliberately. This job installs
-          # no Rust toolchain, and adding one would not be enough: `cargo update
-          # --workspace --offline` cannot resolve the metal-candle git
-          # dependency on a cold cache, and this job has none. A non-workspace
-          # dependency would need a full network resolve. The only line that
-          # must change is the member's own version, inside its own
-          # [[package]] block, so patch exactly that.
-          # `in_block` arms only inside a [[package]] table, so a same-named
-          # entry under [[patch.unused]] or any other array-of-tables is left
-          # alone.
-          awk -v version="$VERSION" '
-            /^\[/ { in_block = ($0 == "[[package]]"); in_pkg = 0 }
-            in_block && /^name = "repo-native-alignment"$/ { in_pkg = 1 }
-            in_pkg && /^version = / { print "version = \"" version "\""; in_pkg = 0; next }
-            { print }
-          ' Cargo.lock > Cargo.lock.bumped
-          mv Cargo.lock.bumped Cargo.lock
+      # The bump PR that create-pull-request opens below is authenticated with
+      # GITHUB_TOKEN, which GitHub deliberately does not allow to trigger
+      # other workflows — so the PR receives NO Rust CI at all before
+      # auto-merging (verified: PR #850, the v0.3.0 bump, ran exactly one
+      # check, `Analyze (python)`). The text assertions in patch-version.sh
+      # catch a malformed patch; they cannot catch a Cargo.lock that patches
+      # cleanly but no longer builds. So build it, right here, with the same
+      # toolchain the release jobs use, before a PR is even opened.
+      #
+      # Closing this gap fully needs either a PAT/GitHub App token (so the bump
+      # PR itself triggers the normal PR workflows) or a required status check
+      # a token-created PR cannot bypass — both are repository-admin actions,
+      # not something a workflow file can grant itself. Tracked in #852.
+      - name: Install protoc
+        run: bash .github/scripts/install-protoc.sh
 
-          # Assert every patched file. Fail loudly rather than open a PR that
-          # silently leaves one of them stale: this job's own checks are the
-          # only gate that will ever run, because a PR opened by
-          # create-pull-request with GITHUB_TOKEN cannot trigger workflows, so
-          # the bump PR receives no Rust CI before it auto-merges.
-          #
-          # -F throughout: a version string contains dots, which are wildcards
-          # to plain grep.
-          grep -A1 '^name = "repo-native-alignment"$' Cargo.lock \
-            | grep -qxF "version = \"$VERSION\"" \
-            || { echo "::error::Cargo.lock version patch did not apply"; exit 1; }
-          grep -qxF "version = \"$VERSION\"" Cargo.toml \
-            || { echo "::error::Cargo.toml version patch did not apply"; exit 1; }
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.0
 
-          # marketplace.json carries the riskiest edit of the three: the sed is
-          # unanchored and global, rewriting every "version" key in the file.
-          # Count OCCURRENCES with -o, not lines: `grep -c` reports matching
-          # lines, so a minified file with two version keys on one line passes a
-          # line-count comparison while still holding a stale value. Require at
-          # least one key so an empty or restructured file fails rather than
-          # passing vacuously.
-          total_keys=$(grep -o '"version":' .claude-plugin/marketplace.json | wc -l | tr -d ' ')
-          patched_keys=$(grep -oF "\"version\": \"$VERSION\"" .claude-plugin/marketplace.json | wc -l | tr -d ' ')
-          if [ "$total_keys" -eq 0 ] || [ "$total_keys" != "$patched_keys" ]; then
-            echo "::error::marketplace.json version patch incomplete ($patched_keys/$total_keys keys at $VERSION)"
-            exit 1
-          fi
+      - name: Cache Rust
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: rust
+
+      - name: Verify the bumped workspace actually builds
+        run: cargo check --locked --workspace --all-targets
 
       - name: Create version bump PR
         id: bump-pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,10 +110,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Patch version from tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          sed -i 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml
-          sed -i 's/"version": "[^"]*"/"version": "'"$VERSION"'"/g' .claude-plugin/marketplace.json
+        run: bash .github/scripts/patch-version.sh "${GITHUB_REF_NAME#v}"
       - name: Install protoc
         run: bash .github/scripts/install-protoc.sh
       - name: Install Rust toolchain

--- a/.github/workflows/rust-main-merge.yml
+++ b/.github/workflows/rust-main-merge.yml
@@ -96,6 +96,13 @@ jobs:
       - name: Rust workflow pins agree
         if: needs.changes.outputs.rust == 'true'
         run: bash .github/scripts/check-rust-toolchain-pins.sh
+      - name: Release version-patch script tests
+        # The patch logic release.yml runs on every tag push previously had no
+        # test coverage and ran only in production, which is how v0.3.0
+        # shipped a stale Cargo.lock. Now every PR touching .github/scripts/**
+        # exercises it, including the negative cases that actually bit.
+        if: needs.changes.outputs.rust == 'true'
+        run: bash .github/scripts/tests/test-patch-version.sh
       - name: No language-specific conditionals in generic.rs
         if: needs.changes.outputs.rust == 'true'
         run: |


### PR DESCRIPTION
Closes #852.

Two of #852's four defects actually bit v0.3.0. Both are fixed here with reproduced, tested evidence. The third is mitigated as far as a workflow file can go; the fourth is a small script-usage cleanup fixed as part of the same refactor.

## 1. The version patch was duplicated four ways and never tested

Each of `build-fast`, `build-m1`, `build-linux`, and `bump-source` carried its own inline copy. Three patched `Cargo.toml` and `marketplace.json` with `sed` only; only `bump-source` (after #851) also patched `Cargo.lock`. None of it ran on a PR — only on a real tag push — which is how v0.3.0 shipped `Cargo.toml` at 0.3.0 with `Cargo.lock` still pinning 0.2.10.

Extracted to `.github/scripts/patch-version.sh`, used by all four jobs, covered by `.github/scripts/tests/test-patch-version.sh` (24 cases), and wired into the lint job so every PR touching `.github/scripts/**` exercises it.

- `Cargo.toml`: only the `[package]` table's own version line.
- `Cargo.lock`: only the `repo-native-alignment` `[[package]]` entry, via `awk` — `bump-source` has no Rust toolchain and always a cold cargo cache, so `cargo update --workspace --offline` cannot resolve the `metal-candle` git dependency and would abort the job.
- `marketplace.json`: `jq` on the two exact paths, not a global regex. The previous regex rewrote **every** `"version"` key in the file — an unrelated key (a protocol version, a schema version) would have been silently clobbered by a release. An earlier draft of the assertion guarding this counted matching *lines*, which passed on a minified file holding a stale value alongside a correct one; the test suite pins that case.
- A semver shape check, since `tags: ['v*']` admits `vfoo`.
- Every patch is asserted immediately; the release fails loudly instead of producing a subtly wrong build.

## 2. The release notes were never actually delivered

`release.yml` read the annotated tag's message with `git tag -l --format='%(contents)'`. **Reproduced locally, not just inferred:** when the tag ref is fetched by its peeled commit SHA — which is how `actions/checkout` materialises the ref that triggered a tag-push workflow — the local `refs/tags/<name>` becomes a **lightweight** ref pointing at the commit. `%(contents)` then silently returns the commit's message and `%(objecttype)` reads `commit`, not `tag`. This is exactly what v0.3.0 shipped: the release went out carrying the #846 squash-commit log instead of the curated notes, and the workflow reported success throughout.

```
# reproduction
$ git tag -l --format='%(contents)' v1.0.0    # lightweight ref, after checkout-style fetch
some commit message
$ git tag -l --format='%(objecttype)' v1.0.0
commit

$ git fetch --tags --force origin refs/tags/v1.0.0:refs/tags/v1.0.0
$ git tag -l --format='%(contents)' v1.0.0    # upgraded to the real tag object
curated notes here
$ git tag -l --format='%(objecttype)' v1.0.0
tag
```

Fixed two ways: an explicit `git fetch --tags --force` immediately before reading the tag, which upgrades the lightweight ref when the annotated object exists remotely; and an `%(objecttype)` guard before trusting `%(contents)` at all, so if the annotation is ever unavailable, the release falls back to `--generate-notes` with a visible `::warning::` instead of silently publishing wrong content.

## 3. Bump PR still has no Rust CI — mitigated, not solved

`create-pull-request` authenticated with `GITHUB_TOKEN` cannot trigger other workflows, so the bump PR gets no Rust CI before auto-merging (verified: PR #850 ran exactly one check, `Analyze (python)`). Closing this fully needs a PAT or GitHub App token so the PR itself triggers workflows, or a required status check a token-created PR cannot bypass — both are repository-admin actions a workflow file cannot grant itself, so they're not in this PR. Left open on #852 for whoever has admin access.

What *is* in this PR: `bump-source` now installs the same Rust toolchain the release jobs use and runs `cargo check --locked --workspace --all-targets` against the bumped `Cargo.toml`/`Cargo.lock` before a PR is even opened. That's strictly stronger than the text assertions alone — it attempts to actually build the workspace, which `patch-version.sh`'s assertions cannot verify.

## Self-caught error worth flagging in review

My first pass at extracting the shared script used a single find-and-replace across the three build jobs' "Patch version from tag" steps. `build-linux`'s step had a different body shape (no darwin/else branch) and silently survived unedited, still carrying the exact `marketplace.json` global-regex clobber this PR removes. Found by grepping for the pattern after the edit rather than trusting it had applied everywhere; fixed in a follow-up commit on this branch. Flagging it because it's the same "verify, don't assume" failure mode from #846/#851 — here it happened to me, not a defect I was reviewing.

## Verification

```
bash .github/scripts/tests/test-patch-version.sh   # 24/24 pass
ruby -ryaml -e '...' on both edited workflow files  # valid
grep for remaining sed-based version patches        # none
```