### PR TITLE
Record the v0.3.1 release receipt

### DIFF
--- a/.oh/sessions/v0.3.1-release.md
+++ b/.oh/sessions/v0.3.1-release.md
@@ -1,0 +1,69 @@
+---
+type: session
+release: v0.3.1
+issues: [849, 852]
+prs: [854, 855, 856]
+status: complete
+date: 2026-08-02
+outcome: context-assembly
+---
+
+# v0.3.1 release receipt
+
+## What shipped
+
+| | |
+|---|---|
+| Tag | `v0.3.1`, annotated, at `596edee2bb59799dabf277f497bbdbea133e11b4` |
+| Release | https://github.com/open-horizon-labs/repo-native-alignment/releases/tag/v0.3.1 |
+| Published | 2026-08-02T00:40:43Z (UTC), not a draft, not a pre-release |
+| Prior release | v0.3.0 at `9a8fdef5`, 2026-08-01T17:14:16Z |
+| Scope | patch: 3 LSP recovery fixes (#855) + 3 release-workflow fixes (#854), no new public capability |
+
+## Why this release exists
+
+v0.3.0 shipped three known LSP recovery limitations, disclosed in its own release notes with a tracking issue (#849). This release closes all three, plus release-workflow reliability issues found while shipping v0.3.0 (#852), now fixed (#854) and exercised for the first time by this very release.
+
+## Content
+
+- #855 — non-Git influence-pattern binding inside excluded directories, bare-repo fallback, SourceLineCache negative-caching. Two independent review rounds; round 1 found one blocking defect (a truncate-before-filter bug in the new bounded search, introduced during the fix itself), confirmed and repaired; round 2 approved after independently reproducing the revert-fails/fix-passes property two separate ways.
+- #854 — extracted the duplicated, previously untested version-patch logic into `.github/scripts/patch-version.sh` (24-case test suite), fixed the tag-annotation notes-delivery bug, replaced a global-regex `marketplace.json` patch with a targeted one. One review round, approved with only non-blocking warnings.
+
+## Artifact verification
+
+Release assets are byte-identical to the CI workflow artifacts from run [30725268332](https://github.com/open-horizon-labs/repo-native-alignment/actions/runs/30725268332). No local build substituted.
+
+| Archive | SHA-256 | Bytes |
+|---|---|---|
+| `repo-native-alignment-darwin-arm64-fast.tar.gz` | `7f61214d94ffec26d47e21f50e4078bc3874cf79b5d662c9fdfe02ea202d02f2` | 48,548,759 |
+| `repo-native-alignment-darwin-arm64.tar.gz` | `e09753797f67c80f37289ab375e5e599f49c757fc2280854f98fd3c305a634df` | 50,371,043 |
+| `repo-native-alignment-linux-x86_64.tar.gz` | `6ed8fa591b09dc5c76f982de53468624d329150d9c750b84a66960e8e362ded8` | 56,561,562 |
+
+Extracted M4 artifact reports `repo-native-alignment 0.3.1`, Mach-O 64-bit arm64.
+
+## Delivery verification (real MCP client, downloaded artifact)
+
+`.github/scripts/mcp-smoke.mjs` with the official MCP TypeScript SDK, against the downloaded `darwin-arm64-fast` binary.
+
+```text
+MCP smoke check PASSED (4 tools visible).
+```
+
+Same six delivery assertions as v0.3.0's smoke, including `list_roots fails old-schema work closed` / `delivers deterministic recovery disposition`, confirming the #833/#846 recovery machinery still works end-to-end on this head.
+
+## The release-workflow fix proved itself on first use
+
+This is the first release built after #854 merged, and both defects it fixed were directly exercised:
+
+- **Notes delivered correctly, no manual correction needed.** v0.3.0's published notes silently fell back to the tagged commit's squash message and needed a manual `gh release edit` to fix. v0.3.1's notes published correctly on the first attempt — 9 markdown headings intact, matching the authored file exactly.
+- **Version-bump PR (#856) kept all three files in agreement.** `Cargo.toml`, `Cargo.lock`, and `.claude-plugin/marketplace.json` all report `0.3.1` on `main`; `cargo metadata --locked` exits 0. This is the exact defect class that shipped in v0.3.0 (`Cargo.toml` bumped, `Cargo.lock` left stale) — it did not recur.
+
+## Known limitation carried forward, unchanged
+
+#852's fourth item — the bump PR receives no Rust CI before auto-merging, because `create-pull-request` with `GITHUB_TOKEN` cannot trigger workflows — is still open. Confirmed on #856: it ran exactly one check, `Analyze (python)`. The in-job assertions in `patch-version.sh` are the only real gate on that content; fully closing this needs a PAT or GitHub App token, or a required status check a token-created PR cannot bypass. Both are repository-admin actions, tracked in #852.
+
+## Corrections made to v0.3.0's live notes during this session
+
+Two factual errors found and fixed in the already-published v0.3.0 release, independent of this new release:
+- "roughly 69 result files" corrected to the reproducible 54 (`git ls-files 'benchmark/**' | grep -ciE 'result'`).
+- The "Known limitations... Tracked in #849" section updated to state the gaps are fixed on `main` (#855) as of 2026-08-01, since #849 closed before this correction was made.


### PR DESCRIPTION
Docs only — records the v0.3.1 release delivery evidence: tag/artifact identity, SHA-256 verification against the CI build, real-MCP-client delivery smoke against the downloaded binary, and confirmation that the two release-workflow fixes from #854 held on their first real release (notes published correctly, version files stayed in agreement).

Also notes two corrections made to v0.3.0's already-published release notes (stale benchmark-file count, stale issue reference) and the one remaining #852 item (bump PR still gets no Rust CI before auto-merge — needs a PAT or required check, both repository-admin actions).